### PR TITLE
add -w flag to wait till pg_ctl actually finishes what was asked

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -382,6 +382,7 @@ impl PostgresNode {
                         self.pgdata().to_str().unwrap(),
                         "-l",
                         self.pgdata().join("log").to_str().unwrap(),
+                        "-w", //wait till pg_ctl actually does what was asked
                     ],
                     args,
                 ]


### PR DESCRIPTION
Tiny fix. 
This should help to avoid a situation when we're trying to start a new postgres, when the old one haven't stopped yet.
