### PR TITLE
clippy cleanup #1

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -73,7 +73,7 @@ impl ComputeControlPlane {
             base_port: 65431,
             pageserver: Arc::clone(pageserver),
             nodes: BTreeMap::new(),
-            env: env.clone(),
+            env,
         }
     }
 

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -9,7 +9,6 @@ use std::error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use home;
 use serde_derive::{Deserialize, Serialize};
 
 type Result<T> = std::result::Result<T, Box<dyn error::Error>>;

--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -58,7 +58,7 @@ impl TestStorageControlPlane {
         let env = local_env::test_env();
 
         let pserver = Arc::new(PageServerNode {
-            env: env.clone(),
+            env,
             kill_on_exit: true,
             listen_address: None,
         });
@@ -110,7 +110,7 @@ impl TestStorageControlPlane {
     pub fn get_wal_acceptor_conn_info(&self) -> String {
         self.wal_acceptors
             .iter()
-            .map(|wa| wa.listen.to_string().to_string())
+            .map(|wa| wa.listen.to_string())
             .collect::<Vec<String>>()
             .join(",")
     }

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -14,10 +14,7 @@ use clap::{App, Arg};
 use daemonize::Daemonize;
 use anyhow::Result;
 
-use slog;
 use slog::Drain;
-use slog_scope;
-use slog_stdlog;
 
 use pageserver::page_service;
 use pageserver::restore_datadir;

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -205,7 +205,7 @@ pub struct CacheEntryContent {
 impl CacheEntry {
     fn new(key: CacheKey) -> CacheEntry {
         CacheEntry {
-            key: key,
+            key,
             content: Mutex::new(CacheEntryContent {
                 page_image: None,
                 wal_record: None,
@@ -253,8 +253,8 @@ impl PageCache {
 
         // Look up cache entry. If it's a page image, return that. If it's a WAL record,
         // ask the WAL redo service to reconstruct the page image from the WAL records.
-        let minkey = CacheKey { tag: tag, lsn: 0 };
-        let maxkey = CacheKey { tag: tag, lsn: lsn };
+        let minkey = CacheKey { tag, lsn: 0 };
+        let maxkey = CacheKey { tag, lsn };
 
         let entry_rc: Arc<CacheEntry>;
         {
@@ -302,7 +302,7 @@ impl PageCache {
             let entry_opt = entries.next_back();
 
             if entry_opt.is_none() {
-                static ZERO_PAGE: [u8; 8192] = [0 as u8; 8192];
+                static ZERO_PAGE: [u8; 8192] = [0u8; 8192];
                 return Ok(Bytes::from_static(&ZERO_PAGE));
                 /* return Err("could not find page image")?; */
             }
@@ -433,7 +433,7 @@ impl PageCache {
     //
     pub fn put_wal_record(&self, tag: BufferTag, rec: WALRecord) {
         let key = CacheKey {
-            tag: tag,
+            tag,
             lsn: rec.lsn,
         };
 
@@ -469,7 +469,7 @@ impl PageCache {
     // Memorize a full image of a page version
     //
     pub fn put_page_image(&self, tag: BufferTag, lsn: u64, img: Bytes) {
-        let key = CacheKey { tag: tag, lsn: lsn };
+        let key = CacheKey { tag, lsn };
 
         let entry = CacheEntry::new(key.clone());
         entry.content.lock().unwrap().page_image = Some(img);

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -259,7 +259,7 @@ impl Connection {
             stream: BufWriter::new(socket),
             buffer: BytesMut::with_capacity(10 * 1024),
             init_done: false,
-            conf: conf,
+            conf,
         }
     }
 
@@ -560,7 +560,7 @@ impl Connection {
 
                     self.write_message(&BeMessage::ZenithNblocksResponse(ZenithStatusResponse {
                         ok: true,
-                        n_blocks: n_blocks,
+                        n_blocks,
                     }))
                     .await?
                 }

--- a/pageserver/src/restore_s3.rs
+++ b/pageserver/src/restore_s3.rs
@@ -60,8 +60,8 @@ pub fn restore_main(conf: &PageServerConf) {
 async fn restore_chunk(conf: &PageServerConf) -> Result<(), S3Error> {
     let backend = Storage {
         region: Region::Custom {
-            region: env::var("S3_REGION").unwrap().into(),
-            endpoint: env::var("S3_ENDPOINT").unwrap().into(),
+            region: env::var("S3_REGION").unwrap(),
+            endpoint: env::var("S3_ENDPOINT").unwrap(),
         },
         credentials: Credentials::new(
             Some(&env::var("S3_ACCESSKEY").unwrap()),
@@ -313,7 +313,7 @@ async fn slurp_base_file(
             dbnode: parsed.dbnode,
             relnode: parsed.relnode,
             forknum: parsed.forknum as u8,
-            blknum: blknum,
+            blknum,
         };
 
         pcache.put_page_image(tag, parsed.lsn, bytes.copy_to_bytes(8192));

--- a/pageserver/src/tui.rs
+++ b/pageserver/src/tui.rs
@@ -14,7 +14,6 @@ use tui::text::{Span, Spans, Text};
 use tui::widgets::{Block, BorderType, Borders, Paragraph, Widget};
 use tui::Terminal;
 
-use slog;
 use slog::Drain;
 
 lazy_static! {

--- a/pageserver/src/tui_logger.rs
+++ b/pageserver/src/tui_logger.rs
@@ -10,7 +10,6 @@
 //
 use chrono::offset::Local;
 use chrono::DateTime;
-use slog;
 use slog::{Drain, Level, OwnedKVList, Record};
 use slog_async::AsyncRecord;
 use std::collections::VecDeque;
@@ -81,7 +80,7 @@ impl<'b> TuiLoggerWidget<'b> {
             style_trace: None,
             style_info: None,
             show_module: true,
-            logger: logger,
+            logger,
         }
     }
 }

--- a/pageserver/src/waldecoder.rs
+++ b/pageserver/src/waldecoder.rs
@@ -63,7 +63,7 @@ pub struct WalStreamDecoder {
 impl WalStreamDecoder {
     pub fn new(lsn: u64) -> WalStreamDecoder {
         WalStreamDecoder {
-            lsn: lsn,
+            lsn,
 
             startlsn: 0,
             contlen: 0,
@@ -582,8 +582,8 @@ pub fn decode_wal_record(lsn: u64, rec: Bytes) -> DecodedWALRecord {
     // Since we don't care about the data payloads here, we're done.
 
     return DecodedWALRecord {
-        lsn: lsn,
+        lsn,
         record: rec,
-        blocks: blocks,
+        blocks,
     };
 }

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -88,7 +88,7 @@ async fn walreceiver_main(
         // empty database snapshot), so for now I just put start of first segment which
         // seems to be a valid record.
         pcache.init_valid_lsn(0x_1_000_000_u64);
-        startpoint = u64::from(0x_1_000_000_u64);
+        startpoint = 0x_1_000_000_u64;
     } else {
         // There might be some padding after the last full record, skip it.
         //
@@ -156,7 +156,7 @@ async fn walreceiver_main(
                             };
 
                             let rec = page_cache::WALRecord {
-                                lsn: lsn,
+                                lsn,
                                 will_init: blk.will_init || blk.apply_image,
                                 rec: recdata.clone(),
                             };

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -208,7 +208,7 @@ impl WalRedoProcess {
         tokio::spawn(f_stderr);
 
         Ok(WalRedoProcess {
-            child: child,
+            child,
             stdin: RefCell::new(stdin),
             stdout: RefCell::new(stdout),
         })

--- a/walkeeper/src/bin/wal_acceptor.rs
+++ b/walkeeper/src/bin/wal_acceptor.rs
@@ -11,10 +11,7 @@ use std::{fs::File, fs::OpenOptions};
 
 use clap::{App, Arg};
 
-use slog;
 use slog::Drain;
-use slog_scope;
-use slog_stdlog;
 
 use walkeeper::wal_service;
 use walkeeper::WalAcceptorConf;

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -402,7 +402,7 @@ impl System {
             },
         };
         System {
-            id: id,
+            id,
             mutex: Mutex::new(shared_state),
             cond: Notify::new(),
         }
@@ -989,7 +989,7 @@ impl Connection {
                 },
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {}
                 Err(e) => {
-                    return Err(e.into());
+                    return Err(e);
                 }
             }
 
@@ -1018,7 +1018,7 @@ impl Connection {
                         Ok(opened_file) => file = opened_file,
                         Err(e) => {
                             error!("Failed to open log file {:?}: {}", &wal_file_path, e);
-                            return Err(e.into());
+                            return Err(e);
                         }
                     }
                 }
@@ -1130,7 +1130,7 @@ impl Connection {
                         }
                         Err(e) => {
                             error!("Failed to open log file {:?}: {}", &wal_file_path, e);
-                            return Err(e.into());
+                            return Err(e);
                         }
                     }
                 }


### PR DESCRIPTION
Resolve some basic warnings from clippy:
- useless conversion to the same type
- redundant field names in struct initialization
- redundant single-component path imports