### PR TITLE
Simplify construction of rocksdb keys and values.

### DIFF
--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -198,7 +198,7 @@ impl RelTag {
         buf.put_u32(self.dbnode);
         buf.put_u32(self.relnode);
     }
-    pub fn unpack(buf: &mut BytesMut) -> RelTag {
+    pub fn unpack(buf: &mut Bytes) -> RelTag {
         RelTag {
             forknum: buf.get_u8(),
             spcnode: buf.get_u32(),
@@ -237,7 +237,7 @@ impl BufferTag {
         self.rel.pack(buf);
         buf.put_u32(self.blknum);
     }
-    pub fn unpack(buf: &mut BytesMut) -> BufferTag {
+    pub fn unpack(buf: &mut Bytes) -> BufferTag {
         BufferTag {
             rel: RelTag::unpack(buf),
             blknum: buf.get_u32(),
@@ -264,7 +264,7 @@ impl WALRecord {
         buf.put_u32(self.rec.len() as u32);
         buf.put_slice(&self.rec[..]);
     }
-    pub fn unpack(buf: &mut BytesMut) -> WALRecord {
+    pub fn unpack(buf: &mut Bytes) -> WALRecord {
         let lsn = Lsn::from(buf.get_u64());
         let will_init = buf.get_u8() != 0;
         let main_data_offset = buf.get_u32();


### PR DESCRIPTION
I'm going nuts with the pattern:

    let k = iter.key().unwrap();
    buf.clear();
    buf.extend_from_slice(&k);
    let key = CacheKey::unpack(&mut buf);

Introduce helper functions to convert a CacheKey into BytesMut, and
from [u8] into CacheKey. Reduces the boilerplate code a lot.

The helper functions create a new BytesMut on each call, whereas the old
coding could reuse a single BytesMut, so this could be a bit slower. I
haven't tried measuring it, but at least it's not immediately noticeable,
and readability is much more imporatant at this point. We can optimize
later