### PR TITLE
clippy cleanup #3

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -133,12 +133,7 @@ fn parse_filename(fname: &str) -> Result<(u32, u32, u32), FilePathError> {
     let relnode_str = caps.name("relnode").unwrap().as_str();
     let relnode = u32::from_str_radix(relnode_str, 10)?;
 
-    let forkname_match = caps.name("forkname");
-    let forkname = if forkname_match.is_none() {
-        None
-    } else {
-        Some(forkname_match.unwrap().as_str())
-    };
+    let forkname = caps.name("forkname").map(|f| f.as_str());
     let forknum = forkname_to_forknum(forkname)?;
 
     let segno_match = caps.name("segno");

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -6,7 +6,6 @@ use log::*;
 use parse_duration::parse;
 use std::fs::{self, OpenOptions};
 use std::io;
-use std::path::PathBuf;
 use std::process::exit;
 use std::thread;
 use std::time::Duration;
@@ -125,7 +124,7 @@ fn start_pageserver(conf: &PageServerConf) -> Result<()> {
     if conf.daemonize {
         info!("daemonizing...");
 
-        let repodir = PathBuf::from(zenith_repo_dir());
+        let repodir = zenith_repo_dir();
 
         // There should'n be any logging to stdin/stdout. Redirect it to the main log so
         // that we will see any accidental manual fprintf's or backtraces.

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -14,7 +14,6 @@ use anyhow::{bail, Context};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use lazy_static::lazy_static;
 use log::*;
-use rocksdb;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
@@ -414,7 +413,7 @@ impl PageCache {
     ///
     pub fn relsize_get(&self, rel: &RelTag, lsn: Lsn) -> anyhow::Result<u32> {
         self.wait_lsn(lsn)?;
-        return self.relsize_get_nowait(rel, lsn);
+        self.relsize_get_nowait(rel, lsn)
     }
 
     ///

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -687,9 +687,7 @@ impl Connection {
             self.write_message_noflush(&BeMessage::CommandComplete)?;
             self.write_message(&BeMessage::ReadyForQuery)
         } else if query_string.starts_with(b"callmemaybe ") {
-            let query_str = String::from_utf8(query_string.to_vec())
-                .unwrap()
-                .to_string();
+            let query_str = String::from_utf8(query_string.to_vec()).unwrap();
 
             // callmemaybe <zenith timelineid as hex string> <connstr>
             let re = Regex::new(r"^callmemaybe ([[:xdigit:]]+) (.*)$").unwrap();
@@ -849,11 +847,7 @@ impl Connection {
         // find latest snapshot
         let snapshotlsn = restore_local_repo::find_latest_snapshot(&self.conf, timelineid).unwrap();
 
-        basebackup::send_snapshot_tarball(
-            &mut CopyDataSink { stream: stream },
-            timelineid,
-            snapshotlsn,
-        )?;
+        basebackup::send_snapshot_tarball(&mut CopyDataSink { stream }, timelineid, snapshotlsn)?;
 
         // CopyDone
         self.stream.write_u8(b'c')?;

--- a/pageserver/src/restore_s3.rs
+++ b/pageserver/src/restore_s3.rs
@@ -198,12 +198,7 @@ fn parse_filename(fname: &str) -> Result<(u32, u32, u32, u64), FilePathError> {
     let relnode_str = caps.name("relnode").unwrap().as_str();
     let relnode: u32 = relnode_str.parse()?;
 
-    let forkname_match = caps.name("forkname");
-    let forkname = if forkname_match.is_none() {
-        None
-    } else {
-        Some(forkname_match.unwrap().as_str())
-    };
+    let forkname = caps.name("forkname").map(|f| f.as_str());
     let forknum = forkname_to_forknum(forkname)?;
 
     let segno_match = caps.name("segno");

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -168,8 +168,8 @@ fn walreceiver_main(
         // different like having 'initdb' method on a pageserver (or importing some shared
         // empty database snapshot), so for now I just put start of first segment which
         // seems to be a valid record.
-        pcache.init_valid_lsn(Lsn(0x_1_000_000));
-        startpoint = Lsn(0x_1_000_000);
+        pcache.init_valid_lsn(Lsn(0x0100_0000));
+        startpoint = Lsn(0x0100_0000);
     } else {
         // There might be some padding after the last full record, skip it.
         //
@@ -257,7 +257,7 @@ fn walreceiver_main(
                                     blknum: truncate.blkno,
                                 };
                                 let rec = page_cache::WALRecord {
-                                    lsn: lsn,
+                                    lsn,
                                     will_init: false,
                                     truncate: true,
                                     rec: recdata.clone(),
@@ -330,7 +330,7 @@ fn walreceiver_main(
             _ => (),
         }
     }
-    return Ok(());
+    Ok(())
 }
 
 /// Data returned from the postgres `IDENTIFY_SYSTEM` command

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -116,9 +116,9 @@ impl WalRedoManager {
             .spawn(move || {
                 let mut internal = WalRedoManagerInternal {
                     _conf: conf_copy,
-                    timelineid: timelineid,
-                    pcache: pcache,
-                    request_rx: request_rx,
+                    timelineid,
+                    pcache,
+                    request_rx,
                 };
                 internal.wal_redo_main();
             })


### PR DESCRIPTION
Fix some issues raised by clippy. Mostly trivial ones, though some allow 4-5 lines of code to be reduced to 1.

`File::write` does not guarantee all bytes are written; it behaves like the `write` syscall. Clippy points out `write_all` is probably a better choice.

Fixes #67.