### PR TITLE
WIP: Add test for following relmapper files at CREATE DATABASE

### DIFF
--- a/test_runner/batch_others/test_createdb.py
+++ b/test_runner/batch_others/test_createdb.py
@@ -1,0 +1,34 @@
+import pytest
+import getpass
+import psycopg2
+
+pytest_plugins = ("fixtures.zenith_fixtures")
+
+#
+# Test CREATE DATABASE when there have been relmapper changes
+#
+def test_createdb(zenith_cli, pageserver, postgres, pg_bin):
+    zenith_cli.run(["branch", "test_createdb", "empty"]);
+
+    pg = postgres.create_start('test_createdb')
+    print("postgres is running on 'test_createdb' branch")
+
+    conn = psycopg2.connect(pg.connstr());
+    conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = conn.cursor()
+
+    # Cause a 'relmapper' change in the original branch
+    cur.execute('VACUUM FULL pg_class');
+
+    cur.execute('CREATE DATABASE foodb');
+
+    conn.close();
+
+    # Create a branch
+    zenith_cli.run(["branch", "test_createdb2", "test_createdb"]);
+
+    pg2 = postgres.create_start('test_createdb2')
+
+    # Test that you can connect to the new database on both branches
+    conn = psycopg2.connect(pg.connstr('foodb'));
+    conn2 = psycopg2.connect(pg2.connstr('foodb'));

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -186,9 +186,9 @@ class Postgres:
             self.zenith_cli.run(['pg', 'stop', self.branch])
 
     # Return a libpq connection string to connect to the Postgres instance
-    def connstr(self):
-        conn_str = 'host={} port={} dbname=postgres user={}'.format(
-            self.host, self.port, self.username)
+    def connstr(self, dbname='postgres'):
+        conn_str = 'host={} port={} dbname={} user={}'.format(
+            self.host, self.port, dbname, self.username)
         return conn_str
 
 class PostgresFactory:


### PR DESCRIPTION
Something wrong with handling CREATE DATABASE and relmapper files.  This test fails currently:
```
FAILED batch_others/test_createdb.py::test_createdb - psycopg2.OperationalError: PANIC:  could not open critical system index 2662
```
If you comment out the `VACUUM FULL pg_class` line, it works.