### PR TITLE
Minor refactoring and cleanup of the Timeline interface.

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -835,7 +835,7 @@ impl Connection {
                         forknum: req.forknum,
                     };
 
-                    let exist = timeline.get_relsize_exists(tag, req.lsn).unwrap_or(false);
+                    let exist = timeline.get_rel_exists(tag, req.lsn).unwrap_or(false);
 
                     PagestreamBeMessage::Status(PagestreamStatusResponse {
                         ok: exist,
@@ -850,7 +850,7 @@ impl Connection {
                         forknum: req.forknum,
                     };
 
-                    let n_blocks = timeline.get_relsize(tag, req.lsn).unwrap_or(0);
+                    let n_blocks = timeline.get_rel_size(tag, req.lsn).unwrap_or(0);
 
                     PagestreamBeMessage::Nblocks(PagestreamStatusResponse { ok: true, n_blocks })
                 }

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -7,6 +7,7 @@
 //!
 
 use crate::page_cache;
+use crate::restore_local_repo;
 use crate::waldecoder::*;
 use crate::PageServerConf;
 use crate::ZTimelineId;
@@ -184,7 +185,7 @@ fn walreceiver_main(
 
                 while let Some((lsn, recdata)) = waldecoder.poll_decode()? {
                     let decoded = decode_wal_record(recdata.clone());
-                    timeline.save_decoded_record(decoded, recdata, lsn)?;
+                    restore_local_repo::save_decoded_record(&*timeline, decoded, recdata, lsn)?;
 
                     // Now that this record has been handled, let the page cache know that
                     // it is up-to-date to this LSN


### PR DESCRIPTION
Move `save_decoded_record` out of the Timeline trait. The storage
implementation shouldn't need to know how to decode records.

Also move put_create_database() out of the Timeline trait. Add a new
`list_rels` function to Timeline to support it, instead.

Rename `get_relsize` to `get_rel_size`, and `get_relsize_exists` to
`get_rel_exists`. Seems nicer.