### PR TITLE
pageserver - timeline snapshot api

### DIFF
--- a/pageserver/src/object_store.rs
+++ b/pageserver/src/object_store.rs
@@ -1,5 +1,5 @@
 //! Low-level key-value storage abstraction.
-//! 
+//!
 use crate::repository::{BufferTag, RelTag};
 use crate::ZTimelineId;
 use anyhow::Result;
@@ -49,6 +49,16 @@ pub trait ObjectStore: Send + Sync {
         key: &ObjectKey,
         lsn: Lsn,
     ) -> Result<Box<dyn Iterator<Item = (Lsn, Vec<u8>)> + 'a>>;
+
+    /// Iterate through versions of all objects in a timeline.
+    ///
+    /// Returns objects in increasing key-version order.
+    /// Returns all versions up to and including the specified LSN.
+    fn objects<'a>(
+        &'a self,
+        timeline: ZTimelineId,
+        lsn: Lsn,
+    ) -> Result<Box<dyn Iterator<Item = Result<(BufferTag, Lsn, Vec<u8>)>> + 'a>>;
 
     /// Iterate through all keys with given tablespace and database ID, and LSN <= 'lsn'.
     ///


### PR DESCRIPTION
A somewhat abstract iterator over a timeline history, designed with the intention of being used for timeline serialization.
The `SnapshotUpdate` and `SnapshotRelationUpdate` provide a notion of postgres storage events not tied to our repository implementation.

I stuck with the iterator returning a Result pattern introduced in the latest refactor.