### PR TITLE
Refactoring wal_service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,6 +165,11 @@ jobs:
             du -sh /tmp/test_output/*
             for DIR in /tmp/test_output/*; do
               mv $DIR/repo/pageserver.log $DIR/ || true # ignore errors
+              for PGDIR in $DIR/repo/pgdatadirs/pg?; do
+                echo "PGDIR: $PGDIR"
+                NEW_LOG="${PGDIR##*/}_log"
+                mv $PGDIR/log "$DIR/$NEW_LOG" || true # ignore errors
+              done
               echo "rm $DIR/repo"
               rm -rf $DIR/repo
             done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +659,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hmac"
@@ -2438,5 +2453,9 @@ dependencies = [
 name = "zenith_utils"
 version = "0.1.0"
 dependencies = [
+ "bincode",
+ "bytes",
+ "hex-literal",
+ "serde",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "regex",
  "rocksdb",
  "rust-s3",
+ "serde",
  "slog",
  "slog-async",
  "slog-scope",
@@ -2246,6 +2247,7 @@ dependencies = [
  "postgres_ffi",
  "regex",
  "rust-s3",
+ "serde",
  "slog",
  "slog-async",
  "slog-scope",
@@ -2255,6 +2257,7 @@ dependencies = [
  "tokio-stream",
  "walkdir",
  "workspace_hack",
+ "zenith_utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,12 +1292,13 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 [[package]]
 name = "postgres"
 version = "0.19.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
 dependencies = [
  "bytes",
  "fallible-iterator",
  "futures",
  "log",
+ "postgres-protocol",
  "tokio",
  "tokio-postgres",
 ]
@@ -1305,13 +1306,14 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
+ "lazy_static",
  "md-5",
  "memchr",
  "rand",
@@ -1322,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2031,7 +2033,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.1"
-source = "git+https://github.com/zenithdb/rust-postgres.git?rev=a0d067b66447951d1276a53fb09886539c3fa094#a0d067b66447951d1276a53fb09886539c3fa094"
+source = "git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858#9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,6 @@ dependencies = [
  "serde",
  "tar",
  "thiserror",
- "tokio-postgres",
  "toml",
  "walkeeper",
  "workspace_hack",
@@ -778,7 +777,6 @@ dependencies = [
  "pageserver",
  "postgres",
  "rand",
- "tokio-postgres",
  "walkeeper",
 ]
 
@@ -1177,7 +1175,6 @@ dependencies = [
  "termion",
  "thiserror",
  "tokio",
- "tokio-postgres",
  "tokio-stream",
  "tui",
  "walkdir",
@@ -2240,7 +2237,6 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "tokio",
- "tokio-postgres",
  "tokio-stream",
  "walkdir",
  "workspace_hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ dependencies = [
  "crc32c",
  "daemonize",
  "fs2",
+ "hex",
  "lazy_static",
  "log",
  "pageserver",

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 rand = "0.8.3"
 tar = "0.4.33"
 postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 lazy_static = "1.4"

--- a/control_plane/Cargo.toml
+++ b/control_plane/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 rand = "0.8.3"
 tar = "0.4.33"
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 lazy_static = "1.4"

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -419,7 +419,7 @@ impl PostgresNode {
         }
     }
 
-    pub fn safe_psql(&self, db: &str, sql: &str) -> Vec<tokio_postgres::Row> {
+    pub fn safe_psql(&self, db: &str, sql: &str) -> Vec<postgres::Row> {
         let connstring = format!(
             "host={} port={} dbname={} user={}",
             self.address.ip(),

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 lazy_static = "1.4.0"
 rand = "0.8.3"
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 
 pageserver = { path = "../pageserver" }
 walkeeper = { path = "../walkeeper" }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -10,8 +10,6 @@ edition = "2018"
 lazy_static = "1.4.0"
 rand = "0.8.3"
 postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
-
 pageserver = { path = "../pageserver" }
 walkeeper = { path = "../walkeeper" }
 control_plane = { path = "../control_plane" }

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -27,10 +27,10 @@ daemonize = "0.4.1"
 rust-s3 = { version = "0.27.0-rc4", features = ["no-verify-ssl"] }
 tokio = { version = "1.3.0", features = ["full"] }
 tokio-stream = { version = "0.1.4" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 rocksdb = "0.16.0"
 anyhow = "1.0"
 crc32c = "0.6.0"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -27,7 +27,6 @@ daemonize = "0.4.1"
 rust-s3 = { version = "0.27.0-rc4", features = ["no-verify-ssl"] }
 tokio = { version = "1.3.0", features = ["full"] }
 tokio-stream = { version = "0.1.4" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 postgres-types = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -38,6 +38,8 @@ thiserror = "1.0"
 hex = "0.4.3"
 tar = "0.4.33"
 parse_duration = "2.1.1"
+serde = { version = "1.0", features = ["derive"] }
+
 
 postgres_ffi = { path = "../postgres_ffi" }
 zenith_utils = { path = "../zenith_utils" }

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -49,7 +50,7 @@ pub struct PageServerConf {
 /// is separate from PostgreSQL timelines, and doesn't have those
 /// limitations. A zenith timeline is identified by a 128-bit ID, which
 /// is usually printed out as a hex string.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ZTimelineId([u8; 16]);
 
 impl FromStr for ZTimelineId {

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -26,9 +26,9 @@ use std::str::FromStr;
 use std::sync::Mutex;
 use std::thread;
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use tokio::runtime::Runtime;
-use tokio_postgres::replication::{PgTimestamp, ReplicationStream};
+use tokio_postgres::replication::ReplicationStream;
 use tokio_postgres::{NoTls, SimpleQueryMessage, SimpleQueryRow};
 use tokio_stream::StreamExt;
 use zenith_utils::lsn::Lsn;
@@ -244,7 +244,7 @@ fn walreceiver_main(
                 let reply_requested: bool = keepalive.reply() != 0;
 
                 trace!(
-                    "received PrimaryKeepAlive(wal_end: {}, timestamp: {} reply: {})",
+                    "received PrimaryKeepAlive(wal_end: {}, timestamp: {:?} reply: {})",
                     wal_end,
                     timestamp,
                     reply_requested,
@@ -254,8 +254,8 @@ fn walreceiver_main(
                     let last_lsn = PgLsn::from(u64::from(timeline.get_last_valid_lsn()));
                     let write_lsn = last_lsn;
                     let flush_lsn = last_lsn;
-                    let apply_lsn = PgLsn::INVALID;
-                    let ts = PgTimestamp::now()?;
+                    let apply_lsn = PgLsn::from(0);
+                    let ts = SystemTime::now();
                     const NO_REPLY: u8 = 0u8;
 
                     runtime.block_on(

--- a/postgres_ffi/src/xlog_utils.rs
+++ b/postgres_ffi/src/xlog_utils.rs
@@ -33,18 +33,8 @@ pub type TimestampTz = u64;
 pub type XLogSegNo = u64;
 
 #[allow(non_snake_case)]
-pub fn XLogSegmentOffset(xlogptr: XLogRecPtr, wal_segsz_bytes: usize) -> u32 {
-    (xlogptr as u32) & (wal_segsz_bytes as u32 - 1)
-}
-
-#[allow(non_snake_case)]
 pub fn XLogSegmentsPerXLogId(wal_segsz_bytes: usize) -> XLogSegNo {
     (0x100000000u64 / wal_segsz_bytes as u64) as XLogSegNo
-}
-
-#[allow(non_snake_case)]
-pub fn XLByteToSeg(xlogptr: XLogRecPtr, wal_segsz_bytes: usize) -> XLogSegNo {
-    xlogptr / wal_segsz_bytes as u64
 }
 
 #[allow(non_snake_case)]

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -30,6 +30,7 @@ crc32c = "0.6.0"
 parse_duration = "2.1.1"
 walkdir = "2"
 serde = { version = "1.0", features = ["derive"] }
+hex = "0.4.3"
 
 # FIXME: 'pageserver' is needed for ZTimelineId. Refactor
 pageserver = { path = "../pageserver" }

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -23,9 +23,9 @@ daemonize = "0.4.1"
 rust-s3 = { version = "0.27.0-rc4", features = ["no-verify-ssl"] }
 tokio = { version = "1.3.0", features = ["full"] }
 tokio-stream = { version = "0.1.4" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="a0d067b66447951d1276a53fb09886539c3fa094" }
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 anyhow = "1.0"
 crc32c = "0.6.0"
 parse_duration = "2.1.1"

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -29,8 +29,10 @@ anyhow = "1.0"
 crc32c = "0.6.0"
 parse_duration = "2.1.1"
 walkdir = "2"
+serde = { version = "1.0", features = ["derive"] }
 
 # FIXME: 'pageserver' is needed for ZTimelineId. Refactor
 pageserver = { path = "../pageserver" }
 postgres_ffi = { path = "../postgres_ffi" }
 workspace_hack = { path = "../workspace_hack" }
+zenith_utils = { path = "../zenith_utils" }

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -23,7 +23,6 @@ daemonize = "0.4.1"
 rust-s3 = { version = "0.27.0-rc4", features = ["no-verify-ssl"] }
 tokio = { version = "1.3.0", features = ["full"] }
 tokio-stream = { version = "0.1.4" }
-tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 postgres-protocol = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 anyhow = "1.0"

--- a/walkeeper/src/pq_protocol.rs
+++ b/walkeeper/src/pq_protocol.rs
@@ -7,7 +7,6 @@ use std::str::FromStr;
 
 pub type Oid = u32;
 pub type SystemId = u64;
-pub type Result<T> = std::result::Result<T, io::Error>;
 
 #[derive(Debug)]
 pub enum FeMessage {
@@ -52,7 +51,7 @@ pub enum StartupRequestCode {
 }
 
 impl FeStartupMessage {
-    pub fn parse(buf: &mut BytesMut) -> Result<Option<FeMessage>> {
+    pub fn parse(buf: &mut BytesMut) -> io::Result<Option<FeMessage>> {
         const MAX_STARTUP_PACKET_LENGTH: usize = 10000;
         const CANCEL_REQUEST_CODE: u32 = (1234 << 16) | 5678;
         const NEGOTIATE_SSL_CODE: u32 = (1234 << 16) | 5679;
@@ -202,7 +201,7 @@ impl<'a> BeMessage<'a> {
 }
 
 impl FeMessage {
-    pub fn parse(buf: &mut BytesMut) -> Result<Option<FeMessage>> {
+    pub fn parse(buf: &mut BytesMut) -> io::Result<Option<FeMessage>> {
         if buf.len() < 5 {
             let to_read = 5 - buf.len();
             buf.reserve(to_read);

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -1,7 +1,7 @@
-///
-///   WAL service listens for client connections and
-///   receive WAL from wal_proposer and send it to WAL receivers
-///
+//!
+//!   WAL service listens for client connections and
+//!   receive WAL from wal_proposer and send it to WAL receivers
+//!
 use anyhow::{anyhow, bail, Result};
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -666,9 +666,9 @@ impl Connection {
         Ok(())
     }
 
-    //
-    // Read full message or return None if connection is closed
-    //
+    ///
+    /// Read full message or return None if connection is closed
+    ///
     fn read_message(&mut self) -> Result<Option<FeMessage>> {
         loop {
             if let Some(message) = self.parse_message()? {
@@ -685,9 +685,9 @@ impl Connection {
         }
     }
 
-    //
-    // Parse libpq message
-    //
+    ///
+    /// Parse libpq message
+    ///
     fn parse_message(&mut self) -> Result<Option<FeMessage>> {
         let msg = if !self.init_done {
             FeStartupMessage::parse(&mut self.inbuf)?
@@ -697,23 +697,23 @@ impl Connection {
         Ok(msg)
     }
 
-    //
-    // Reset output buffer to start accumulating data of new message
-    //
+    ///
+    /// Reset output buffer to start accumulating data of new message
+    ///
     fn start_sending(&mut self) {
         self.outbuf.clear();
     }
 
-    //
-    // Send buffered messages
-    //
+    ///
+    /// Send buffered messages
+    ///
     fn send(&mut self) -> Result<()> {
         Ok(self.stream.write_all(&self.outbuf)?)
     }
 
-    //
-    // Send WAL to replica or WAL receiver using standard libpq replication protocol
-    //
+    ///
+    /// Send WAL to replica or WAL receiver using standard libpq replication protocol
+    ///
     fn send_wal(&mut self) -> Result<()> {
         info!("WAL sender to {:?} is started", self.stream.peer_addr()?);
         loop {
@@ -760,9 +760,9 @@ impl Connection {
         Ok(())
     }
 
-    //
-    // Handle IDENTIFY_SYSTEM replication command
-    //
+    ///
+    /// Handle IDENTIFY_SYSTEM replication command
+    ///
     fn handle_identify_system(&mut self) -> Result<bool> {
         let (start_pos, timeline) = self.find_end_of_wal(false);
         let lsn = start_pos.to_string();
@@ -810,9 +810,9 @@ impl Connection {
         Ok(true)
     }
 
-    //
-    // Handle START_REPLICATION replication command
-    //
+    ///
+    /// Handle START_REPLICATION replication command
+    ///
     fn handle_start_replication(&mut self, cmd: &Bytes) -> Result<bool> {
         // helper function to encapsulate the regex -> Lsn magic
         fn get_start_stop(cmd: &[u8]) -> Result<(Lsn, Lsn)> {

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -75,14 +75,12 @@ fn read_into(r: &mut impl Read, buf: &mut BytesMut) -> io::Result<usize> {
 }
 
 /// Unique node identifier used by Paxos
-#[repr(C)]
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
 struct NodeId {
     uuid: u128,
     term: [u8; 8],
 }
 
-#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 struct ServerInfo {
     /// proxy-safekeeper protocol version
@@ -99,7 +97,6 @@ struct ServerInfo {
 }
 
 /// Vote request sent from proxy to safekeepers
-#[repr(C)]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct RequestVote {
     node_id: NodeId,
@@ -110,7 +107,6 @@ struct RequestVote {
 }
 
 /// Information of about storage node
-#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 struct SafeKeeperInfo {
     /// magic for verifying content the control file
@@ -130,7 +126,6 @@ struct SafeKeeperInfo {
 }
 
 /// Hot standby feedback received from replica
-#[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 struct HotStandbyFeedback {
     ts: TimestampTz,
@@ -139,7 +134,6 @@ struct HotStandbyFeedback {
 }
 
 /// Request with WAL message sent from proxy to safekeeper.
-#[repr(C)]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct SafeKeeperRequest {
     /// Sender's node identifier (looks like we do not need it for TCP streaming connection)
@@ -155,7 +149,6 @@ struct SafeKeeperRequest {
 }
 
 /// Report safekeeper state to proxy
-#[repr(C)]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct SafeKeeperResponse {
     epoch: u64,

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -80,8 +80,8 @@ fn read_into(r: &mut impl Read, buf: &mut BytesMut) -> io::Result<usize> {
 /// Unique node identifier used by Paxos
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, PartialEq, Eq, Serialize, Deserialize)]
 struct NodeId {
-    uuid: u128,
-    term: [u8; 8],
+    term: u64,
+    uuid: [u8; 16],
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -227,8 +227,8 @@ impl SafeKeeperInfo {
                 protocol_version: SK_PROTOCOL_VERSION, /* proxy-safekeeper protocol version */
                 pg_version: UNKNOWN_SERVER_VERSION,    /* Postgres server version */
                 node_id: NodeId {
-                    term: [0; 8],
-                    uuid: 0,
+                    term: 0,
+                    uuid: [0; 16],
                 },
                 system_id: 0, /* Postgres system identifier */
                 timeline_id: ZTimelineId::from([0u8; 16]),
@@ -555,8 +555,8 @@ impl Connection {
             self.send()?;
             bail!(
                 "Reject connection attempt with term {} because my term is {}",
-                hex::encode(prop.node_id.term),
-                hex::encode(my_info.server.node_id.term)
+                prop.node_id.term,
+                my_info.server.node_id.term,
             );
         }
         my_info.server.node_id = prop.node_id;

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -5,4 +5,11 @@ authors = ["Eric Seppanen <eric@zenith.tech>"]
 edition = "2018"
 
 [dependencies]
-thiserror = "1"
+serde = "1.0"
+bincode = "1.3"
+thiserror = "1.0"
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+hex-literal = "0.3"
+bytes = "1.0"

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -5,11 +5,10 @@ authors = ["Eric Seppanen <eric@zenith.tech>"]
 edition = "2018"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 thiserror = "1.0"
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
 hex-literal = "0.3"
 bytes = "1.0"

--- a/zenith_utils/src/bin_ser.rs
+++ b/zenith_utils/src/bin_ser.rs
@@ -1,0 +1,211 @@
+//! Utilities for binary serialization/deserialization.
+//!
+//! The [`BeSer`] trait allows us to define data structures
+//! that can match data structures that are sent over the wire
+//! in big-endian form with no packing.
+//!
+//! The [`LeSer`] trait does the same thing, in little-endian form.
+//!
+//! Note: you will get a compile error if you try to `use` both trais
+//! in the same module or scope. This is intended to be a safety
+//! mechanism: mixing big-endian and little-endian encoding in the same file
+//! is error-prone.
+
+#![warn(missing_docs)]
+
+use bincode::Options;
+use serde::{de::DeserializeOwned, Serialize};
+use std::io::{Read, Write};
+use thiserror::Error;
+
+/// An error that occurred during a deserialize operation
+///
+/// This could happen because the input data was too short,
+/// or because an invalid value was encountered.
+#[derive(Debug, Error)]
+#[error("deserialize error")]
+pub struct DeserializeError;
+
+/// An error that occurred during a serialize operation
+///
+/// This probably means our [`Write`] failed, e.g. we tried
+/// to write beyond the end of a buffer.
+#[derive(Debug, Error)]
+#[error("serialize error")]
+pub struct SerializeError;
+
+/// A shortcut that configures big-endian binary serialization
+///
+/// Properties:
+/// - Big endian
+/// - Fixed integer encoding (i.e. 1u32 is 00000001 not 01)
+/// - Allow trailing bytes: this means we don't throw an error
+///   if the deserializer is passed a buffer with more data
+///   past the end.
+pub fn be_coder() -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+}
+
+/// A shortcut that configures little-ending binary serialization
+///
+/// Properties:
+/// - Little endian
+/// - Fixed integer encoding (i.e. 1u32 is 00000001 not 01)
+/// - Allow trailing bytes: this means we don't throw an error
+///   if the deserializer is passed a buffer with more data
+///   past the end.
+pub fn le_coder() -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_little_endian()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+}
+
+/// Binary serialize/deserialize helper functions (Big Endian)
+///
+pub trait BeSer: Serialize + DeserializeOwned {
+    /// Serialize into a byte slice
+    fn ser_into_slice<W: Write>(&self, b: &mut [u8]) -> Result<(), SerializeError> {
+        // This is slightly awkward; we need a mutable reference to a mutable reference.
+        let mut w = b;
+        self.ser_into(&mut w)
+    }
+
+    /// Serialize into a borrowed writer
+    ///
+    /// This is useful for most `Write` types except `&mut [u8]`, which
+    /// can more easily use [`ser_into_slice`](Self::ser_into_slice).
+    fn ser_into<W: Write>(&self, w: &mut W) -> Result<(), SerializeError> {
+        le_coder().serialize_into(w, &self).or(Err(SerializeError))
+    }
+
+    /// Serialize into a new heap-allocated buffer
+    fn ser(&self) -> Result<Vec<u8>, SerializeError> {
+        be_coder().serialize(&self).or(Err(SerializeError))
+    }
+
+    /// Deserialize from a byte slice
+    fn des(buf: &[u8]) -> Result<Self, DeserializeError> {
+        be_coder().deserialize(buf).or(Err(DeserializeError))
+    }
+
+    /// Deserialize from a reader
+    ///
+    /// tip: `&[u8]` implements `Read`
+    fn des_from<R: Read>(r: R) -> Result<Self, DeserializeError> {
+        le_coder().deserialize_from(r).or(Err(DeserializeError))
+    }
+}
+
+/// Binary serialize/deserialize helper functions (Big Endian)
+///
+pub trait LeSer: Serialize + DeserializeOwned {
+    /// Serialize into a byte slice
+    fn ser_into_slice<W: Write>(&self, b: &mut [u8]) -> Result<(), SerializeError> {
+        // This is slightly awkward; we need a mutable reference to a mutable reference.
+        let mut w = b;
+        self.ser_into(&mut w)
+    }
+
+    /// Serialize into a borrowed writer
+    ///
+    /// This is useful for most `Write` types except `&mut [u8]`, which
+    /// can more easily use [`ser_into_slice`](Self::ser_into_slice).
+    fn ser_into<W: Write>(&self, w: &mut W) -> Result<(), SerializeError> {
+        le_coder().serialize_into(w, &self).or(Err(SerializeError))
+    }
+
+    /// Serialize into a new heap-allocated buffer
+    fn ser(&self) -> Result<Vec<u8>, SerializeError> {
+        le_coder().serialize(&self).or(Err(SerializeError))
+    }
+
+    /// Deserialize from a byte slice
+    fn des(buf: &[u8]) -> Result<Self, DeserializeError> {
+        le_coder().deserialize(buf).or(Err(DeserializeError))
+    }
+
+    /// Deserialize from a reader
+    ///
+    /// tip: `&[u8]` implements `Read`
+    fn des_from<R: Read>(r: R) -> Result<Self, DeserializeError> {
+        le_coder().deserialize_from(r).or(Err(DeserializeError))
+    }
+}
+
+impl<T> BeSer for T where T: Serialize + DeserializeOwned {}
+
+impl<T> LeSer for T where T: Serialize + DeserializeOwned {}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    pub struct ShortStruct {
+        a: u8,
+        b: u32,
+    }
+
+    #[test]
+    fn be_short() {
+        use super::BeSer;
+
+        let x = ShortStruct { a: 7, b: 65536 };
+
+        let encoded = x.ser().unwrap();
+
+        assert_eq!(encoded, vec![7, 0, 1, 0, 0]);
+
+        let raw = [8u8, 7, 3, 0, 0];
+        let decoded = ShortStruct::des(&raw).unwrap();
+
+        assert_eq!(
+            decoded,
+            ShortStruct {
+                a: 8,
+                b: 0x07030000
+            }
+        );
+
+        // has trailing data
+        let raw = [8u8, 7, 3, 0, 0, 0xFF, 0xFF, 0xFF];
+        let _ = ShortStruct::des(&raw).unwrap();
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    pub struct BigMsg {
+        pub tag: u8,
+        pub blockpos: u64,
+        pub last_flush_position: u64,
+        pub apply: u64,
+        pub timestamp: u64,
+        pub reply_requested: u8,
+    }
+
+    #[test]
+    fn be_big() {
+        use super::BeSer;
+
+        let msg = BigMsg {
+            tag: 42,
+            blockpos: 0x1000_2000_3000_4000,
+            last_flush_position: 0x1234_2345_3456_4567,
+            apply: 0x9876_5432_10FE_DCBA,
+            timestamp: 0xABBA_CDDC_EFFE_0110,
+            reply_requested: 1,
+        };
+
+        let encoded = msg.ser().unwrap();
+        let expected = hex_literal::hex!(
+            "2A 1000 2000 3000 4000 1234 2345 3456 4567 9876 5432 10FE DCBA ABBA CDDC EFFE 0110 01"
+        );
+        assert_eq!(encoded, expected);
+
+        let msg2 = BigMsg::des(&encoded).unwrap();
+        assert_eq!(msg, msg2);
+    }
+}

--- a/zenith_utils/src/lib.rs
+++ b/zenith_utils/src/lib.rs
@@ -8,3 +8,5 @@ pub mod seqwait;
 
 // Async version of SeqWait. Currently unused.
 // pub mod seqwait_async;
+
+pub mod bin_ser;

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::{Add, AddAssign};
 use std::path::Path;
@@ -10,7 +11,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub const XLOG_BLCKSZ: u32 = 8192;
 
 /// A Postgres LSN (Log Sequence Number), also known as an XLogRecPtr
-#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Lsn(pub u64);
 
 /// We tried to parse an LSN from a string, but failed

--- a/zenith_utils/tests/bin_ser_test.rs
+++ b/zenith_utils/tests/bin_ser_test.rs
@@ -1,0 +1,42 @@
+use bytes::{Buf, BytesMut};
+use hex_literal::hex;
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+use zenith_utils::bin_ser::LeSer;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct HeaderData {
+    magic: u16,
+    info: u16,
+    tli: u32,
+    pageaddr: u64,
+    len: u32,
+}
+
+// A manual implementation using BytesMut, just so we can
+// verify that we decode the same way.
+pub fn decode_header_data(buf: &mut BytesMut) -> HeaderData {
+    HeaderData {
+        magic: buf.get_u16_le(),
+        info: buf.get_u16_le(),
+        tli: buf.get_u32_le(),
+        pageaddr: buf.get_u64_le(),
+        len: buf.get_u32_le(),
+    }
+}
+
+pub fn decode2<R: Read>(reader: &mut R) -> HeaderData {
+    HeaderData::des_from(reader).unwrap()
+}
+
+#[test]
+fn test1() {
+    let raw1 = hex!("8940 7890 5534 7890  1289 5379 8378 7893  4207 8923 4712 3218");
+    let mut buf1 = BytesMut::from(&raw1[..]);
+    let mut buf2 = &raw1[..];
+    let dec1 = decode_header_data(&mut buf1);
+    let dec2 = decode2(&mut buf2);
+    assert_eq!(dec1, dec2);
+    eprintln!("{} {}", buf1.len(), buf2.len());
+    assert_eq!(buf1, buf2);
+}


### PR DESCRIPTION
**Add some helper traits for binary serialization**

`BeSer` implements methods for big-endian encoding/decoding.
`LeSer` implements methods for little-endian encoding/decoding.

**Use `serde` for serialization in wal_service**

I verified that the encoding/decoding is identical to the previous manual implementation.

There is a mix of big-endian and little-endian in wal_service. I don't really understand why. It would be nice to pick one, if we can. `NodeId` is a strange corner case: one field is serialized little-endian and one field is serialized big-endian. Hopefully we can fix that in the future.

**Use anyhow for error handling**

We may eventually want precise error types for some of this, but `anyhow::Error` is a lot easier than trying to force `io::Error`.

**Drop `repr(C)` in wal_service structs**

The C memory representation is only needed if we want to guarantee the same memory layout as some other program. Since we're using `serde` to serialize these data structures, we can let the compiler do what it wants.

**Add serde support to Lsn type**

A serialized `Lsn` and a serialized `u64` should be identical.

**Switch to `Lsn` type**

Replace `XLogRecPtr` with `Lsn` in `wal_service.rs`

This removes the last use of `XLogSegmentOffset` and `XLByteToSeg`, so delete them. (replaced by `Lsn::segment_offset` and `Lsn::segment_number`.)