### PR TITLE
Move postgres code related to zenith pageserver to contrib/zenith.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,14 @@ postgres-headers: postgres-configure
 	+@echo "Installing PostgreSQL headers"
 	$(MAKE) -C tmp_install/build/src/include MAKELEVEL=0 install
 
-# Compile and install PostgreSQL
+
+# Compile and install PostgreSQL and contrib/zenith
 postgres: postgres-configure
 	+@echo "Compiling PostgreSQL"
 	$(MAKE) -C tmp_install/build MAKELEVEL=0 install
+	+@echo "Compiling contrib/zenith"
+	(cd vendor/postgres/contrib/zenith && \
+	$(MAKE) PG_CONFIG=$(abspath tmp_install)/bin/pg_config install USE_PGXS=1)
 
 postgres-clean:
 	$(MAKE) -C tmp_install/build MAKELEVEL=0 clean

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -105,7 +105,8 @@ impl ComputeControlPlane {
         node.append_conf(
             "postgresql.conf",
             format!(
-                "callmemaybe_connstring = '{}'\n", // FIXME escaping
+                "shared_preload_libraries = zenith\n\
+                zenith.callmemaybe_connstring = '{}'\n", // FIXME escaping
                 node.connstr()
             )
             .as_str(),
@@ -132,7 +133,8 @@ impl ComputeControlPlane {
         node.append_conf(
             "postgresql.conf",
             format!(
-                "callmemaybe_connstring = '{}'\n", // FIXME escaping
+                "shared_preload_libraries = zenith\n\
+                zenith.callmemaybe_connstring = '{}'\n", // FIXME escaping
                 node.connstr()
             )
             .as_str(),
@@ -169,7 +171,7 @@ impl PostgresNode {
         lazy_static! {
             static ref CONF_PORT_RE: Regex = Regex::new(r"(?m)^\s*port\s*=\s*(\d+)\s*$").unwrap();
             static ref CONF_TIMELINE_RE: Regex =
-                Regex::new(r"(?m)^\s*zenith_timeline\s*=\s*'(\w+)'\s*$").unwrap();
+                Regex::new(r"(?m)^\s*zenith.zenith_timeline\s*=\s*'(\w+)'\s*$").unwrap();
         }
 
         // parse data directory name
@@ -312,8 +314,9 @@ impl PostgresNode {
         self.append_conf(
             "postgresql.conf",
             &format!(
-                "page_server_connstring = 'host={} port={}'\n\
-                      zenith_timeline='{}'\n",
+                "shared_preload_libraries = zenith \n\
+                 zenith.page_server_connstring = 'host={} port={}'\n\
+                 zenith.zenith_timeline='{}'\n",
                 self.pageserver.address().ip(),
                 self.pageserver.address().port(),
                 self.timelineid

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -386,6 +386,8 @@ impl WalRedoProcess {
                 .open(PathBuf::from(&datadir).join("postgresql.conf"))?;
             config.write_all(b"shared_buffers=128kB\n")?;
             config.write_all(b"fsync=off\n")?;
+            config.write_all(b"shared_preload_libraries=zenith\n")?;
+            config.write_all(b"zenith.wal_redo=on\n")?;
         }
         // Start postgres itself
         let mut child = Command::new("postgres")


### PR DESCRIPTION
- vendor/postgres changes https://github.com/zenithdb/postgres/pull/46

- Respective changes in RUST code: use shared library, use new GUC names.
- Add contrib build to Makefile.

