### PR TITLE
Debug Timed out while waiting for WAL record problem

### DIFF
--- a/pageserver/src/repository/rocksdb.rs
+++ b/pageserver/src/repository/rocksdb.rs
@@ -542,13 +542,13 @@ impl RocksTimeline {
             );
             lsn = last_valid_lsn;
         }
-        //trace!("Start waiting for LSN {}, valid LSN is {}", lsn,  self.last_valid_lsn.load());
+        trace!("Start waiting for LSN {}, valid LSN is {}", lsn,  self.last_valid_lsn.load());
         self.last_valid_lsn
             .wait_for_timeout(lsn, TIMEOUT)
             .with_context(|| {
                 format!(
-                    "Timed out while waiting for WAL record at LSN {} to arrive",
-                    lsn
+                    "Timed out while waiting for WAL record at LSN {} to arrive. valid LSN in {}",
+                    lsn, self.last_valid_lsn.load(),
                 )
             })?;
         //trace!("Stop waiting for LSN {}, valid LSN is {}", lsn,  self.last_valid_lsn.load());

--- a/pageserver/src/repository/rocksdb.rs
+++ b/pageserver/src/repository/rocksdb.rs
@@ -30,7 +30,7 @@ use zenith_utils::lsn::{AtomicLsn, Lsn};
 use zenith_utils::seqwait::SeqWait;
 
 // Timeout when waiting or WAL receiver to catch up to an LSN given in a GetPage@LSN call.
-static TIMEOUT: Duration = Duration::from_secs(60);
+static TIMEOUT: Duration = Duration::from_secs(600);
 
 pub struct RocksRepository {
     conf: &'static PageServerConf,


### PR DESCRIPTION
It seems that our recent CI failures are caused by TIMEOUT that we use when waiting for walreceiver to catch up to the requested LSN.
https://github.com/zenithdb/zenith/blob/main/pageserver/src/repository/rocksdb.rs#L32

I suppose we observe it more often with recent changes simply because we've added more records to handle. 
And now it depends on CircleCI performance fluctuations.

@knizhnik , @hlinnaka , 
Let's agree to increase this timeout or remove it at all  - at the very worst CI will timeout the job. 

BTW,  does this wait_lsn() code really belong to rocksdb module? Or we should refactor it and move it somewhere?