### PR TITLE
Wait WAL receiver to start

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -400,7 +400,7 @@ impl PostgresNode {
     }
 
     fn dump_log_file(&self) {
-		if let Ok(mut file) = File::open(zenith_repo_dir().join("pageserver.log")) {
+		if let Ok(mut file) = File::open(self.env.repo_path.join("pageserver.log")) {
 			let mut buffer = String::new();
 			file.read_to_string(&mut buffer).unwrap();
 			println!("--------------- Dump pageserver.log:\n{}", buffer);

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -404,10 +404,13 @@ impl PostgresNode {
         for entry in fs::read_dir(dir).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
-            let mut file = File::open(&path).unwrap();
-            let mut buffer = String::new();
-            file.read_to_string(&mut buffer).unwrap();
-            println!("File {:?}:\n{}", &path, buffer);
+			if path.is_dir() {
+				if let Ok(mut file) = File::open(path.join("pageserver.log")) {
+					let mut buffer = String::new();
+					file.read_to_string(&mut buffer).unwrap();
+					println!("File {:?}:\n{}", &path, buffer);
+				}
+			}
         }
     }
 

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -399,19 +399,12 @@ impl PostgresNode {
         String::from_utf8(output.stdout).unwrap().trim().to_string()
     }
 
-    fn dump_log_files(&self) {
-        let dir = zenith_repo_dir();
-        for entry in fs::read_dir(dir).unwrap() {
-            let entry = entry.unwrap();
-            let path = entry.path();
-			if path.is_dir() {
-				if let Ok(mut file) = File::open(path.join("pageserver.log")) {
-					let mut buffer = String::new();
-					file.read_to_string(&mut buffer).unwrap();
-					println!("File {:?}:\n{}", &path, buffer);
-				}
-			}
-        }
+    fn dump_log_file(&self) {
+		if let Ok(mut file) = File::open(zenith_repo_dir().join("pageserver.log")) {
+			let mut buffer = String::new();
+			file.read_to_string(&mut buffer).unwrap();
+			println!("--------------- Dump pageserver.log:\n{}", buffer);
+		}
     }
 
     pub fn safe_psql(&self, db: &str, sql: &str) -> Vec<tokio_postgres::Row> {
@@ -427,7 +420,7 @@ impl PostgresNode {
         println!("Running {}", sql);
         let result = client.query(sql, &[]);
         if result.is_err() {
-            self.dump_log_files();
+            self.dump_log_file();
         }
         result.unwrap()
     }

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -400,11 +400,11 @@ impl PostgresNode {
     }
 
     fn dump_log_file(&self) {
-		if let Ok(mut file) = File::open(self.env.repo_path.join("pageserver.log")) {
-			let mut buffer = String::new();
-			file.read_to_string(&mut buffer).unwrap();
-			println!("--------------- Dump pageserver.log:\n{}", buffer);
-		}
+        if let Ok(mut file) = File::open(self.env.repo_path.join("pageserver.log")) {
+            let mut buffer = String::new();
+            file.read_to_string(&mut buffer).unwrap();
+            println!("--------------- Dump pageserver.log:\n{}", buffer);
+        }
     }
 
     pub fn safe_psql(&self, db: &str, sql: &str) -> Vec<tokio_postgres::Row> {

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -172,7 +172,7 @@ fn open_rocksdb(_conf: &PageServerConf, timelineid: ZTimelineId) -> rocksdb::DB 
     opts.create_if_missing(true);
     opts.set_use_fsync(true);
     opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
-	opts.create_missing_column_families(true);
+    opts.create_missing_column_families(true);
     rocksdb::DB::open_cf(&opts, &path, &[rocksdb::DEFAULT_COLUMN_FAMILY_NAME]).unwrap()
 }
 
@@ -429,7 +429,7 @@ impl PageCache {
 
                         // reconstruct most recent page version
                         if content.wal_record.is_some() {
-							trace!("Reconstruct most recent page {:?}", key);
+                            trace!("Reconstruct most recent page {:?}", key);
                             // force reconstruction of most recent page version
                             self.reconstruct_page(key, content)?;
                         }
@@ -451,7 +451,7 @@ impl PageCache {
                                     minbuf.clear();
                                     minbuf.extend_from_slice(&k);
                                     let key = CacheKey::unpack(&mut minbuf);
-									trace!("Reconstruct horizon page {:?}", key);
+                                    trace!("Reconstruct horizon page {:?}", key);
                                     self.reconstruct_page(key, content)?;
                                 }
                             }
@@ -459,13 +459,13 @@ impl PageCache {
                         // remove records prior to horizon
                         minbuf.clear();
                         minkey.pack(&mut minbuf);
-						trace!("Delete records in range {:?}..{:?}", minkey, maxkey);
+                        trace!("Delete records in range {:?}..{:?}", minkey, maxkey);
                         self.db.delete_range_cf(cf, &minbuf[..], &maxbuf[..])?;
 
                         maxkey = minkey;
                     } else {
-						break;
-					}
+                        break;
+                    }
                 }
             }
         }
@@ -857,11 +857,13 @@ impl PageCache {
                         }
                     }
                     let relsize = tag.blknum + 1;
+                    info!("Size of relation {:?} at {} is {}", rel, lsn, relsize);
                     return Ok(relsize);
                 }
             }
             break;
         }
+        info!("Size of relation {:?} at {} is zero", rel, lsn);
         Ok(0)
     }
 
@@ -886,9 +888,11 @@ impl PageCache {
             buf.extend_from_slice(&k);
             let tag = BufferTag::unpack(&mut buf);
             if tag.rel == *rel {
+                info!("Relation {:?} exists at {}", rel, lsn);
                 return Ok(true);
             }
         }
+        info!("Relation {:?} doesn't exist at {}", rel, lsn);
         Ok(false)
     }
 

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -15,6 +15,7 @@ use crate::ZTimelineId;
 use anyhow::Error;
 use lazy_static::lazy_static;
 use log::*;
+use postgres_ffi::xlog_utils::*;
 use postgres_protocol::message::backend::ReplicationMessage;
 use postgres_types::PgLsn;
 use std::collections::HashMap;
@@ -30,7 +31,6 @@ use tokio::time::{sleep, Duration};
 use tokio_postgres::replication::{PgTimestamp, ReplicationStream};
 use tokio_postgres::{NoTls, SimpleQueryMessage, SimpleQueryRow};
 use tokio_stream::StreamExt;
-use postgres_ffi::xlog_utils::*;
 
 //
 // We keep one WAL Receiver active per timeline.


### PR DESCRIPTION
If WAL receiver is not started before receiving first request by pageserver, then computation node is given wrong result (zero page).
It is well known problem of deadlock during zenith (we need to access catalog to perform authentication of replication connection).
But right now with local access to catalog relations it is not present. 