### PR TITLE
Add a unit test for handling a relation file larger than 1 GB

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -102,18 +102,20 @@ fn main() -> Result<()> {
         gc_horizon: DEFAULT_GC_HORIZON,
         gc_period: Duration::from_secs(DEFAULT_GC_PERIOD_SEC),
         listen_addr: "127.0.0.1:64000".parse().unwrap(),
-        workdir,
+        // we will change the current working directory to the repository below,
+        // so always set 'workdir' to '.'
+        workdir: PathBuf::from("."),
         pg_distrib_dir,
     };
 
     // Create repo and exit if init was requested
     if arg_matches.is_present("init") {
-        branches::init_repo(&conf)?;
+        branches::init_repo(&conf, &workdir)?;
         return Ok(());
     }
 
     // Set CWD to workdir for non-daemon modes
-    env::set_current_dir(&conf.workdir)?;
+    env::set_current_dir(&workdir)?;
 
     if arg_matches.is_present("daemonize") {
         conf.daemonize = true;

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -26,6 +26,13 @@ pub struct PageServerConf {
     pub listen_addr: SocketAddr,
     pub gc_horizon: u64,
     pub gc_period: Duration,
+
+    // Repository directory, relative to current working directory.
+    // Normally, the page server changes the current working directory
+    // to the repository, and 'workdir' is always '.'. But we don't do
+    // that during unit testing, because the current directory is global
+    // to the process but different unit tests work on different
+    // repositories.
     pub workdir: PathBuf,
 
     pub pg_distrib_dir: PathBuf,
@@ -37,21 +44,19 @@ impl PageServerConf {
     //
 
     fn tag_path(&self, name: &str) -> PathBuf {
-        std::path::Path::new("refs").join("tags").join(name)
+        self.workdir.join("refs").join("tags").join(name)
     }
 
     fn branch_path(&self, name: &str) -> PathBuf {
-        std::path::Path::new("refs").join("branches").join(name)
+        self.workdir.join("refs").join("branches").join(name)
     }
 
     fn timeline_path(&self, timelineid: ZTimelineId) -> PathBuf {
-        std::path::Path::new("timelines").join(timelineid.to_string())
+        self.workdir.join("timelines").join(timelineid.to_string())
     }
 
     fn snapshots_path(&self, timelineid: ZTimelineId) -> PathBuf {
-        std::path::Path::new("timelines")
-            .join(timelineid.to_string())
-            .join("snapshots")
+        self.timeline_path(timelineid).join("snapshots")
     }
 
     //

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -136,8 +136,10 @@ pub const XLOG_TBLSPC_DROP: u8 = 0x10;
 
 pub const SIZEOF_XLOGRECORD: u32 = 24;
 
-// FIXME:
+// from pg_config.h. These can be changed with configure options --with-blocksize=BLOCKSIZE and
+// --with-segsize=SEGSIZE, but assume the defaults for now.
 pub const BLCKSZ: u16 = 8192;
+pub const RELSEG_SIZE: u32 = 1024 * 1024 * 1024 / (BLCKSZ as u32);
 
 //
 // from xlogrecord.h


### PR DESCRIPTION
First commit changes the meaning of PageServerConf::workdir; see commit message. The second one adds the test.

@kelvich, please take a look at the first commit in particular. Thoughts?