### PR TITLE
Little cleanup on `save_decoded_record` function

### DIFF
--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -221,7 +221,7 @@ pub fn import_timeline_wal(walpath: &Path, timeline: &dyn Timeline, startpoint: 
             }
             if let Some((lsn, recdata)) = rec.unwrap() {
                 let decoded = decode_wal_record(recdata.clone());
-                save_decoded_record(timeline, decoded, recdata, lsn)?;
+                save_decoded_record(timeline, &decoded, recdata, lsn)?;
                 last_lsn = lsn;
             } else {
                 break;
@@ -249,12 +249,12 @@ pub fn import_timeline_wal(walpath: &Path, timeline: &dyn Timeline, startpoint: 
 ///
 pub fn save_decoded_record(
     timeline: &dyn Timeline,
-    decoded: DecodedWALRecord,
+    decoded: &DecodedWALRecord,
     recdata: Bytes,
     lsn: Lsn,
 ) -> Result<()> {
-    // Figure out which blocks the record applies to, and "put" a separate copy
-    // of the record for each block.
+    // Iterate through all the blocks that the record modifies, and
+    // "put" a separate copy of the record for each block.
     for blk in decoded.blocks.iter() {
         let tag = BufferTag {
             rel: RelTag {

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -185,7 +185,7 @@ fn walreceiver_main(
 
                 while let Some((lsn, recdata)) = waldecoder.poll_decode()? {
                     let decoded = decode_wal_record(recdata.clone());
-                    restore_local_repo::save_decoded_record(&*timeline, decoded, recdata, lsn)?;
+                    restore_local_repo::save_decoded_record(&*timeline, &decoded, recdata, lsn)?;
                     last_rec_lsn = lsn;
                 }
 


### PR DESCRIPTION
Pass DecodedWALRecord by reference, seems nicer, and probably marginally
faster.
