### PR TITLE
Jump to newer tokio-postgres:replication code, handle keepalive messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project",
- "socket2 0.4.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1089,7 +1089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
 dependencies = [
  "libc",
- "socket2 0.4.0",
+ "socket2",
 ]
 
 [[package]]
@@ -1209,6 +1209,7 @@ dependencies = [
  "log",
  "postgres",
  "postgres-protocol",
+ "postgres-types",
  "rand 0.8.3",
  "regex",
  "rust-s3",
@@ -1333,8 +1334,8 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.0"
-source = "git+https://github.com/kelvich/rust-postgres?branch=replication_rebase#f3425d991f75cb7b464a37e6b3d5d05f8bf51c02"
+version = "0.19.1"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1346,8 +1347,8 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.0"
-source = "git+https://github.com/kelvich/rust-postgres?branch=replication_rebase#f3425d991f75cb7b464a37e6b3d5d05f8bf51c02"
+version = "0.6.1"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
 dependencies = [
  "base64",
  "byteorder",
@@ -1363,8 +1364,8 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.0"
-source = "git+https://github.com/kelvich/rust-postgres?branch=replication_rebase#f3425d991f75cb7b464a37e6b3d5d05f8bf51c02"
+version = "0.2.1"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1884,17 +1885,6 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
@@ -2086,8 +2076,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.0"
-source = "git+https://github.com/kelvich/rust-postgres?branch=replication_rebase#f3425d991f75cb7b464a37e6b3d5d05f8bf51c02"
+version = "0.7.1"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2098,10 +2088,10 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "phf",
- "pin-project",
+ "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.3.19",
+ "socket2",
  "tokio",
  "tokio-util",
 ]

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 rand = "0.8.3"
-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
-tokio-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
 
 serde = ""
 serde_derive = ""

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.3"
-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
-tokio-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
 
 pageserver = { path = "../pageserver" }
 walkeeper = { path = "../walkeeper" }

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -29,9 +29,10 @@ daemonize = "0.4.1"
 rust-s3 = { git = "https://github.com/hlinnaka/rust-s3", features = ["no-verify-ssl"] }
 tokio = { version = "1.3.0", features = ["full"] }
 tokio-stream = { version = "0.1.4" }
-tokio-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
-postgres-protocol = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
 anyhow = "1.0"
 crc32c = "0.6.0"
 walkdir = "2"

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -29,9 +29,9 @@ daemonize = "0.4.1"
 rust-s3 = { git = "https://github.com/hlinnaka/rust-s3", features = ["no-verify-ssl"] }
 tokio = { version = "1.3.0", features = ["full"] }
 tokio-stream = { version = "0.1.4" }
-tokio-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
-postgres-protocol = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
-postgres = { git = "https://github.com/kelvich/rust-postgres", branch = "replication_rebase" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
 anyhow = "1.0"
 crc32c = "0.6.0"
 


### PR DESCRIPTION
Fixes #30.

The upstream PR has evolved a lot; jump to the latest version and make the required local changes to match.

Add code to handle keepalive messages.

The LSN values sent may need to change in the future. Currently we send:
- write_lsn <= page_cache last_valid_lsn
- flush_lsn <= page_cache last_valid_lsn
- apply_lsn <= 0

As mentioned [here](https://github.com/zenithdb/zenith/issues/30#issuecomment-820222889), it would be nice to be able to send the same standby_status_update message on demand at other times. I haven't looked at that yet.
