### PR TITLE
pageserver: change over some error handling to anyhow+thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "termion",
+ "thiserror",
  "tokio",
  "tokio-postgres",
  "tokio-stream",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -36,3 +36,4 @@ postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b
 anyhow = "1.0"
 crc32c = "0.6.0"
 walkdir = "2"
+thiserror = "1.0"

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -34,14 +34,15 @@ pub fn thread_main(conf: &PageServerConf, wal_producer_connstr: &str) {
 
     runtime.block_on(async {
         loop {
-            let _res = walreceiver_main(conf, wal_producer_connstr).await;
+            let res = walreceiver_main(conf, wal_producer_connstr).await;
 
-            // TODO: print/log the error
-            info!(
-                "WAL streaming connection failed, retrying in 1 second...: {:?}",
-                _res
-            );
-            sleep(Duration::from_secs(1)).await;
+            if let Err(e) = res {
+                info!(
+                    "WAL streaming connection failed ({}), retrying in 1 second",
+                    e
+                );
+                sleep(Duration::from_secs(1)).await;
+            }
         }
     });
 }


### PR DESCRIPTION
This is a first attempt at a new error-handling strategy:
- Use anyhow::Error as the first choice for easy error handling
- Use thiserror to generate local error types for anything that
  needs it (no error type is available to us) or will be inspected
  or matched on by higher layers.