### PR TITLE
Pass PageServerConf as static ref.

### DIFF
--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -14,7 +14,7 @@ lazy_static! {
     pub static ref REPOSITORY: Mutex<Option<Arc<dyn Repository + Send + Sync>>> = Mutex::new(None);
 }
 
-pub fn init(conf: &PageServerConf) {
+pub fn init(conf: &'static PageServerConf) {
     let mut m = REPOSITORY.lock().unwrap();
 
     // Set up a WAL redo manager, for applying WAL records.

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -424,7 +424,7 @@ impl PagestreamBeMessage {
 ///
 /// Listens for connections, and launches a new handler thread for each.
 ///
-pub fn thread_main(conf: &PageServerConf) {
+pub fn thread_main(conf: &'static PageServerConf) {
     info!("Starting page server on {}", conf.listen_addr);
 
     let listener = TcpListener::bind(conf.listen_addr).unwrap();
@@ -433,7 +433,7 @@ pub fn thread_main(conf: &PageServerConf) {
         let (socket, peer_addr) = listener.accept().unwrap();
         debug!("accepted connection from {}", peer_addr);
         socket.set_nodelay(true).unwrap();
-        let mut conn_handler = Connection::new(conf.clone(), socket);
+        let mut conn_handler = Connection::new(conf, socket);
 
         thread::spawn(move || {
             if let Err(err) = conn_handler.run() {
@@ -448,11 +448,11 @@ struct Connection {
     stream_in: BufReader<TcpStream>,
     stream: BufWriter<TcpStream>,
     init_done: bool,
-    conf: PageServerConf,
+    conf: &'static PageServerConf,
 }
 
 impl Connection {
-    pub fn new(conf: PageServerConf, socket: TcpStream) -> Connection {
+    pub fn new(conf: &'static PageServerConf, socket: TcpStream) -> Connection {
         Connection {
             stream_in: BufReader::new(socket.try_clone().unwrap()),
             stream: BufWriter::new(socket),

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -335,10 +335,13 @@ mod tests {
             workdir: repo_dir.into(),
             pg_distrib_dir: "".into(),
         };
+        // Make a static copy of the config. This can never be free'd, but that's
+        // OK in a test.
+        let conf: &'static PageServerConf = Box::leak(Box::new(conf));
 
         let walredo_mgr = TestRedoManager {};
 
-        let repo = rocksdb::RocksRepository::new(&conf, Arc::new(walredo_mgr));
+        let repo = rocksdb::RocksRepository::new(conf, Arc::new(walredo_mgr));
 
         Ok(Box::new(repo))
     }

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -45,7 +45,7 @@ lazy_static! {
 
 // Launch a new WAL receiver, or tell one that's running about change in connection string
 pub fn launch_wal_receiver(
-    conf: &PageServerConf,
+    conf: &'static PageServerConf,
     timelineid: ZTimelineId,
     wal_producer_connstr: &str,
 ) {
@@ -62,11 +62,10 @@ pub fn launch_wal_receiver(
             receivers.insert(timelineid, receiver);
 
             // Also launch a new thread to handle this connection
-            let conf_copy = conf.clone();
             let _walreceiver_thread = thread::Builder::new()
                 .name("WAL receiver thread".into())
                 .spawn(move || {
-                    thread_main(&conf_copy, timelineid);
+                    thread_main(conf, timelineid);
                 })
                 .unwrap();
         }
@@ -87,7 +86,7 @@ fn get_wal_producer_connstr(timelineid: ZTimelineId) -> String {
 //
 // This is the entry point for the WAL receiver thread.
 //
-fn thread_main(conf: &PageServerConf, timelineid: ZTimelineId) {
+fn thread_main(conf: &'static PageServerConf, timelineid: ZTimelineId) {
     info!(
         "WAL receiver thread started for timeline : '{}'",
         timelineid


### PR DESCRIPTION
It's created once early in server startup, after parsing the
command-line options, and never modified afterwards. To simplify
things, pass it around as static ref, instead of making copies in all
the different structs. We still pass around a reference to it, rather
than putting it in a global variable, to allow unit testing with
different configs in the same process.