### PR TITLE
circleci: shrink python tracebacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
             if [ -n "$TEST_FILTER" ]; then
               TEST_FILTER="-k $TEST_FILTER"
             fi
-            pytest $TEST_FILE $TEST_FILTER $EXTRA_PARAMS
+            pytest --tb=short $TEST_FILE $TEST_FILTER $EXTRA_PARAMS
       - run:
           # CircleCI artifacts are preserved one file at a time, so skipping
           # this step isn't a good idea. If you want to extract the


### PR DESCRIPTION
Mostly we're not testing python code, so verbose python tracebacks are unhelpful. Add `--tb=short` to the pytest args to cut down on the noise.

To override this during testing, set the `extra_params` parameter on the circleci job to `--tb=auto` or `--tb=long`.

This is a trivial change, and I intend to just merge it immediately; I'm using this PR to also test whether CircleCI is testing PRs from forks.