### PR TITLE
Don't restart WAL streaming in the middle of a record.

### DIFF
--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -47,10 +47,12 @@ pub trait Timeline {
         src_tablespace_id: Oid,
     ) -> Result<()>;
 
-    fn advance_last_record_lsn(&self, lsn: Lsn);
     fn advance_last_valid_lsn(&self, lsn: Lsn);
-    fn init_valid_lsn(&self, lsn: Lsn);
     fn get_last_valid_lsn(&self) -> Lsn;
+    fn init_valid_lsn(&self, lsn: Lsn);
+
+    fn advance_last_record_lsn(&self, lsn: Lsn);
+    fn get_last_record_lsn(&self) -> Lsn;
 }
 
 #[derive(Clone)]

--- a/pageserver/src/repository/rocksdb.rs
+++ b/pageserver/src/repository/rocksdb.rs
@@ -828,6 +828,10 @@ impl Timeline for RocksTimeline {
         }
     }
 
+    fn get_last_record_lsn(&self) -> Lsn {
+        self.last_record_lsn.load()
+    }
+
     fn init_valid_lsn(&self, lsn: Lsn) {
         let old = self.last_valid_lsn.advance(lsn);
         assert!(old == Lsn(0));


### PR DESCRIPTION
I think this was changed inadvertently by commit 2c308da4d2. Change it
back.

Fixes https://github.com/zenithdb/zenith/issues/98