### PR TITLE
Use explicit threads.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,5 +2761,4 @@ name = "zenith_utils"
 version = "0.1.0"
 dependencies = [
  "thiserror",
- "tokio",
 ]

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -5,8 +5,4 @@ authors = ["Eric Seppanen <eric@zenith.tech>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.5", features = ["sync", "time" ] }
 thiserror = "1"
-
-[dev-dependencies]
-tokio = { version = "1.5", features = ["macros", "rt"] }

--- a/zenith_utils/src/lib.rs
+++ b/zenith_utils/src/lib.rs
@@ -5,3 +5,6 @@
 pub mod lsn;
 /// SeqWait allows waiting for a future sequence number to arrive
 pub mod seqwait;
+
+// Async version of SeqWait. Currently unused.
+// pub mod seqwait_async;

--- a/zenith_utils/src/seqwait.rs
+++ b/zenith_utils/src/seqwait.rs
@@ -1,12 +1,12 @@
 #![warn(missing_docs)]
 
-use std::collections::BTreeMap;
+use std::cmp::{Eq, Ordering, PartialOrd};
+use std::collections::BinaryHeap;
 use std::fmt::Debug;
 use std::mem;
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Mutex;
 use std::time::Duration;
-use tokio::sync::watch::{channel, Receiver, Sender};
-use tokio::time::timeout;
 
 /// An error happened while waiting for a number
 #[derive(Debug, PartialEq, thiserror::Error)]
@@ -23,14 +23,44 @@ struct SeqWaitInt<T>
 where
     T: Ord,
 {
-    waiters: BTreeMap<T, (Sender<()>, Receiver<()>)>,
+    waiters: BinaryHeap<Waiter<T>>,
     current: T,
     shutdown: bool,
 }
 
+struct Waiter<T>
+where
+    T: Ord,
+{
+    wake_num: T,              // wake me when this number arrives ...
+    wake_channel: Sender<()>, // ... by sending a message to this channel
+}
+
+// BinaryHeap is a max-heap, and we want a min-heap. Reverse the ordering here
+// to get that.
+impl<T: Ord> PartialOrd for Waiter<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        other.wake_num.partial_cmp(&self.wake_num)
+    }
+}
+
+impl<T: Ord> Ord for Waiter<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.wake_num.cmp(&self.wake_num)
+    }
+}
+
+impl<T: Ord> PartialEq for Waiter<T> {
+    fn eq(&self, other: &Self) -> bool {
+        other.wake_num == self.wake_num
+    }
+}
+
+impl<T: Ord> Eq for Waiter<T> {}
+
 /// A tool for waiting on a sequence number
 ///
-/// This provides a way to await the arrival of a number.
+/// This provides a way to wait the arrival of a number.
 /// As soon as the number arrives by another caller calling
 /// [`advance`], then the waiter will be woken up.
 ///
@@ -56,7 +86,7 @@ where
     /// Create a new `SeqWait`, initialized to a particular number
     pub fn new(starting_num: T) -> Self {
         let internal = SeqWaitInt {
-            waiters: BTreeMap::new(),
+            waiters: BinaryHeap::new(),
             current: starting_num,
             shutdown: false,
         };
@@ -92,29 +122,12 @@ where
     ///
     /// This call won't complete until someone has called `advance`
     /// with a number greater than or equal to the one we're waiting for.
-    pub async fn wait_for(&self, num: T) -> Result<(), SeqWaitError> {
-        let mut rx = {
-            let mut internal = self.internal.lock().unwrap();
-            if internal.current >= num {
-                return Ok(());
-            }
-            if internal.shutdown {
-                return Err(SeqWaitError::Shutdown);
-            }
-
-            // If we already have a channel for waiting on this number, reuse it.
-            if let Some((_, rx)) = internal.waiters.get_mut(&num) {
-                // an Err from changed() means the sender was dropped.
-                rx.clone()
-            } else {
-                // Create a new channel.
-                let (tx, rx) = channel(());
-                internal.waiters.insert(num, (tx, rx.clone()));
-                rx
-            }
-            // Drop the lock as we exit this scope.
-        };
-        rx.changed().await.map_err(|_| SeqWaitError::Shutdown)
+    pub fn wait_for(&self, num: T) -> Result<(), SeqWaitError> {
+        match self.queue_for_wait(num) {
+            Ok(None) => Ok(()),
+            Ok(Some(rx)) => rx.recv().map_err(|_| SeqWaitError::Shutdown),
+            Err(e) => Err(e),
+        }
     }
 
     /// Wait for a number to arrive
@@ -124,14 +137,36 @@ where
     ///
     /// If that hasn't happened after the specified timeout duration,
     /// [`SeqWaitError::Timeout`] will be returned.
-    pub async fn wait_for_timeout(
-        &self,
-        num: T,
-        timeout_duration: Duration,
-    ) -> Result<(), SeqWaitError> {
-        timeout(timeout_duration, self.wait_for(num))
-            .await
-            .unwrap_or(Err(SeqWaitError::Timeout))
+    pub fn wait_for_timeout(&self, num: T, timeout_duration: Duration) -> Result<(), SeqWaitError> {
+        match self.queue_for_wait(num) {
+            Ok(None) => Ok(()),
+            Ok(Some(rx)) => rx.recv_timeout(timeout_duration).map_err(|e| match e {
+                std::sync::mpsc::RecvTimeoutError::Timeout => SeqWaitError::Timeout,
+                std::sync::mpsc::RecvTimeoutError::Disconnected => SeqWaitError::Shutdown,
+            }),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Register and return a channel that will be notified when a number arrives,
+    /// or None, if it has already arrived.
+    fn queue_for_wait(&self, num: T) -> Result<Option<Receiver<()>>, SeqWaitError> {
+        let mut internal = self.internal.lock().unwrap();
+        if internal.current >= num {
+            return Ok(None);
+        }
+        if internal.shutdown {
+            return Err(SeqWaitError::Shutdown);
+        }
+
+        // Create a new channel.
+        let (tx, rx) = channel();
+        internal.waiters.push(Waiter {
+            wake_num: num,
+            wake_channel: tx,
+        });
+        // Drop the lock as we exit this scope.
+        Ok(Some(rx))
     }
 
     /// Announce a new number has arrived
@@ -152,22 +187,19 @@ where
             }
             internal.current = num;
 
-            // split_off will give me all the high-numbered waiters,
-            // so split and then swap. Everything at or above `num`
-            // stays.
-            let mut split = internal.waiters.split_off(&num);
-            std::mem::swap(&mut split, &mut internal.waiters);
-
-            // `split_at` didn't get the value at `num`; if it's
-            // there take that too.
-            if let Some(sleeper) = internal.waiters.remove(&num) {
-                split.insert(num, sleeper);
+            // Pop all waiters <= num from the heap. Collect them in a vector, and
+            // wake them up after releasing the lock.
+            let mut wake_these = Vec::new();
+            while let Some(n) = internal.waiters.peek() {
+                if n.wake_num > num {
+                    break;
+                }
+                wake_these.push(internal.waiters.pop().unwrap().wake_channel);
             }
-
-            split
+            wake_these
         };
 
-        for (_wake_num, (tx, _rx)) in wake_these {
+        for tx in wake_these {
             // This can fail if there are no receivers.
             // We don't care; discard the error.
             let _ = tx.send(());
@@ -179,38 +211,40 @@ where
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use tokio::time::{sleep, Duration};
+    use std::thread::sleep;
+    use std::thread::spawn;
+    use std::time::Duration;
 
-    #[tokio::test]
-    async fn seqwait() {
+    #[test]
+    fn seqwait() {
         let seq = Arc::new(SeqWait::new(0));
         let seq2 = Arc::clone(&seq);
         let seq3 = Arc::clone(&seq);
-        tokio::spawn(async move {
-            seq2.wait_for(42).await.expect("wait_for 42");
+        spawn(move || {
+            seq2.wait_for(42).expect("wait_for 42");
             seq2.advance(100);
-            seq2.wait_for(999).await.expect_err("no 999");
+            seq2.wait_for(999).expect_err("no 999");
         });
-        tokio::spawn(async move {
-            seq3.wait_for(42).await.expect("wait_for 42");
-            seq3.wait_for(0).await.expect("wait_for 0");
+        spawn(move || {
+            seq3.wait_for(42).expect("wait_for 42");
+            seq3.wait_for(0).expect("wait_for 0");
         });
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1));
         seq.advance(99);
-        seq.wait_for(100).await.expect("wait_for 100");
+        seq.wait_for(100).expect("wait_for 100");
         seq.shutdown();
     }
 
-    #[tokio::test]
-    async fn seqwait_timeout() {
+    #[test]
+    fn seqwait_timeout() {
         let seq = Arc::new(SeqWait::new(0));
         let seq2 = Arc::clone(&seq);
-        tokio::spawn(async move {
+        spawn(move || {
             let timeout = Duration::from_millis(1);
-            let res = seq2.wait_for_timeout(42, timeout).await;
+            let res = seq2.wait_for_timeout(42, timeout);
             assert_eq!(res, Err(SeqWaitError::Timeout));
         });
-        sleep(Duration::from_secs(1)).await;
+        sleep(Duration::from_secs(1));
         // This will attempt to wake, but nothing will happen
         // because the waiter already dropped its Receiver.
         seq.advance(99);

--- a/zenith_utils/src/seqwait_async.rs
+++ b/zenith_utils/src/seqwait_async.rs
@@ -1,0 +1,224 @@
+///
+/// Async version of 'seqwait.rs'
+///
+/// NOTE: This is currently unused. If you need this, you'll need to uncomment this in lib.rs.
+///
+
+#![warn(missing_docs)]
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::mem;
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio::sync::watch::{channel, Receiver, Sender};
+use tokio::time::timeout;
+
+/// An error happened while waiting for a number
+#[derive(Debug, PartialEq, thiserror::Error)]
+#[error("SeqWaitError")]
+pub enum SeqWaitError {
+    /// The wait timeout was reached
+    Timeout,
+    /// [`SeqWait::shutdown`] was called
+    Shutdown,
+}
+
+/// Internal components of a `SeqWait`
+struct SeqWaitInt<T>
+where
+    T: Ord,
+{
+    waiters: BTreeMap<T, (Sender<()>, Receiver<()>)>,
+    current: T,
+    shutdown: bool,
+}
+
+/// A tool for waiting on a sequence number
+///
+/// This provides a way to await the arrival of a number.
+/// As soon as the number arrives by another caller calling
+/// [`advance`], then the waiter will be woken up.
+///
+/// This implementation takes a blocking Mutex on both [`wait_for`]
+/// and [`advance`], meaning there may be unexpected executor blocking
+/// due to thread scheduling unfairness. There are probably better
+/// implementations, but we can probably live with this for now.
+///
+/// [`wait_for`]: SeqWait::wait_for
+/// [`advance`]: SeqWait::advance
+///
+pub struct SeqWait<T>
+where
+    T: Ord,
+{
+    internal: Mutex<SeqWaitInt<T>>,
+}
+
+impl<T> SeqWait<T>
+where
+    T: Ord + Debug + Copy,
+{
+    /// Create a new `SeqWait`, initialized to a particular number
+    pub fn new(starting_num: T) -> Self {
+        let internal = SeqWaitInt {
+            waiters: BTreeMap::new(),
+            current: starting_num,
+            shutdown: false,
+        };
+        SeqWait {
+            internal: Mutex::new(internal),
+        }
+    }
+
+    /// Shut down a `SeqWait`, causing all waiters (present and
+    /// future) to return an error.
+    pub fn shutdown(&self) {
+        let waiters = {
+            // Prevent new waiters; wake all those that exist.
+            // Wake everyone with an error.
+            let mut internal = self.internal.lock().unwrap();
+
+            // This will steal the entire waiters map.
+            // When we drop it all waiters will be woken.
+            mem::take(&mut internal.waiters)
+
+            // Drop the lock as we exit this scope.
+        };
+
+        // When we drop the waiters list, each Receiver will
+        // be woken with an error.
+        // This drop doesn't need to be explicit; it's done
+        // here to make it easier to read the code and understand
+        // the order of events.
+        drop(waiters);
+    }
+
+    /// Wait for a number to arrive
+    ///
+    /// This call won't complete until someone has called `advance`
+    /// with a number greater than or equal to the one we're waiting for.
+    pub async fn wait_for(&self, num: T) -> Result<(), SeqWaitError> {
+        let mut rx = {
+            let mut internal = self.internal.lock().unwrap();
+            if internal.current >= num {
+                return Ok(());
+            }
+            if internal.shutdown {
+                return Err(SeqWaitError::Shutdown);
+            }
+
+            // If we already have a channel for waiting on this number, reuse it.
+            if let Some((_, rx)) = internal.waiters.get_mut(&num) {
+                // an Err from changed() means the sender was dropped.
+                rx.clone()
+            } else {
+                // Create a new channel.
+                let (tx, rx) = channel(());
+                internal.waiters.insert(num, (tx, rx.clone()));
+                rx
+            }
+            // Drop the lock as we exit this scope.
+        };
+        rx.changed().await.map_err(|_| SeqWaitError::Shutdown)
+    }
+
+    /// Wait for a number to arrive
+    ///
+    /// This call won't complete until someone has called `advance`
+    /// with a number greater than or equal to the one we're waiting for.
+    ///
+    /// If that hasn't happened after the specified timeout duration,
+    /// [`SeqWaitError::Timeout`] will be returned.
+    pub async fn wait_for_timeout(
+        &self,
+        num: T,
+        timeout_duration: Duration,
+    ) -> Result<(), SeqWaitError> {
+        timeout(timeout_duration, self.wait_for(num))
+            .await
+            .unwrap_or(Err(SeqWaitError::Timeout))
+    }
+
+    /// Announce a new number has arrived
+    ///
+    /// All waiters at this value or below will be woken.
+    ///
+    /// `advance` will panic if you send it a lower number than
+    /// a previous call.
+    pub fn advance(&self, num: T) {
+        let wake_these = {
+            let mut internal = self.internal.lock().unwrap();
+
+            if internal.current > num {
+                panic!(
+                    "tried to advance backwards, from {:?} to {:?}",
+                    internal.current, num
+                );
+            }
+            internal.current = num;
+
+            // split_off will give me all the high-numbered waiters,
+            // so split and then swap. Everything at or above `num`
+            // stays.
+            let mut split = internal.waiters.split_off(&num);
+            std::mem::swap(&mut split, &mut internal.waiters);
+
+            // `split_at` didn't get the value at `num`; if it's
+            // there take that too.
+            if let Some(sleeper) = internal.waiters.remove(&num) {
+                split.insert(num, sleeper);
+            }
+
+            split
+        };
+
+        for (_wake_num, (tx, _rx)) in wake_these {
+            // This can fail if there are no receivers.
+            // We don't care; discard the error.
+            let _ = tx.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn seqwait() {
+        let seq = Arc::new(SeqWait::new(0));
+        let seq2 = Arc::clone(&seq);
+        let seq3 = Arc::clone(&seq);
+        tokio::spawn(async move {
+            seq2.wait_for(42).await.expect("wait_for 42");
+            seq2.advance(100);
+            seq2.wait_for(999).await.expect_err("no 999");
+        });
+        tokio::spawn(async move {
+            seq3.wait_for(42).await.expect("wait_for 42");
+            seq3.wait_for(0).await.expect("wait_for 0");
+        });
+        sleep(Duration::from_secs(1)).await;
+        seq.advance(99);
+        seq.wait_for(100).await.expect("wait_for 100");
+        seq.shutdown();
+    }
+
+    #[tokio::test]
+    async fn seqwait_timeout() {
+        let seq = Arc::new(SeqWait::new(0));
+        let seq2 = Arc::clone(&seq);
+        tokio::spawn(async move {
+            let timeout = Duration::from_millis(1);
+            let res = seq2.wait_for_timeout(42, timeout).await;
+            assert_eq!(res, Err(SeqWaitError::Timeout));
+        });
+        sleep(Duration::from_secs(1)).await;
+        // This will attempt to wake, but nothing will happen
+        // because the waiter already dropped its Receiver.
+        seq.advance(99);
+    }
+}


### PR DESCRIPTION
Remove 'async' usage a much as feasible. Async code is harder to debug,
and mixing async and non-async code is a recipe for confusion and bugs.

There are a couple of exceptions:

- The code in walredo.rs, which needs to read and write to the child
  process simultaneously, still uses async. It's more convenient there.
  The 'async' usage is carefully limited to just the functions that
  communicate with the child process.

- Code in walreceiver.rs that uses tokio-postgres to do streaming
  replication. We have to use async there, because tokio-postgres is
  async. Most rust-postgres functionality has non-async wrappers, but
  not the new replication client code. The async usage is very limited
  here, too: we use just block_on to call the tokio-postgres functions.

The code in 'page_service.rs' now launches a dedicated thread for each
connection.

This replaces tokio::sync::watch::channel with std::sync:mpsc in
'seqwait.rs', to make that non-async. It's not a drop-in replacement,
though: std::sync::mpsc doesn't support multiple consumers, so we cannot
share a channel between multiple waiters. So this removes the code to
check if an existing channel can be reused, and creates a new one for
each waiter. That created another problem: BTreeMap cannot hold
duplicates, so I replaced that with BinaryHeap.

Similarly, the tokio::{mpsc, oneshot} channels used between WAL redo
manager and PageCache are replaced with std::sync::mpsc. (There is no
separate 'oneshot' channel in the standard library.)

See discussion at https://github.com/zenithdb/zenith/issues/58