### PR TITLE
Fix compilation with older rust version.

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -54,7 +54,7 @@ fn add_slru_segments(
                 let segname = format!("{}/{:>04X}", path, curr_segno.unwrap());
 				let header = new_tar_header(&segname, SEG_SIZE as u64)?;
                 ar.append(&header, &seg_buf[..])?;
-                seg_buf.fill(0);
+                seg_buf = [0u8; SEG_SIZE];
             }
             curr_segno = Some(segno);
             let offs_start = (page % pg_constants::SLRU_PAGES_PER_SEGMENT) as usize

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -302,7 +302,7 @@ impl PostgresRedoManagerInternal {
                 if xlogrec.xl_rmid == pg_constants::RM_CLOG_ID {
                     let info = xlogrec.xl_info & !pg_constants::XLR_INFO_MASK;
                     if info == pg_constants::CLOG_ZEROPAGE {
-                        page.clone_from_slice(&ZERO_PAGE);
+                        page.copy_from_slice(&ZERO_PAGE);
                     }
                 } else if xlogrec.xl_rmid == pg_constants::RM_XACT_ID {
                     let info = xlogrec.xl_info & pg_constants::XLOG_XACT_OPMASK;
@@ -368,9 +368,9 @@ impl PostgresRedoManagerInternal {
                 } else if xlogrec.xl_rmid == pg_constants::RM_MULTIXACT_ID {
                     let info = xlogrec.xl_info & pg_constants::XLOG_XACT_OPMASK;
                     if info == pg_constants::XLOG_MULTIXACT_ZERO_OFF_PAGE {
-                        page.fill(0);
+                        page.copy_from_slice(&ZERO_PAGE);
                     } else if info == pg_constants::XLOG_MULTIXACT_ZERO_MEM_PAGE {
-                        page.fill(0);
+                        page.copy_from_slice(&ZERO_PAGE);
                     } else if info == pg_constants::XLOG_MULTIXACT_CREATE_ID {
                         let xlrec = XlMultiXactCreate::decode(&mut buf);
                         if tag.rel.forknum == pg_constants::PG_MXACT_OFFSETS_FORKNUM {


### PR DESCRIPTION
Commit 9ece1e863d used `slice.fill`, which isn't available until Rust
v1.50.0. I have 1.48.0 installed, so it was failing to compile for me.

We haven't really standardized on any particular Rust version, and if
there's a good feature we need in a recent version, let's bump up the
minimum requirement. But this is simple enough to work around.