### PR TITLE
Rework pg subcommand in CLI: start calls create

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -80,11 +80,10 @@ impl ComputeControlPlane {
         &mut self,
         is_test: bool,
         timelineid: ZTimelineId,
+        name: &str,
     ) -> Result<Arc<PostgresNode>> {
-        let node_id = self.nodes.len() as u32 + 1;
-
         let node = Arc::new(PostgresNode {
-            name: format!("pg{}", node_id),
+            name: name.to_owned(),
             address: SocketAddr::new("127.0.0.1".parse().unwrap(), self.get_port()),
             env: self.env.clone(),
             pageserver: Arc::clone(&self.pageserver),
@@ -105,7 +104,7 @@ impl ComputeControlPlane {
             .expect("failed to get timeline_id")
             .timeline_id;
 
-        let node = self.new_from_page_server(true, timeline_id);
+        let node = self.new_from_page_server(true, timeline_id, branch_name);
         let node = node.unwrap();
 
         // Configure the node to stream WAL directly to the pageserver
@@ -129,7 +128,9 @@ impl ComputeControlPlane {
             .expect("failed to get timeline_id")
             .timeline_id;
 
-        let node = self.new_from_page_server(true, timeline_id).unwrap();
+        let node = self
+            .new_from_page_server(true, timeline_id, branch_name)
+            .unwrap();
 
         node.append_conf(
             "postgresql.conf",
@@ -146,7 +147,9 @@ impl ComputeControlPlane {
             .expect("failed to get timeline_id")
             .timeline_id;
 
-        let node = self.new_from_page_server(false, timeline_id).unwrap();
+        let node = self
+            .new_from_page_server(false, timeline_id, branch_name)
+            .unwrap();
 
         // Configure the node to stream WAL directly to the pageserver
         node.append_conf(

--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -38,7 +38,7 @@ impl ComputeControlPlane {
         let pageserver = Arc::new(PageServerNode::from_env(&env));
 
         let pgdatadirspath = &env.pg_data_dirs_path();
-        let nodes: Result<BTreeMap<_, _>> = fs::read_dir(pgdatadirspath)
+        let nodes: Result<BTreeMap<_, _>> = fs::read_dir(&pgdatadirspath)
             .with_context(|| format!("failed to list {}", pgdatadirspath.display()))?
             .into_iter()
             .map(|f| {

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -164,15 +164,3 @@ pub fn save_config(conf: &LocalEnv) -> Result<()> {
     fs::write(config_path, conf_str)?;
     Ok(())
 }
-
-// Find the directory where the binaries were put (i.e. target/debug/)
-pub fn cargo_bin_dir() -> PathBuf {
-    let mut pathbuf = std::env::current_exe().unwrap();
-
-    pathbuf.pop();
-    if pathbuf.ends_with("deps") {
-        pathbuf.pop();
-    }
-
-    pathbuf
-}

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -203,10 +203,11 @@ impl PostgresNodeExt for PostgresNode {
                 println!("--------------- regression.diffs:\n{}", buffer);
             }
             // self.dump_log_file();
-            if let Ok(mut file) = File::open(self.env.pg_data_dir("pg1").join("log")) {
+
+            if let Ok(mut file) = File::open(self.env.pg_data_dir("main").join("log")) {
                 let mut buffer = String::new();
                 file.read_to_string(&mut buffer).unwrap();
-                println!("--------------- pgdatadirs/pg1/log:\n{}", buffer);
+                println!("--------------- pgdatadirs/main/log:\n{}", buffer);
             }
         }
         regress_check

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -14,9 +14,20 @@ use nix::unistd::Pid;
 use postgres;
 
 use control_plane::compute::PostgresNode;
-use control_plane::local_env;
 use control_plane::read_pidfile;
 use control_plane::{local_env::LocalEnv, storage::PageServerNode};
+
+// Find the directory where the binaries were put (i.e. target/debug/)
+fn cargo_bin_dir() -> PathBuf {
+    let mut pathbuf = std::env::current_exe().unwrap();
+
+    pathbuf.pop();
+    if pathbuf.ends_with("deps") {
+        pathbuf.pop();
+    }
+
+    pathbuf
+}
 
 // local compute env for tests
 pub fn create_test_env(testname: &str) -> LocalEnv {
@@ -39,7 +50,7 @@ pub fn create_test_env(testname: &str) -> LocalEnv {
     LocalEnv {
         pageserver_connstring: "postgresql://127.0.0.1:64000".to_string(),
         pg_distrib_dir: Path::new(env!("CARGO_MANIFEST_DIR")).join("../tmp_install"),
-        zenith_distrib_dir: Some(local_env::cargo_bin_dir()),
+        zenith_distrib_dir: Some(cargo_bin_dir()),
         base_data_dir: base_path,
         remotes: BTreeMap::default(),
     }

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -202,13 +202,7 @@ impl PostgresNodeExt for PostgresNode {
                 file.read_to_string(&mut buffer).unwrap();
                 println!("--------------- regression.diffs:\n{}", buffer);
             }
-            // self.dump_log_file();
-
-            if let Ok(mut file) = File::open(self.env.pg_data_dir("main").join("log")) {
-                let mut buffer = String::new();
-                file.read_to_string(&mut buffer).unwrap();
-                println!("--------------- pgdatadirs/main/log:\n{}", buffer);
-            }
+            self.dump_log_file();
         }
         regress_check
     }
@@ -287,7 +281,7 @@ impl PostgresNodeExt for PostgresNode {
         println!("Running {}", sql);
         let result = client.query(sql, &[]);
         if result.is_err() {
-            // self.dump_log_file();
+            self.dump_log_file();
         }
         result.unwrap()
     }

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -31,14 +31,6 @@ pub struct BranchInfo {
     pub latest_valid_lsn: Option<Lsn>,
 }
 
-// impl BranchInfo {
-//     pub fn lsn_string(&self) -> String {
-//         let lsn_string_opt = self.latest_valid_lsn.map(|lsn| lsn.to_string());
-//         let lsn_str = lsn_string_opt.as_deref().unwrap_or("?");
-//         format!("{}@{}", self.name, lsn_str)
-//     }
-// }
-
 #[derive(Debug, Clone, Copy)]
 pub struct PointInTime {
     pub timelineid: ZTimelineId,
@@ -116,14 +108,6 @@ pub fn init_repo(conf: &PageServerConf) -> Result<()> {
     let data = tli.to_string();
     fs::write(conf.branch_path("main"), data)?;
     println!("created main branch");
-
-    // XXX: do we need that now? -- yep, for test only
-
-    // // Also update the system id in the LocalEnv
-    // local_env.systemid = systemid;
-    // // write config
-    // let toml = toml::to_string(&local_env)?;
-    // fs::write(repopath.join("config"), toml)?;
 
     println!(
         "new zenith repository was created in {}",

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -158,21 +158,23 @@ class Postgres:
         self.host = 'localhost'
         self.port = 55431 + instance_num
         self.repo_dir = repo_dir
-        # path to conf is <repo_dir>/pgdatadirs/pg<instance_num>/postgresql.conf
+        self.branch = None
+        # path to conf is <repo_dir>/pgdatadirs/<branch_name>/postgresql.conf
 
     def create_start(self, branch, config_lines=None):
         """ create the pg data directory, and start the server """
         self.zenith_cli.run(['pg', 'create', branch])
+        self.branch = branch
         if config_lines is None:
             config_lines = []
         self.config(config_lines)
-        self.zenith_cli.run(['pg', 'start', 'pg{}'.format(self.instance_num)])
+        self.zenith_cli.run(['pg', 'start', branch])
         self.running = True
         return
 
     #lines should be an array of valid postgresql.conf rows
     def config(self, lines):
-        filename = 'pgdatadirs/pg{}/postgresql.conf'.format(self.instance_num)
+        filename = 'pgdatadirs/{}/postgresql.conf'.format(self.branch)
         config_name = os.path.join(self.repo_dir, filename)
         with open(config_name, 'a') as conf:
             for line in lines:
@@ -181,7 +183,7 @@ class Postgres:
 
     def stop(self):
         if self.running:
-            self.zenith_cli.run(['pg', 'stop', 'pg{}'.format(self.instance_num)])
+            self.zenith_cli.run(['pg', 'stop', self.branch])
 
     # Return a libpq connection string to connect to the Postgres instance
     def connstr(self):

--- a/zenith/Cargo.toml
+++ b/zenith/Cargo.toml
@@ -10,19 +10,6 @@ edition = "2018"
 clap = "2.33.0"
 anyhow = "1.0"
 serde_json = "1"
-# rand = "0.8.3"
-# tar = "0.4.33"
-# serde = { version = "1.0", features = ["derive"] }
-# toml = "0.5"
-# lazy_static = "1.4"
-# regex = "1"
-# # hex = "0.4.3"
-# bytes = "1.0.1"
-# # fs_extra = "1.2.0"
-# nix = "0.20"
-# # thiserror = "1"
-# url = "2.2.2"
-
 postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 
 # FIXME: 'pageserver' is needed for ZTimelineId. Refactor

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -20,10 +20,10 @@ use zenith_utils::lsn::Lsn;
 //   * Providing CLI api to the pageserver (local or remote)
 //   * TODO: export/import to/from usual postgres
 fn main() -> Result<()> {
-    let name_arg = Arg::with_name("NAME")
+    let timeline_arg = Arg::with_name("timeline")
         .short("n")
         .index(1)
-        .help("name of this postgres instance")
+        .help("timeline name")
         .required(true);
 
     let matches = App::new("zenith")
@@ -51,17 +51,10 @@ fn main() -> Result<()> {
         .subcommand(
             SubCommand::with_name("pg")
                 .about("Manage postgres instances")
-                .subcommand(
-                    SubCommand::with_name("create")
-                        // .arg(name_arg.clone()
-                        //     .required(false)
-                        //     .help("name of this postgres instance (will be pgN if omitted)"))
-                        .arg(Arg::with_name("timeline").required(false).index(1)),
-                )
                 .subcommand(SubCommand::with_name("list"))
-                .subcommand(SubCommand::with_name("start").arg(name_arg.clone()))
-                .subcommand(SubCommand::with_name("stop").arg(name_arg.clone()))
-                .subcommand(SubCommand::with_name("destroy").arg(name_arg.clone())),
+                .subcommand(SubCommand::with_name("create").arg(timeline_arg.clone()))
+                .subcommand(SubCommand::with_name("start").arg(timeline_arg.clone()))
+                .subcommand(SubCommand::with_name("stop").arg(timeline_arg.clone())),
         )
         .subcommand(
             SubCommand::with_name("remote")
@@ -177,66 +170,68 @@ fn main() -> Result<()> {
 
 /// Returns a map of timeline IDs to branch_name@lsn strings.
 /// Connects to the pageserver to query this information.
-fn get_branch_infos(env: &local_env::LocalEnv) -> Result<HashMap<ZTimelineId, String>> {
+fn get_branch_infos(env: &local_env::LocalEnv) -> Result<HashMap<ZTimelineId, BranchInfo>> {
     let page_server = PageServerNode::from_env(env);
     let branch_infos: Vec<BranchInfo> = page_server.branches_list()?;
-    let branch_infos: Result<HashMap<ZTimelineId, String>> = branch_infos
+    let branch_infos: HashMap<ZTimelineId, BranchInfo> = branch_infos
         .into_iter()
-        .map(|branch_info| {
-            let lsn_string_opt = branch_info.latest_valid_lsn.map(|lsn| lsn.to_string());
-            let lsn_str = lsn_string_opt.as_deref().unwrap_or("?");
-            let branch_lsn_string = format!("{}@{}", branch_info.name, lsn_str);
-            Ok((branch_info.timeline_id, branch_lsn_string))
-        })
+        .map(|branch_info| (branch_info.timeline_id, branch_info))
         .collect();
 
-    branch_infos
+    Ok(branch_infos)
 }
 
 fn handle_pg(pg_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
     let mut cplane = ComputeControlPlane::load(env.clone())?;
 
     match pg_match.subcommand() {
-        ("create", Some(sub_m)) => {
-            let timeline_arg = sub_m.value_of("timeline").unwrap_or("main");
-            println!("Initializing Postgres on timeline {}...", timeline_arg);
-            cplane.new_node(timeline_arg)?;
-        }
         ("list", Some(_sub_m)) => {
             let branch_infos = get_branch_infos(env).unwrap_or_else(|e| {
                 eprintln!("Failed to load branch info: {}", e);
                 HashMap::new()
             });
 
-            println!("NODE\tADDRESS\t\tSTATUS\tBRANCH@LSN");
-            for (node_name, node) in cplane.nodes.iter() {
+            println!("BRANCH\tADDRESS\t\tLSN\t\tSTATUS");
+            for (timeline_name, node) in cplane.nodes.iter() {
                 println!(
                     "{}\t{}\t{}\t{}",
-                    node_name,
+                    timeline_name,
                     node.address,
-                    node.status(),
                     branch_infos
                         .get(&node.timelineid)
-                        .map(|s| s.as_str())
-                        .unwrap_or("?")
+                        .map(|bi| bi
+                            .latest_valid_lsn
+                            .map_or("?".to_string(), |lsn| lsn.to_string()))
+                        .unwrap_or("?".to_string()),
+                    node.status(),
                 );
             }
         }
+        ("create", Some(sub_m)) => {
+            let timeline_name = sub_m.value_of("timeline").unwrap_or("main");
+            cplane.new_node(timeline_name)?;
+        }
         ("start", Some(sub_m)) => {
-            let name = sub_m.value_of("NAME").unwrap();
-            let node = cplane
-                .nodes
-                .get(name)
-                .ok_or_else(|| anyhow!("postgres {} is not found", name))?;
-            node.start()?;
+            let timeline_name = sub_m.value_of("timeline").unwrap_or("main");
+
+            let node = cplane.nodes.get(timeline_name);
+
+            println!("Starting postgres on timeline {}...", timeline_name);
+            if let Some(node) = node {
+                node.start()?;
+            } else {
+                let node = cplane.new_node(timeline_name)?;
+                node.start()?;
+            }
         }
         ("stop", Some(sub_m)) => {
-            let name = sub_m.value_of("NAME").unwrap();
+            let timeline_name = sub_m.value_of("timeline").unwrap_or("main");
             let node = cplane
                 .nodes
-                .get(name)
-                .ok_or_else(|| anyhow!("postgres {} is not found", name))?;
+                .get(timeline_name)
+                .ok_or_else(|| anyhow!("postgres {} is not found", timeline_name))?;
             node.stop()?;
+            // TODO: destroy data directory here
         }
 
         _ => {}

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -179,19 +179,7 @@ fn main() -> Result<()> {
 /// Connects to the pageserver to query this information.
 fn get_branch_infos(env: &local_env::LocalEnv) -> Result<HashMap<ZTimelineId, String>> {
     let page_server = PageServerNode::from_env(env);
-    let mut client = page_server.page_server_psql_client()?;
-    let branches_msgs = client.simple_query("pg_list")?;
-
-    let branches_json = branches_msgs
-        .first()
-        .map(|msg| match msg {
-            postgres::SimpleQueryMessage::Row(row) => row.get(0),
-            _ => None,
-        })
-        .flatten()
-        .ok_or_else(|| anyhow!("missing branches"))?;
-
-    let branch_infos: Vec<BranchInfo> = serde_json::from_str(branches_json)?;
+    let branch_infos: Vec<BranchInfo> = page_server.branches_list()?;
     let branch_infos: Result<HashMap<ZTimelineId, String>> = branch_infos
         .into_iter()
         .map(|branch_info| {


### PR DESCRIPTION
Rework pg subcommand in CLI.

1. Create data directory on start
2. Remove distinct pg names, now pg name == branch name.

Also few minor clean ups.