### PR TITLE
Re-implement in-memory storage

### DIFF
--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -3,23 +3,22 @@
 //! isn't much here. If we implement multi-tenancy, this will probably be changed into
 //! a hash map, keyed by the tenant ID.
 
+use crate::repository::inmemory::InMemoryRepository;
 use crate::PageServerConf;
-//use crate::repository::Repository;
-use crate::repository::rocksdb::RocksRepository;
 use lazy_static::lazy_static;
 use std::sync::{Arc, Mutex};
 
 lazy_static! {
-    pub static ref REPOSITORY: Mutex<Option<Arc<RocksRepository>>> = Mutex::new(None);
+    pub static ref REPOSITORY: Mutex<Option<Arc<InMemoryRepository>>> = Mutex::new(None);
 }
 
 pub fn init(conf: &PageServerConf) {
     let mut m = REPOSITORY.lock().unwrap();
 
-    *m = Some(Arc::new(RocksRepository::new(conf)));
+    *m = Some(Arc::new(InMemoryRepository::new(conf)));
 }
 
-pub fn get_repository() -> Arc<RocksRepository> {
+pub fn get_repository() -> Arc<InMemoryRepository> {
     let o = &REPOSITORY.lock().unwrap();
     Arc::clone(o.as_ref().unwrap())
 }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -24,7 +24,7 @@ use zenith_utils::lsn::Lsn;
 
 use crate::basebackup;
 use crate::page_cache;
-use crate::repository::{BufferTag, RelTag, Repository, Timeline};
+use crate::repository::{BufferTag, RelTag, Repository};
 use crate::restore_local_repo;
 use crate::walreceiver;
 use crate::PageServerConf;

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -849,7 +849,7 @@ impl Connection {
         /* Send a tarball of the latest snapshot on the timeline */
 
         // find latest snapshot
-        let snapshotlsn = restore_local_repo::find_latest_snapshot(&self.conf, timelineid).unwrap();
+        let snapshotlsn = restore_local_repo::find_latest_snapshot(timelineid).unwrap();
 
         basebackup::send_snapshot_tarball(&mut CopyDataSink { stream }, timelineid, snapshotlsn)?;
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -849,7 +849,7 @@ impl Connection {
         /* Send a tarball of the latest snapshot on the timeline */
 
         // find latest snapshot
-        let snapshotlsn = restore_local_repo::find_latest_snapshot(timelineid).unwrap();
+        let snapshotlsn = restore_local_repo::find_latest_snapshot(timelineid, Lsn(0)).unwrap();
 
         basebackup::send_snapshot_tarball(&mut CopyDataSink { stream }, timelineid, snapshotlsn)?;
 

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -1,4 +1,4 @@
-pub mod rocksdb;
+pub mod inmemory;
 
 use crate::waldecoder::{Oid, DecodedWALRecord};
 use crate::ZTimelineId;
@@ -17,7 +17,7 @@ pub trait Repository {
     ///
     /// The Timeline is expected to be already "open", i.e. `get_or_restore_timeline`
     /// should've been called on it earlier already.
-    fn get_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<rocksdb::RocksTimeline>>;
+    fn get_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<inmemory::InMemoryTimeline>>;
 
     /// Get Timeline handle for given zenith timeline ID.
     ///
@@ -25,7 +25,7 @@ pub trait Repository {
     fn get_or_restore_timeline(
         &self,
         timelineid: ZTimelineId,
-    ) -> Result<Arc<rocksdb::RocksTimeline>>;
+    ) -> Result<Arc<inmemory::InMemoryTimeline>>;
 
     //fn get_stats(&self) -> RepositoryStats;
 }

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -1,6 +1,6 @@
 pub mod inmemory;
 
-use crate::waldecoder::{Oid, DecodedWALRecord};
+use crate::waldecoder::{DecodedWALRecord, Oid};
 use crate::ZTimelineId;
 use anyhow::Result;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -10,28 +10,22 @@ use zenith_utils::lsn::Lsn;
 ///
 /// A repository corresponds to one .zenith directory. One repository holds multiple
 /// timelines, forked off from the same initial call to 'initdb'.
-///
-/// FIXME: I wish these would return an abstract `&dyn Timeline`.
 pub trait Repository {
     /// Get Timeline handle for given zenith timeline ID.
     ///
     /// The Timeline is expected to be already "open", i.e. `get_or_restore_timeline`
     /// should've been called on it earlier already.
-    fn get_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<inmemory::InMemoryTimeline>>;
+    fn get_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<dyn Timeline>>;
 
     /// Get Timeline handle for given zenith timeline ID.
     ///
     /// Creates a new Timeline object if it's not "open" already.
-    fn get_or_restore_timeline(
-        &self,
-        timelineid: ZTimelineId,
-    ) -> Result<Arc<inmemory::InMemoryTimeline>>;
+    fn get_or_restore_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<dyn Timeline>>;
 
     //fn get_stats(&self) -> RepositoryStats;
 }
 
 pub trait Timeline {
-
     //------------------------------------------------------------------------------
     // Public GET functions
     //------------------------------------------------------------------------------
@@ -85,7 +79,7 @@ pub trait Timeline {
         &self,
         decoded: DecodedWALRecord,
         recdata: Bytes,
-        lsn: Lsn
+        lsn: Lsn,
     ) -> anyhow::Result<()>;
 
     /// Remember the all WAL before the given LSN has been processed.

--- a/pageserver/src/repository/inmemory.rs
+++ b/pageserver/src/repository/inmemory.rs
@@ -1,0 +1,336 @@
+//!
+//! Zenith repository implementation that's backed by full base backups (called snapshots)
+//! of the PostgreSQL cluster, and the WAL. All the WAL on a timeline is loaded into memory
+//! at startup, hence the name "inmemory.rs".
+//!
+
+use anyhow::{bail, Context, Result};
+use bytes::Bytes;
+use log::*;
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::repository::{BufferTag, RelTag, Repository, Timeline, WALRecord};
+use crate::waldecoder::{DecodedWALRecord, Oid, XlCreateDatabase, XlSmgrTruncate};
+use crate::walredo::WalRedoManager;
+use crate::PageServerConf;
+use crate::ZTimelineId;
+
+use zenith_utils::lsn::{AtomicLsn, Lsn};
+use zenith_utils::seqwait::SeqWait;
+use postgres_ffi::pg_constants;
+
+mod relfile;
+
+use relfile::RelFileEntry;
+
+// Timeout when waiting or WAL receiver to catch up to an LSN given in a GetPage@LSN call.
+static TIMEOUT: Duration = Duration::from_secs(60);
+
+///
+/// Repository consists of multiple timelines. Keep them in a hash table.
+///
+pub struct InMemoryRepository {
+    conf: PageServerConf,
+    timelines: Mutex<HashMap<ZTimelineId, Arc<InMemoryTimeline>>>,
+}
+
+/// Public interface
+impl Repository for InMemoryRepository {
+    fn get_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<InMemoryTimeline>> {
+        let timelines = self.timelines.lock().unwrap();
+
+        match timelines.get(&timelineid) {
+            Some(timeline) => Ok(Arc::clone(&timeline)),
+            None => bail!("timeline not found"),
+        }
+    }
+
+    fn get_or_restore_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<InMemoryTimeline>> {
+        let mut timelines = self.timelines.lock().unwrap();
+
+        match timelines.get(&timelineid) {
+            Some(timeline) => Ok(timeline.clone()),
+            None => {
+                let timeline = InMemoryTimeline::new(&self.conf, timelineid);
+
+                // FIXME load on demand
+                crate::restore_local_repo::restore_timeline(
+                    &self.conf, &timeline, timelineid, false,
+                )?;
+
+                let timeline_rc = Arc::new(timeline);
+                timelines.insert(timelineid, timeline_rc.clone());
+                Ok(timeline_rc)
+            }
+        }
+    }
+}
+
+/// Private functions
+impl InMemoryRepository {
+    pub fn new(conf: &PageServerConf) -> InMemoryRepository {
+        InMemoryRepository {
+            conf: conf.clone(),
+            timelines: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+pub struct InMemoryTimeline {
+    timelineid: ZTimelineId,
+
+    relfiles: Mutex<HashMap<RelTag, Arc<RelFileEntry>>>,
+
+    // WAL redo manager
+    walredo_mgr: WalRedoManager,
+
+    // What page versions do we hold in the repository? If we get a
+    // request > last_valid_lsn, we need to wait until we receive all
+    // the WAL up to the request. The SeqWait provides functions for
+    // that. TODO: If we get a request for an old LSN, such that the
+    // versions have already been garbage collected away, we should
+    // throw an error, but we don't track that currently.
+    //
+    // last_record_lsn points to the end of last processed WAL record.
+    // It can lag behind last_valid_lsn, if the WAL receiver has
+    // received some WAL after the end of last record, but not the
+    // whole next record yet. In the page cache, we care about
+    // last_valid_lsn, but if the WAL receiver needs to restart the
+    // streaming, it needs to restart at the end of last record, so we
+    // track them separately. last_record_lsn should perhaps be in
+    // walreceiver.rs instead of here, but it seems convenient to keep
+    // all three values together.
+    //
+    last_valid_lsn: SeqWait<Lsn>,
+    last_record_lsn: AtomicLsn,
+
+    // Counters, for metrics collection.
+    pub num_entries: AtomicU64,
+    pub num_page_images: AtomicU64,
+    pub num_wal_records: AtomicU64,
+    pub num_getpage_requests: AtomicU64,
+}
+
+impl Timeline for InMemoryTimeline {
+    /// Look up given page in the cache.
+    fn get_page_at_lsn(&self, tag: BufferTag, lsn: Lsn) -> Result<Bytes> {
+        debug!("get_page_at_lsn: {:?} at {}", tag, lsn);
+        self.wait_lsn(lsn)?;
+        self.get_relfile(tag.rel)
+            .get_page_at_lsn(&self.walredo_mgr, tag.blknum, lsn)
+    }
+
+    fn get_relsize(&self, rel: RelTag, lsn: Lsn) -> Result<u32> {
+        self.wait_lsn(lsn)?;
+        let result = self.get_relfile(rel).get_relsize(lsn);
+        debug!("get_relsize: {:?} at {} -> {:?}", rel, lsn, result);
+        result
+    }
+    fn get_relsize_exists(&self, rel: RelTag, lsn: Lsn) -> Result<bool> {
+        self.wait_lsn(lsn)?;
+        let result = self.get_relfile(rel).exists(lsn);
+
+        debug!("get_relsize_exists: {:?} at {} -> {:?}", rel, lsn, result);
+        result
+    }
+
+    fn put_wal_record(&self, tag: BufferTag, rec: WALRecord) {
+        debug!("put_wal_record: {:?} at {:?}", tag, rec);
+        self.get_relfile(tag.rel).put_wal_record(tag.blknum, rec);
+    }
+
+    fn put_truncation(&self, rel: RelTag, lsn: Lsn, relsize: u32) -> anyhow::Result<()> {
+        debug!("put_truncation: {:?} at {}", relsize, lsn);
+        self.get_relfile(rel).put_truncation(lsn, relsize)
+    }
+
+    fn put_page_image(&self, tag: BufferTag, lsn: Lsn, img: Bytes) {
+        debug!("put_page_image: {:?} at {}", tag, lsn);
+        self.get_relfile(tag.rel)
+            .put_page_image(tag.blknum, lsn, img)
+    }
+
+    fn put_create_database(&self, _lsn: Lsn, _db_id: Oid, _tablespace_id: Oid, _src_db_id: Oid, _src_tablespace_id: Oid) -> Result<()> {
+
+        // TODO: Make a copy of everything in the old DB under new DB id
+        bail!("CREATE DATABASE not implemented");
+    }
+
+    // Process a WAL record. We make a separate copy of it for every block it modifies.
+    fn save_decoded_record(
+        &self,
+        decoded: DecodedWALRecord,
+        recdata: Bytes,
+        lsn: Lsn) -> anyhow::Result<()>
+    {
+        for blk in decoded.blocks.iter() {
+            let tag = BufferTag {
+                rel: RelTag {
+                    spcnode: blk.rnode_spcnode,
+                    dbnode: blk.rnode_dbnode,
+                    relnode: blk.rnode_relnode,
+                    forknum: blk.forknum as u8,
+                },
+                blknum: blk.blkno,
+            };
+
+            let rec = WALRecord {
+                lsn,
+                will_init: blk.will_init || blk.apply_image,
+                rec: recdata.clone(),
+                main_data_offset: decoded.main_data_offset as u32,
+            };
+
+            self.put_wal_record(tag, rec);
+        }
+        // include truncate wal record in all pages
+        if decoded.xl_rmid == pg_constants::RM_SMGR_ID
+            && (decoded.xl_info & pg_constants::XLR_RMGR_INFO_MASK)
+                == pg_constants::XLOG_SMGR_TRUNCATE
+        {
+            let truncate = XlSmgrTruncate::decode(&decoded);
+            if (truncate.flags & pg_constants::SMGR_TRUNCATE_HEAP) != 0 {
+                let rel = RelTag {
+                    spcnode: truncate.rnode.spcnode,
+                    dbnode: truncate.rnode.dbnode,
+                    relnode: truncate.rnode.relnode,
+                    forknum: pg_constants::MAIN_FORKNUM,
+                };
+                self.put_truncation(rel, lsn, truncate.blkno)?;
+            }
+        } else if decoded.xl_rmid == pg_constants::RM_DBASE_ID
+            && (decoded.xl_info & pg_constants::XLR_RMGR_INFO_MASK)
+                == pg_constants::XLOG_DBASE_CREATE
+        {
+            let createdb = XlCreateDatabase::decode(&decoded);
+            self.put_create_database(
+                lsn,
+                createdb.db_id,
+                createdb.tablespace_id,
+                createdb.src_db_id,
+                createdb.src_tablespace_id,
+            )?;
+        }
+        // Now that this record has been handled, let the page cache know that
+        // it is up-to-date to this LSN
+        self.advance_last_record_lsn(lsn);
+        Ok(())
+    }
+
+    /// Remember that WAL has been received and added to the page cache up to the given LSN
+    fn advance_last_valid_lsn(&self, lsn: Lsn) {
+        let old = self.last_valid_lsn.advance(lsn);
+
+        // Can't move backwards.
+        if lsn < old {
+            warn!(
+                "attempted to move last valid LSN backwards (was {}, new {})",
+                old, lsn
+            );
+        }
+    }
+
+    fn init_valid_lsn(&self, lsn: Lsn) {
+        let old = self.last_valid_lsn.advance(lsn);
+        assert!(old == Lsn(0));
+        let old = self.last_record_lsn.fetch_max(lsn);
+        assert!(old == Lsn(0));
+    }
+
+    fn get_last_valid_lsn(&self) -> Lsn {
+        self.last_valid_lsn.load()
+    }
+
+    ///
+    /// Remember the (end of) last valid WAL record remembered in the page cache.
+    ///
+    /// NOTE: this updates last_valid_lsn as well.
+    ///
+    fn advance_last_record_lsn(&self, lsn: Lsn) {
+        // Can't move backwards.
+        let old = self.last_record_lsn.fetch_max(lsn);
+        assert!(old <= lsn);
+
+        // Also advance last_valid_lsn
+        let old = self.last_valid_lsn.advance(lsn);
+        // Can't move backwards.
+        if lsn < old {
+            warn!(
+                "attempted to move last record LSN backwards (was {}, new {})",
+                old, lsn
+            );
+        }
+    }
+
+    fn get_last_record_lsn(&self) -> Lsn {
+        self.last_record_lsn.load()
+    }
+}
+
+impl InMemoryTimeline {
+    fn new(conf: &PageServerConf, timelineid: ZTimelineId) -> InMemoryTimeline {
+        InMemoryTimeline {
+            timelineid,
+            relfiles: Mutex::new(HashMap::new()),
+
+            walredo_mgr: WalRedoManager::new(conf, timelineid),
+
+            last_valid_lsn: SeqWait::new(Lsn(0)),
+            last_record_lsn: AtomicLsn::new(0),
+
+            num_entries: AtomicU64::new(0),
+            num_page_images: AtomicU64::new(0),
+            num_wal_records: AtomicU64::new(0),
+            num_getpage_requests: AtomicU64::new(0),
+        }
+    }
+
+    ///
+    /// Get a handle to a RelFileEntry
+    ///
+    fn get_relfile(&self, tag: RelTag) -> Arc<RelFileEntry> {
+        // First, look up the relfile
+        let mut relfiles = self.relfiles.lock().unwrap();
+        if let Some(relentry) = relfiles.get(&tag) {
+            relentry.clone()
+        } else {
+            // No RelFileEntry for this relation yet. Create one.
+            let relentry = Arc::new(RelFileEntry::new(self.timelineid, tag));
+            relfiles.insert(tag, relentry.clone());
+
+            relentry
+        }
+    }
+
+    ///
+    /// Wait until WAL has been received up to the given LSN.
+    ///
+    fn wait_lsn(&self, mut lsn: Lsn) -> anyhow::Result<Lsn> {
+        // When invalid LSN is requested, it means "don't wait, return latest version of the page"
+        // This is necessary for bootstrap.
+        if lsn == Lsn(0) {
+            let last_valid_lsn = self.last_valid_lsn.load();
+            trace!(
+                "walreceiver doesn't work yet last_valid_lsn {}, requested {}",
+                last_valid_lsn,
+                lsn
+            );
+            lsn = last_valid_lsn;
+        }
+
+        self.last_valid_lsn
+            .wait_for_timeout(lsn, TIMEOUT)
+            .with_context(|| {
+                format!(
+                    "Timed out while waiting for WAL record at LSN {} to arrive",
+                    lsn
+                )
+            })?;
+
+        Ok(lsn)
+    }
+}

--- a/pageserver/src/repository/inmemory.rs
+++ b/pageserver/src/repository/inmemory.rs
@@ -139,7 +139,13 @@ impl Timeline for InMemoryTimeline {
     }
 
     fn put_wal_record(&self, tag: BufferTag, rec: WALRecord) {
-        debug!("put_wal_record: {:?} at {:?}", tag, rec);
+        if tag.rel.forknum == postgres_ffi::pg_constants::PG_XACT_FORKNUM as u8 {
+            // TODO
+            debug!("got WAL record for CLOG, ignoring");
+            return;
+        }
+
+        debug!("put_wal_record: {:?} at {}", tag, rec.lsn);
         self.get_relfile(tag.rel).put_wal_record(tag.blknum, rec);
     }
 

--- a/pageserver/src/repository/inmemory/relfile.rs
+++ b/pageserver/src/repository/inmemory/relfile.rs
@@ -251,7 +251,7 @@ impl RelFileEntry {
                 dirty: true,
                 page_image: None,
                 record: Some(rec),
-            }
+            },
         );
     }
 
@@ -264,7 +264,7 @@ impl RelFileEntry {
                 dirty: true,
                 page_image: Some(img),
                 record: None,
-            }
+            },
         );
     }
 
@@ -277,8 +277,10 @@ impl RelFileEntry {
 
             if old.is_some() {
                 // We already had an entry for this LSN. That's odd..
-                warn!("Page version of rel {:?} blk {} at {} already exists",
-                      self.tag, blknum, lsn);
+                warn!(
+                    "Page version of rel {:?} blk {} at {} already exists",
+                    self.tag, blknum, lsn
+                );
             }
 
             // release lock on 'page_versions'
@@ -420,12 +422,7 @@ fn get_pg_relation_path(tag: RelTag) -> String {
     } else if tag.spcnode == pg_constants::DEFAULTTABLESPACE_OID {
         /* The default tablespace is {datadir}/base */
         if let Some(forkname) = forknumber_to_name(tag.forknum) {
-            format!(
-                "base/{}/{}_{}",
-                tag.dbnode,
-                tag.relnode,
-                forkname
-            )
+            format!("base/{}/{}_{}", tag.dbnode, tag.relnode, forkname)
         } else {
             format!("base/{}/{}", tag.dbnode, tag.relnode)
         }
@@ -440,10 +437,7 @@ fn get_pg_relation_path(tag: RelTag) -> String {
         if let Some(forkname) = forknumber_to_name(tag.forknum) {
             format!(
                 "pg_tblspc/{}/{}/{}_{}",
-                tag.spcnode,
-                tag.dbnode,
-                tag.relnode,
-                forkname,
+                tag.spcnode, tag.dbnode, tag.relnode, forkname,
             )
         } else {
             format!("pg_tblspc/{}/{}/{}", tag.spcnode, tag.dbnode, tag.relnode)

--- a/pageserver/src/repository/inmemory/relfile.rs
+++ b/pageserver/src/repository/inmemory/relfile.rs
@@ -1,0 +1,392 @@
+//!
+//! `relfile` manages storage, caching, and page versioning on a single relation file.
+//!
+//! Currently, the "file format" consists of two parts: base snapshots, and the WAL.
+//! A base snapshot consists of a copy of the PostgreSQL data directory, in the normal
+//! PostgreSQL file format. A base snapshot is taken at one particular instant, at
+//! a specific LSN. Each snapshot is stored in a directory, named like this:
+//!
+//!    .zenith/timelines/<timelineid>/snapshots/<LSN>/
+//!
+//! The second component is the WAL, stored in the regular PostgreSQL format, in 16 MB
+//! (by default) files. It is stored in:
+//!
+//!    .zenith/timelines/<timelineid>/wal/
+//!
+//! At Page Server startup, we load all the WAL into memory, see
+//! 'InMemoryRepository::get_or_restore_timeline`. The files from the snapshot are
+//! loaded into memory the first time a page from a relfile is requested (a "request"
+//! also includes digesting any WAL records that apply to the file)
+
+use crate::repository::{BufferTag, RelTag, WALRecord};
+use crate::walredo::WalRedoManager;
+use crate::ZTimelineId;
+use anyhow::{bail, Result};
+use bytes::Bytes;
+use log::*;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::Read;
+use std::ops::Bound::Included;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use postgres_ffi::pg_constants;
+use postgres_ffi::relfile_utils::forknumber_to_name;
+use zenith_utils::lsn::Lsn;
+
+static ZERO_PAGE: Bytes = Bytes::from_static(&[0u8; 8192]);
+
+///
+/// RelFileEntry is the in-memory data structure associated with a relation file.
+///
+pub struct RelFileEntry {
+    timelineid: ZTimelineId,
+    tag: RelTag,
+
+    ///
+    /// All versions of all pages in the file are are kept here.
+    ///
+    page_versions: Mutex<BTreeMap<(u32, Lsn), PageVersion>>,
+
+    ///
+    /// `relsizes` tracks the size of the relation at different points in time.
+    ///
+    relsizes: Mutex<BTreeMap<Lsn, u32>>,
+}
+
+///
+/// Represents a version of a page at a specific LSN. The LSN is the key of the
+/// entry in the 'page_versions' hash, it is not duplicted here.
+///
+/// A page version can be stored as a full page image, or as WAL record that needs
+/// to be applied over the previous page version to reconstruct this version.
+///
+struct PageVersion {
+    // if true, this page version has not been stored on disk yet
+    // TODO: writeback not implemented yet.
+    #[allow(dead_code)]
+    dirty: bool,
+
+    /// an 8kb page image
+    page_image: Option<Bytes>,
+    /// WAL record to get from previous page version to this one.
+    record: Option<WALRecord>,
+}
+
+impl RelFileEntry {
+    pub fn new(timelineid: ZTimelineId, tag: RelTag) -> RelFileEntry {
+        let relfile = RelFileEntry {
+            timelineid,
+            tag,
+            page_versions: Mutex::new(BTreeMap::new()),
+            relsizes: Mutex::new(BTreeMap::new()),
+        };
+
+        // Try to restore the file from latest snapshot.
+        //
+        // We don't propagate the error to the caller. In a better implementation, we
+        // wouldn't try to immediately load a snapshot anyway, we would load
+        // pages on demand. If restoring a page fails, that should result in an error
+        // in get_page_at_lsn(), not here.
+        //
+        // FIXME: skip this for the special relfile that actually means the CLOG.
+        if tag.forknum != pg_constants::PG_XACT_FORKNUM as u8 {
+            match crate::restore_local_repo::find_latest_snapshot(timelineid) {
+                Ok(snapshotlsn) => {
+                    let res = relfile.restore_relfile(snapshotlsn);
+                    if res.is_err() {
+                        error!("could not restore {:?} on timeline {} from snapshot {}", tag, timelineid, snapshotlsn);
+                    }
+                }
+                Err(e) => {
+                    error!("could not find snapshot for timeline {}: {}", timelineid, e);
+                }
+            }
+        }
+
+        relfile
+    }
+
+    /// Look up given page in the cache.
+    pub fn get_page_at_lsn(
+        &self,
+        walredo_mgr: &WalRedoManager,
+        blknum: u32,
+        lsn: Lsn
+    ) -> Result<Bytes> {
+        // Scan the BTreeMap backwards, starting from the given entry.
+        let mut records: Vec<WALRecord> = Vec::new();
+        let mut page_img: Option<Bytes> = None;
+        {
+            let page_versions = self.page_versions.lock().unwrap();
+            let minkey = (blknum, Lsn(0));
+            let maxkey = (blknum, lsn);
+            let mut iter = page_versions.range((Included(&minkey), Included(&maxkey)));
+
+            while let Some(((_blknum, _entry_lsn), entry)) = iter.next_back() {
+                if let Some(img) = &entry.page_image {
+                    page_img = Some(img.clone());
+                    break;
+                } else if let Some(rec) = &entry.record {
+                    records.push(rec.clone());
+                    if rec.will_init {
+                        // This WAL record initializes the page, so no need to go further back
+                        break;
+                    }
+                } else {
+                    // No base image, and no WAL record. Huh?
+                    bail!("no page image or WAL record for requested page");
+                }
+            }
+
+            // release lock on 'page_versions'
+        }
+        records.reverse();
+
+        // If we have a page image, and no WAL, we're all set
+        if records.is_empty() {
+            if let Some(img) = page_img {
+                Ok(img)
+            } else {
+                // FIXME: this ought to be an error?
+                warn!("Page {:?}/{} at {} not found", self.tag, blknum, lsn);
+                Ok(ZERO_PAGE.clone())
+            }
+        } else {
+            // We need to do WAL redo.
+            //
+            // If we don't have a base image, then the oldest WAL record better initialize
+            // the page
+            if page_img.is_none() && !records.first().unwrap().will_init {
+                // FIXME: this ought to be an error?
+                warn!(
+                    "Base image for page {:?}/{} at {} not found, but got {} WAL records",
+                    self.tag,
+                    blknum,
+                    lsn,
+                    records.len()
+                );
+                Ok(ZERO_PAGE.clone())
+            } else {
+                let img = walredo_mgr.request_redo(
+                    BufferTag {
+                        rel: self.tag,
+                        blknum,
+                    },
+                    lsn,
+                    page_img,
+                    records,
+                )?;
+
+                self.put_page_image(blknum, lsn, img.clone());
+
+                Ok(img)
+            }
+        }
+    }
+
+    /// Get size of the relation at given LSN
+    pub fn get_relsize(&self, lsn: Lsn) -> Result<u32> {
+        // Scan the BTreeMap backwards, starting from the given entry.
+        let relsizes = self.relsizes.lock().unwrap();
+        let mut iter = relsizes.range((Included(&Lsn(0)), Included(&lsn)));
+
+        if let Some((_entry_lsn, entry)) = iter.next_back() {
+            Ok(*entry)
+        } else {
+            bail!("No size found for relfile {:?} at {}", self.tag, lsn);
+        }
+    }
+
+    /// Does this relation exist at given LSN?
+    pub fn exists(&self, lsn: Lsn) -> Result<bool> {
+        // Scan the BTreeMap backwards, starting from the given entry.
+        let relsizes = self.relsizes.lock().unwrap();
+        let mut iter = relsizes.range((Included(&Lsn(0)), Included(&lsn)));
+
+        if let Some((_entry_lsn, _entry)) = iter.next_back() {
+            Ok(true)
+        } else {
+            bail!("No size found for relfile {:?} at {}", self.tag, lsn);
+        }
+    }
+
+    /// Remember new page version, as a WAL record over previous version
+    pub fn put_wal_record(&self, blknum: u32, rec: WALRecord) {
+        self.put_page_version(
+            blknum,
+            rec.lsn,
+            PageVersion {
+                dirty: true,
+                page_image: None,
+                record: Some(rec),
+            }
+        );
+    }
+
+    /// Remember new page version, as a full page image
+    pub fn put_page_image(&self, blknum: u32, lsn: Lsn, img: Bytes) {
+        self.put_page_version(
+            blknum,
+            lsn,
+            PageVersion {
+                dirty: true,
+                page_image: Some(img),
+                record: None,
+            }
+        );
+    }
+
+    /// Common subroutine of the public put_wal_record() and put_page_image() functions.
+    /// Adds the page version to the in-memory tree
+    fn put_page_version(&self, blknum: u32, lsn: Lsn, pv: PageVersion) {
+        {
+            let mut page_versions = self.page_versions.lock().unwrap();
+            let old = page_versions.insert((blknum, lsn), pv);
+
+            if old.is_some() {
+                // We already had an entry for this LSN. That's odd..
+                warn!("Page version of rel {:?} blk {} at {} already exists",
+                      self.tag, blknum, lsn);
+            }
+
+            // release lock on 'page_versions'
+        }
+
+        // Also update the relation size, if this extended the relation.
+        {
+            let mut relsizes = self.relsizes.lock().unwrap();
+            let mut iter = relsizes.range((Included(&Lsn(0)), Included(&lsn)));
+
+            let oldsize;
+            if let Some((_entry_lsn, entry)) = iter.next_back() {
+                oldsize = *entry;
+                if blknum >= oldsize {
+                    debug!("enlarging relation {:?} from {} to {} blocks", self.tag, oldsize, blknum + 1);
+                    relsizes.insert(lsn, blknum + 1);
+                }
+            } else {
+                debug!("creating relation {:?} with {} blocks", self.tag, blknum + 1);
+                relsizes.insert(lsn, blknum + 1);
+            }
+        }
+    }
+
+    /// Remember that the relation was truncated at given LSN
+    pub fn put_truncation(&self, lsn: Lsn, relsize: u32) -> anyhow::Result<()> {
+        let mut relsizes = self.relsizes.lock().unwrap();
+        let old = relsizes.insert(lsn, relsize);
+
+        if old.is_some() {
+            // We already had an entry for this LSN. That's odd..
+            warn!("Inserting truncation, but had an entry for the LSN already");
+        }
+
+        Ok(())
+    }
+
+
+    ///
+    /// Scan one file from a snapshot, loading all pages into memory.
+    ///
+    /// The relfile is just a flat file in the same format used by PostgreSQL. There
+    /// is no version information in it.
+    ///
+    fn restore_relfile(&self, snapshotlsn: Lsn) -> Result<()> {
+        debug!("restoring relfile {:?} from snapshot at {}", self.tag, snapshotlsn);
+
+        //
+        // timelines/<timelineid>/snapshots/<snapshot LSN>/base/<dbid>/<relid>
+        let path = PathBuf::from("timelines")
+            .join(self.timelineid.to_string())
+            .join("snapshots")
+            .join(format!("{:016X}", snapshotlsn.0))
+            .join(get_pg_relation_path(self.tag));
+
+        // FIXME: segments are not handled correctly. Assume there's only one
+        let segno = 0;
+
+        let mut file = File::open(&path)?;
+        let mut buf: [u8; 8192] = [0u8; 8192];
+
+        // FIXME: use constants (BLCKSZ)
+        let mut blknum: u32 = segno * (1024 * 1024 * 1024 / 8192);
+        loop {
+            let r = file.read_exact(&mut buf);
+            match r {
+                Ok(_) => {
+                    self.put_page_image(blknum, snapshotlsn, Bytes::copy_from_slice(&buf));
+                    /*
+                    if oldest_lsn == 0 || p.lsn < oldest_lsn {
+                    oldest_lsn = p.lsn;
+                }
+                     */
+                }
+
+                // TODO: UnexpectedEof is expected
+                Err(e) => match e.kind() {
+                    std::io::ErrorKind::UnexpectedEof => {
+                        // reached EOF. That's expected.
+                        // FIXME: maybe check that we read the full length of the file?
+                        break;
+                    }
+                    _ => {
+                        error!("error reading file: {:?} ({})", path, e);
+                        break;
+                    }
+                },
+            };
+            blknum += 1;
+        }
+
+        Ok(())
+    }
+}
+
+/// See PostgreSQL's GetRelationPath()
+///
+/// FIXME: It's not clear where we should handle different 1GB segments.
+/// Broken, currently.
+fn get_pg_relation_path(tag: RelTag) -> String {
+    if tag.spcnode == pg_constants::GLOBALTABLESPACE_OID {
+        /* Shared system relations live in {datadir}/global */
+        assert!(tag.dbnode == 0);
+        if let Some(forkname) = forknumber_to_name(tag.forknum) {
+            format!("global/{}_{}", tag.relnode, forkname)
+        } else {
+            format!("global/{}", tag.relnode)
+        }
+    } else if tag.spcnode == pg_constants::DEFAULTTABLESPACE_OID {
+        /* The default tablespace is {datadir}/base */
+        if let Some(forkname) = forknumber_to_name(tag.forknum) {
+            format!(
+                "base/{}/{}_{}",
+                tag.dbnode,
+                tag.relnode,
+                forkname
+            )
+        } else {
+            format!("base/{}/{}", tag.dbnode, tag.relnode)
+        }
+    } else {
+        //
+        // In PostgreSQL, all other tablespaces are accessed via symlinks. We store them
+        // in the pg_tblspc directory, with no symlinks.
+        //
+        // PostgreSQL uses a version-specific subdir in the path
+        // (TABLESPACE_VERSION_DIRECTORY), but we leave that out.
+        //
+        if let Some(forkname) = forknumber_to_name(tag.forknum) {
+            format!(
+                "pg_tblspc/{}/{}/{}_{}",
+                tag.spcnode,
+                tag.dbnode,
+                tag.relnode,
+                forkname,
+            )
+        } else {
+            format!("pg_tblspc/{}/{}/{}", tag.spcnode, tag.dbnode, tag.relnode)
+        }
+    }
+}

--- a/pageserver/src/repository/inmemory/relfile.rs
+++ b/pageserver/src/repository/inmemory/relfile.rs
@@ -89,6 +89,22 @@ impl RelFileEntry {
         }
     }
 
+    /// Copy a relation from another at given LSN. The new relation will appear with the same LSN.
+    /// This is a subroutine of handling CREATE DATABASE, which makes a copy of the template database.
+    pub fn copy_from(
+        &self,
+        walredo_mgr: &WalRedoManager,
+        src: &RelFileEntry,
+        lsn: Lsn,
+    ) -> Result<()> {
+        let src_size = src.get_relsize(lsn)?;
+        for blknum in 0..src_size {
+            let img = src.get_page_at_lsn(walredo_mgr, blknum, lsn)?;
+            self.put_page_image(blknum, lsn, img);
+        }
+        Ok(())
+    }
+
     /// Look up given page in the cache.
     pub fn get_page_at_lsn(
         &self,

--- a/pageserver/src/repository/rocksdb.rs
+++ b/pageserver/src/repository/rocksdb.rs
@@ -180,7 +180,7 @@ impl Repository for RocksRepository {
             None => {
                 let timeline = RocksTimeline::new(&self.conf, timelineid);
 
-                restore_timeline(&self.conf, &timeline, timelineid)?;
+                restore_timeline(&self.conf, &timeline, timelineid, true)?;
 
                 let timeline_rc = Arc::new(timeline);
 

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -88,9 +88,10 @@ pub fn restore_timeline(
 }
 
 ///
-/// Find latest snapshot in a timeline's 'snapshots' directory
+/// Scan the 'snapshots' directory of the given timeline, and return the
+/// LSN of the latest snapshot that's earlier or equal to 'maxlsn'
 ///
-pub fn find_latest_snapshot(timeline: ZTimelineId) -> Result<Lsn> {
+pub fn find_latest_snapshot(timeline: ZTimelineId, maxlsn: Lsn) -> Result<Lsn> {
     let snapshotspath = format!("timelines/{}/snapshots", timeline);
 
     let mut last_snapshot_lsn = Lsn(0);
@@ -98,7 +99,9 @@ pub fn find_latest_snapshot(timeline: ZTimelineId) -> Result<Lsn> {
         let filename = direntry.unwrap().file_name();
 
         if let Ok(lsn) = Lsn::from_filename(&filename) {
-            last_snapshot_lsn = max(lsn, last_snapshot_lsn);
+            if lsn <= maxlsn || maxlsn == Lsn(0) {
+                last_snapshot_lsn = max(lsn, last_snapshot_lsn);
+            }
         } else {
             error!("unrecognized file in snapshots directory: {:?}", filename);
         }

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -7,7 +7,7 @@
 //!
 
 use crate::page_cache;
-use crate::repository::{Repository, Timeline};
+use crate::repository::{Repository};
 use crate::waldecoder::*;
 use crate::PageServerConf;
 use crate::ZTimelineId;


### PR DESCRIPTION
This refactors `page_cache.rs`, renaming/splitting the `PageCache` struct into `Repository` and `Timeline`. Repository and Timeline are now abstract traits, so we could potentially have multiple implementations of them, for different "backing stores". Right now, we have just the RocksDB implementation, but the second commit in this PR reintroduces the "in-memory" implementation, which is backed by the snapshot and the WAL stored in the repository directory (ie. `.zenith/timelines/<timeline>/snapshots/<snapshot LSN>` and `.zenith/timelines/<timeline>/wal`). I don't think we'll actually want to have more than one implementation in the long run, but it could be handy in the short term, and more importantly, I think having the abstract traits works as a nice overview and documentation of the interface to the rest of the system. 

The most interesting part of the 'in-memory' implementation is in `pageserver/src/repository/inmemory/relfile.rs`. It provides the functions to deal with one "relation file", i.e. one table or index. The next step is to make the code in `relfile.rs` smarter, implementing writeback of dirty pages (in some LSM-tree-like non-overwriting fashion), garbage collection, following a timeline backwards to its ancestor without having to copy everything at `zenith branch` and so on. I believe those change can be implemented with little changes to the rest of the system, within `relfile.rs`.

This is still Work-In-Progress, and the tests are failing, but I'd like to get feedback on the general idea.

Also, I actually failed to make the Repository/Timeline fully abstract traits, there are direct references to RocksRepository in the Repository struct that's supposed to be abstract (replaced with InMemoryRepository in the second commit). It's not critical, as I said I don't think we actually want to have multiple implementations so we can live with it, the point of the Repository/Timeline traits is more about documentation. But if there's some easy Rust tick I'm missing, I'm all ears.
