### PR TITLE
Misc cleanup of the 'zenith_regress' tests

### DIFF
--- a/test_runner/batch_pg_regress/test_pg_regress.py
+++ b/test_runner/batch_pg_regress/test_pg_regress.py
@@ -6,11 +6,6 @@ import psycopg2
 
 pytest_plugins = ("fixtures.zenith_fixtures")
 
-# FIXME: put host + port in a fixture
-HOST = 'localhost'
-PORT = 55432
-
-
 def test_pg_regress(pageserver, postgres, pg_bin, zenith_cli, test_output_dir, pg_distrib_dir, base_dir, capsys):
 
     # Create a branch for us

--- a/test_runner/batch_pg_regress/test_zenith_regress.py
+++ b/test_runner/batch_pg_regress/test_zenith_regress.py
@@ -6,11 +6,6 @@ import psycopg2
 
 pytest_plugins = ("fixtures.zenith_fixtures")
 
-# FIXME: put host + port in a fixture
-HOST = 'localhost'
-PORT = 55432
-
-
 def test_zenith_regress(pageserver, postgres, pg_bin, zenith_cli, test_output_dir, pg_distrib_dir, base_dir, capsys):
 
     # Create a branch for us

--- a/test_runner/zenith_regress/README.md
+++ b/test_runner/zenith_regress/README.md
@@ -1,11 +1,8 @@
 To add a new SQL test
 
 - add sql script to run to zenith_regress/sql/testname.sql
-- add expected output to zenith/regress/expected/testname.out
-- add testname to both parallel_schedule and serial_schedule files*
+- add expected output to zenith_regress/expected/testname.out
+- add testname to parallel_schedule
 
 That's it.
 For more complex tests see PostgreSQL regression tests. These works basically the same.
-
-*it was changed recently in PostgreSQL upstream - no more separate serial_schedule.
-Someday we'll catch up with these changes.

--- a/test_runner/zenith_regress/parallel_schedule
+++ b/test_runner/zenith_regress/parallel_schedule
@@ -1,8 +1,7 @@
 # ----------
-# src/test/regress/parallel_schedule
-#
-# By convention, we put no more than twenty tests in any one parallel group;
-# this limits the number of connections needed to run the tests.
+# Like in PostgreSQL src/test/regress/parallel_schedule, we put no
+# more than twenty tests in any one parallel group; this limits the
+# number of connections needed to run the tests.
 # ----------
 
 test: zenith-cid

--- a/test_runner/zenith_regress/serial_schedule
+++ b/test_runner/zenith_regress/serial_schedule
@@ -1,6 +1,0 @@
-# src/test/regress/serial_schedule
-# This should probably be in an order similar to parallel_schedule.
-test: zenith-cid
-test: zenith-rel-truncate
-test: zenith-clog
-test: zenith-vacuum-full


### PR DESCRIPTION
- Remove serial_schedule. As was alluded in the README, it's really quite
  pointless.
- Remove unused PORT/HOST variables
- Fix typos