### PR TITLE
add Lsn type

### DIFF
--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -831,8 +831,9 @@ impl PageCache {
         loop {
             thread::sleep(conf.gc_period);
             let last_lsn = self.get_last_valid_lsn();
-            if last_lsn.0 > conf.gc_horizon {
-                let horizon = last_lsn - conf.gc_horizon;
+
+            // checked_sub() returns None on overflow.
+            if let Some(horizon) = last_lsn.checked_sub(conf.gc_horizon) {
                 let mut maxkey = CacheKey {
                     tag: BufferTag {
                         rel: RelTag {

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -25,6 +25,7 @@ use tokio::runtime;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 use tokio::task;
+use zenith_utils::lsn::Lsn;
 
 use crate::basebackup;
 use crate::page_cache;
@@ -84,7 +85,7 @@ struct ZenithRequest {
     relnode: u32,
     forknum: u8,
     blkno: u32,
-    lsn: u64,
+    lsn: Lsn,
 }
 
 #[derive(Debug)]
@@ -373,7 +374,7 @@ impl FeMessage {
                     relnode: body.get_u32(),
                     forknum: body.get_u8(),
                     blkno: body.get_u32(),
-                    lsn: body.get_u64(),
+                    lsn: Lsn::from(body.get_u64()),
                 };
 
                 // TODO: consider using protobuf or serde bincode for less error prone

--- a/pageserver/src/tui.rs
+++ b/pageserver/src/tui.rs
@@ -240,7 +240,9 @@ fn get_metric_u64(title: &str, value: u64) -> Spans {
     ])
 }
 
-fn get_metric_str<'a>(title: &str, value: &'a str) -> Spans<'a> {
+// This is not used since LSNs were removed from page cache stats.
+// Maybe it will be used in the future?
+fn _get_metric_str<'a>(title: &str, value: &'a str) -> Spans<'a> {
     Spans::from(vec![
         Span::styled(format!("{:<20}", title), Style::default()),
         Span::raw(": "),
@@ -261,6 +263,10 @@ impl tui::widgets::Widget for MetricsWidget {
         let mut lines: Vec<Spans> = Vec::new();
 
         let page_cache_stats = crate::page_cache::get_stats();
+
+        // This is not used since LSNs were removed from page cache stats.
+        // Maybe it will be used in the future?
+        /*
         let lsnrange = format!(
             "{} - {}",
             page_cache_stats.first_valid_lsn, page_cache_stats.last_valid_lsn
@@ -268,6 +274,8 @@ impl tui::widgets::Widget for MetricsWidget {
         let last_valid_recordlsn_str = page_cache_stats.last_record_lsn.to_string();
         lines.push(get_metric_str("Valid LSN range", &lsnrange));
         lines.push(get_metric_str("Last record LSN", &last_valid_recordlsn_str));
+        */
+
         lines.push(get_metric_u64(
             "# of cache entries",
             page_cache_stats.num_entries,

--- a/pageserver/src/tui.rs
+++ b/pageserver/src/tui.rs
@@ -248,13 +248,6 @@ fn get_metric_str<'a>(title: &str, value: &'a str) -> Spans<'a> {
     ])
 }
 
-// FIXME: We really should define a datatype for LSNs, with Display trait and
-// helper functions. There's one in tokio-postgres, but I don't think we want
-// to rely on that.
-fn format_lsn(lsn: u64) -> String {
-    return format!("{:X}/{:X}", lsn >> 32, lsn & 0xffff_ffff);
-}
-
 impl tui::widgets::Widget for MetricsWidget {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let block = Block::default()
@@ -270,10 +263,9 @@ impl tui::widgets::Widget for MetricsWidget {
         let page_cache_stats = crate::page_cache::get_stats();
         let lsnrange = format!(
             "{} - {}",
-            format_lsn(page_cache_stats.first_valid_lsn),
-            format_lsn(page_cache_stats.last_valid_lsn)
+            page_cache_stats.first_valid_lsn, page_cache_stats.last_valid_lsn
         );
-        let last_valid_recordlsn_str = format_lsn(page_cache_stats.last_record_lsn);
+        let last_valid_recordlsn_str = page_cache_stats.last_record_lsn.to_string();
         lines.push(get_metric_str("Valid LSN range", &lsnrange));
         lines.push(get_metric_str("Last record LSN", &last_valid_recordlsn_str));
         lines.push(get_metric_u64(

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -166,10 +166,7 @@ async fn walreceiver_main(
         // FIXME: It probably would be better to always start streaming from the beginning
         // of the page, or the segment, so that we could check the page/segment headers
         // too. Just for the sake of paranoia.
-        // FIXME: should any of this logic move inside the Lsn type?
-        if startpoint.0 % 8 != 0 {
-            startpoint += 8 - (startpoint.0 % 8);
-        }
+        startpoint += startpoint.calc_padding(8u32);
     }
     debug!(
         "last_valid_lsn {} starting replication from {}  for timeline {}, server is at {}...",

--- a/zenith_utils/src/lib.rs
+++ b/zenith_utils/src/lib.rs
@@ -1,5 +1,7 @@
 //! zenith_utils is intended to be a place to put code that is shared
 //! between other crates in this repository.
 
+/// `Lsn` type implements common tasks on Log Sequence Numbers
+pub mod lsn;
 /// SeqWait allows waiting for a future sequence number to arrive
 pub mod seqwait;

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 
 use std::fmt;
-use std::ops::{Add, AddAssign, Sub};
+use std::ops::{Add, AddAssign};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -17,6 +17,12 @@ pub struct LsnParseError;
 impl Lsn {
     /// Maximum possible value for an LSN
     pub const MAX: Lsn = Lsn(u64::MAX);
+
+    /// Subtract a number, returning None on overflow.
+    pub fn checked_sub<T: Into<u64>>(self, other: T) -> Option<Lsn> {
+        let other: u64 = other.into();
+        self.0.checked_sub(other).map(Lsn)
+    }
 
     /// Parse an LSN from a filename in the form `0000000000000000`
     pub fn from_filename<F>(filename: F) -> Result<Self, LsnParseError>
@@ -83,15 +89,6 @@ impl FromStr for Lsn {
 impl fmt::Display for Lsn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:X}/{:X}", self.0 >> 32, self.0 & 0xffffffff)
-    }
-}
-
-impl Sub<u64> for Lsn {
-    type Output = Lsn;
-
-    fn sub(self, other: u64) -> Self::Output {
-        // panic if the subtraction overflows/underflows.
-        Lsn(self.0.checked_sub(other).unwrap())
     }
 }
 

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -1,0 +1,137 @@
+#![warn(missing_docs)]
+
+use std::fmt;
+use std::ops::{Add, AddAssign, Sub};
+use std::path::Path;
+use std::str::FromStr;
+
+/// A Postgres LSN (Log Sequence Number), also known as an XLogRecPtr
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Lsn(pub u64);
+
+/// We tried to parse an LSN from a string, but failed
+#[derive(Debug, PartialEq, thiserror::Error)]
+#[error("LsnParseError")]
+pub struct LsnParseError;
+
+impl Lsn {
+    /// Maximum possible value for an LSN
+    pub const MAX: Lsn = Lsn(u64::MAX);
+
+    /// Parse an LSN from a filename in the form `0000000000000000`
+    pub fn from_filename<F>(filename: F) -> Result<Self, LsnParseError>
+    where
+        F: AsRef<Path>,
+    {
+        let filename: &Path = filename.as_ref();
+        let filename = filename.to_str().ok_or(LsnParseError)?;
+        Lsn::from_hex(filename)
+    }
+
+    /// Parse an LSN from a string in the form `0000000000000000`
+    pub fn from_hex<S>(s: S) -> Result<Self, LsnParseError>
+    where
+        S: AsRef<str>,
+    {
+        let s: &str = s.as_ref();
+        let n = u64::from_str_radix(s, 16).or(Err(LsnParseError))?;
+        Ok(Lsn(n))
+    }
+
+    /// Compute the offset into a segment
+    pub fn segment_offset(self, seg_sz: u64) -> u64 {
+        self.0 % seg_sz
+    }
+
+    /// Compute the segment number
+    pub fn segment_number(self, seg_sz: u64) -> u64 {
+        self.0 / seg_sz
+    }
+}
+
+impl From<u64> for Lsn {
+    fn from(n: u64) -> Self {
+        Lsn(n)
+    }
+}
+
+impl From<Lsn> for u64 {
+    fn from(lsn: Lsn) -> u64 {
+        lsn.0
+    }
+}
+
+impl FromStr for Lsn {
+    type Err = LsnParseError;
+
+    /// Parse an LSN from a string in the form `00000000/00000000`
+    ///
+    /// If the input string is missing the '/' character, then use `Lsn::from_hex`
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut splitter = s.split('/');
+        if let (Some(left), Some(right), None) = (splitter.next(), splitter.next(), splitter.next())
+        {
+            let left_num = u32::from_str_radix(left, 16).map_err(|_| LsnParseError)?;
+            let right_num = u32::from_str_radix(right, 16).map_err(|_| LsnParseError)?;
+            Ok(Lsn((left_num as u64) << 32 | right_num as u64))
+        } else {
+            Err(LsnParseError)
+        }
+    }
+}
+
+impl fmt::Display for Lsn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:X}/{:X}", self.0 >> 32, self.0 & 0xffffffff)
+    }
+}
+
+impl Sub<u64> for Lsn {
+    type Output = Lsn;
+
+    fn sub(self, other: u64) -> Self::Output {
+        // panic if the subtraction overflows/underflows.
+        Lsn(self.0.checked_sub(other).unwrap())
+    }
+}
+
+impl Add<u64> for Lsn {
+    type Output = Lsn;
+
+    fn add(self, other: u64) -> Self::Output {
+        // panic if the addition overflows.
+        Lsn(self.0.checked_add(other).unwrap())
+    }
+}
+
+impl AddAssign<u64> for Lsn {
+    fn add_assign(&mut self, other: u64) {
+        // panic if the addition overflows.
+        self.0 = self.0.checked_add(other).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lsn_strings() {
+        assert_eq!("12345678/AAAA5555".parse(), Ok(Lsn(0x12345678AAAA5555)));
+        assert_eq!("aaaa/bbbb".parse(), Ok(Lsn(0x0000AAAA0000BBBB)));
+        assert_eq!("1/A".parse(), Ok(Lsn(0x000000010000000A)));
+        assert_eq!("0/0".parse(), Ok(Lsn(0)));
+        "ABCDEFG/12345678".parse::<Lsn>().unwrap_err();
+        "123456789/AAAA5555".parse::<Lsn>().unwrap_err();
+        "12345678/AAAA55550".parse::<Lsn>().unwrap_err();
+        "-1/0".parse::<Lsn>().unwrap_err();
+        "1/-1".parse::<Lsn>().unwrap_err();
+
+        assert_eq!(format!("{}", Lsn(0x12345678AAAA5555)), "12345678/AAAA5555");
+        assert_eq!(format!("{}", Lsn(0x000000010000000A)), "1/A");
+
+        assert_eq!(Lsn::from_hex("12345678AAAA5555"), Ok(Lsn(0x12345678AAAA5555)));
+        assert_eq!(Lsn::from_hex("0"), Ok(Lsn(0)));
+        assert_eq!(Lsn::from_hex("F12345678AAAA5555"), Err(LsnParseError));
+    }
+}


### PR DESCRIPTION
This type is a zero-cost wrapper for a u64, meant to help code communicate with precision what that value means, and prevent any type mix-ups.

It implements `Display` and `Debug`. `Display` will format as `1234ABCD:5678CDEF` while `Debug` will format as `Lsn(1234567890)`.

This isn't ready to merge; it's for code review purposes only.
There are lots of FIXME comments that want feedback.

Fixes #49.
