### PR TITLE
Fix caching of 'postgres' build in github action.

### DIFF
--- a/pgbuild.sh
+++ b/pgbuild.sh
@@ -31,9 +31,3 @@ export DESTDIR=$REPO_ROOT/tmp_install
 
 echo "Installing postgres to $DESTDIR"
 make install -s
-
-#Configure postgres in src directory. We need it for postgres_ffi build
-echo "Configuring postgres build in place"
-cd ../../vendor/postgres/
-./configure CFLAGS='-O0' --enable-debug --enable-cassert \
-    --enable-depend --with-libxml --prefix=/ > configure.log

--- a/postgres_ffi/build.rs
+++ b/postgres_ffi/build.rs
@@ -23,7 +23,14 @@ fn main() {
         .whitelist_var("PG_CONTROLFILEDATA_OFFSETOF_CRC")
         .whitelist_type("DBState")
 
-        .clang_arg("-I../vendor/postgres/src/include")
+    // Path the server include dir. It is in tmp_install/include/server, if you did
+    // "configure --prefix=<path to tmp_install>". But if you used "configure --prefix=/",
+    // and used DESTDIR to move it into tmp_install, then it's in
+    // tmp_install/include/postgres/server (that's how the pgbuild.sh script does it).
+    // 'pg_config --includedir-server' would perhaps be the more proper way to find it,
+    // but this will do for now.
+        .clang_arg("-I../tmp_install/include/server")
+        .clang_arg("-I../tmp_install/include/postgresql/server")
 
         // Finish the builder and generate the bindings.
         .generate()


### PR DESCRIPTION
The postgres_ext.h isn't found in vendor/postgres, if the Postgres
was restored from cache instead of building it in vendor/postgres.
To fix, change include path to point into tmp_install/include where the
headers are installed, instead of the vendor/postgres source dir.