### PR TITLE
Remove transmutes with hand-written structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
  "regex",
  "thiserror",
  "workspace_hack",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1880,6 +1881,18 @@ checksum = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 
@@ -2474,4 +2487,25 @@ dependencies = [
  "serde",
  "thiserror",
  "workspace_hack",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af017aca1fa6181f5dd7a802456fe6f7666ecdcc18d0910431f0fc89d474e51"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1373,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "memoffset",
  "rand",
  "regex",
  "thiserror",

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -5,7 +5,6 @@
 //
 
 use anyhow::{anyhow, bail, Context, Result};
-use bytes::Bytes;
 use fs::File;
 use postgres_ffi::{pg_constants, xlog_utils};
 use rand::Rng;
@@ -80,7 +79,7 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
 
     // Read control file to extract the LSN and system id
     let controlfile_path = tmppath.join("global").join("pg_control");
-    let controlfile = postgres_ffi::decode_pg_control(Bytes::from(fs::read(controlfile_path)?))?;
+    let controlfile = postgres_ffi::non_portable::decode_pg_control(&fs::read(controlfile_path)?)?;
     // let systemid = controlfile.system_identifier;
     let lsn = controlfile.checkPoint;
     let lsnstr = format!("{:016X}", lsn);
@@ -213,7 +212,7 @@ pub(crate) fn get_system_id(conf: &PageServerConf) -> Result<u64> {
 
     let (_, main_snap_dir) = find_latest_snapshot(conf, *main_tli)?;
     let controlfile_path = main_snap_dir.join("global").join("pg_control");
-    let controlfile = postgres_ffi::decode_pg_control(Bytes::from(fs::read(controlfile_path)?))?;
+    let controlfile = postgres_ffi::non_portable::decode_pg_control(&fs::read(controlfile_path)?)?;
     Ok(controlfile.system_identifier)
 }
 
@@ -354,15 +353,16 @@ fn force_crash_recovery(datadir: &Path) -> Result<()> {
     // Read in the control file
     let controlfilepath = datadir.to_path_buf().join("global").join("pg_control");
     let mut controlfile =
-        postgres_ffi::decode_pg_control(Bytes::from(fs::read(controlfilepath.as_path())?))?;
+        postgres_ffi::non_portable::decode_pg_control(&fs::read(controlfilepath.as_path())?)?;
 
-    controlfile.state = postgres_ffi::DBState_DB_IN_PRODUCTION;
+    controlfile.state = postgres_ffi::non_portable::DBState_DB_IN_PRODUCTION;
 
-    fs::write(
-        controlfilepath.as_path(),
-        postgres_ffi::encode_pg_control(controlfile),
-    )?;
+    // Pad the buffer out to the expected file size.
+    let pg_control_buf = postgres_ffi::non_portable::encode_pg_control(controlfile);
+    let mut pg_control_buf = Vec::from(pg_control_buf);
+    pg_control_buf.resize(postgres_ffi::non_portable::PG_CONTROL_FILE_SIZE, 0);
 
+    fs::write(&controlfilepath, pg_control_buf)?;
     Ok(())
 }
 

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use fs::File;
+use postgres_ffi::non_portable::{ControlFileData, DBState};
 use postgres_ffi::{pg_constants, xlog_utils};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,6 @@ use zenith_utils::lsn::Lsn;
 use crate::page_cache;
 use crate::restore_local_repo;
 use crate::{repository::Repository, PageServerConf, ZTimelineId};
-use postgres_ffi::non_portable::ControlFileData;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BranchInfo {
@@ -355,7 +355,7 @@ fn force_crash_recovery(datadir: &Path) -> Result<()> {
     let controlfilepath = datadir.to_path_buf().join("global").join("pg_control");
     let mut controlfile = ControlFileData::decode(&fs::read(controlfilepath.as_path())?)?;
 
-    controlfile.state = postgres_ffi::non_portable::DBSTATE_DB_IN_PRODUCTION;
+    controlfile.state = DBState::DbInProduction as u32;
 
     // Pad the buffer out to the expected file size.
     let pg_control_buf = ControlFileData::encode(controlfile);

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -82,7 +82,7 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
     let controlfile_path = tmppath.join("global").join("pg_control");
     let controlfile = ControlFileData::decode(&fs::read(controlfile_path)?)?;
     // let systemid = controlfile.system_identifier;
-    let lsn = controlfile.checkPoint;
+    let lsn = controlfile.checkpoint;
     let lsnstr = format!("{:016X}", lsn);
 
     // Bootstrap the repository by loading the newly-initdb'd cluster into 'main' branch.
@@ -355,7 +355,7 @@ fn force_crash_recovery(datadir: &Path) -> Result<()> {
     let controlfilepath = datadir.to_path_buf().join("global").join("pg_control");
     let mut controlfile = ControlFileData::decode(&fs::read(controlfilepath.as_path())?)?;
 
-    controlfile.state = postgres_ffi::non_portable::DBState_DB_IN_PRODUCTION;
+    controlfile.state = postgres_ffi::non_portable::DBSTATE_DB_IN_PRODUCTION;
 
     // Pad the buffer out to the expected file size.
     let pg_control_buf = ControlFileData::encode(controlfile);

--- a/postgres_ffi/Cargo.toml
+++ b/postgres_ffi/Cargo.toml
@@ -18,6 +18,7 @@ hex = "0.4.3"
 lazy_static = "1.4"
 log = "0.4.14"
 thiserror = "1.0"
+zerocopy = "0.5"
 workspace_hack = { path = "../workspace_hack" }
 
 [build-dependencies]

--- a/postgres_ffi/Cargo.toml
+++ b/postgres_ffi/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4"
 log = "0.4.14"
 thiserror = "1.0"
 zerocopy = "0.5"
+memoffset = "0.6.2"
 workspace_hack = { path = "../workspace_hack" }
 
 [build-dependencies]

--- a/postgres_ffi/src/lib.rs
+++ b/postgres_ffi/src/lib.rs
@@ -1,71 +1,14 @@
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
+pub mod non_portable;
 pub mod pg_constants;
 pub mod relfile_utils;
 pub mod xlog_utils;
 
-use bytes::{Buf, Bytes, BytesMut};
-
-// sizeof(ControlFileData)
-const SIZEOF_CONTROLDATA: usize = std::mem::size_of::<ControlFileData>();
-const OFFSETOF_CRC: usize = PG_CONTROLFILEDATA_OFFSETOF_CRC as usize;
-
-impl ControlFileData {
-    // Initialize an all-zeros ControlFileData struct
-    pub fn new() -> ControlFileData {
-        let controlfile: ControlFileData;
-
-        let b = [0u8; SIZEOF_CONTROLDATA];
-        controlfile =
-            unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
-
-        controlfile
-    }
-}
-
-pub fn decode_pg_control(mut buf: Bytes) -> Result<ControlFileData, anyhow::Error> {
-    let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
-    buf.copy_to_slice(&mut b);
-
-    let controlfile: ControlFileData;
-
-    // TODO: verify CRC
-    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
-    data_without_crc.copy_from_slice(&b[0..OFFSETOF_CRC]);
-    let expectedcrc = crc32c::crc32c(&data_without_crc);
-
-    controlfile = unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
-
-    if expectedcrc != controlfile.crc {
-        anyhow::bail!(
-            "invalid CRC in control file: expected {:08X}, was {:08X}",
-            expectedcrc,
-            controlfile.crc
-        );
-    }
-
-    Ok(controlfile)
-}
-
-pub fn encode_pg_control(controlfile: ControlFileData) -> Bytes {
-    let b: [u8; SIZEOF_CONTROLDATA];
-
-    b = unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(controlfile) };
-
-    // Recompute the CRC
-    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
-    data_without_crc.copy_from_slice(&b[0..OFFSETOF_CRC]);
-    let newcrc = crc32c::crc32c(&data_without_crc);
-
-    let mut buf = BytesMut::with_capacity(PG_CONTROL_FILE_SIZE as usize);
-
-    buf.extend_from_slice(&b[0..OFFSETOF_CRC]);
-    buf.extend_from_slice(&newcrc.to_ne_bytes());
-    // Fill the rest of the control file with zeros.
-    buf.resize(PG_CONTROL_FILE_SIZE as usize, 0);
-
-    buf.into()
+// Not for public use; this is only for testing that handwritten structs match
+// Auto-generated structs.
+mod bindgen_bindings {
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(dead_code)]
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }

--- a/postgres_ffi/src/non_portable.rs
+++ b/postgres_ffi/src/non_portable.rs
@@ -24,14 +24,26 @@ type TimeLineID = u32;
 type PgTimeT = i64;
 type PgCrc32c = u32;
 
-pub type DBState = u32;
-pub const DBSTATE_DB_STARTUP: DBState = 0;
-pub const DBSTATE_DB_SHUTDOWNED: DBState = 1;
-pub const DBSTATE_DB_SHUTDOWNED_IN_RECOVERY: DBState = 2;
-pub const DBSTATE_DB_SHUTDOWNING: DBState = 3;
-pub const DBSTATE_DB_IN_CRASH_RECOVERY: DBState = 4;
-pub const DBSTATE_DB_IN_ARCHIVE_RECOVERY: DBState = 5;
-pub const DBSTATE_DB_IN_PRODUCTION: DBState = 6;
+/// This is a placeholder for futre improvement; the `zerocopy` crate can't
+/// derive `FromBytes` for an enum that doesn't have a variant for each
+/// possible integer value (and won't even try for anything bigger than u16.)
+type DbStateRaw = u32;
+/// FIXME: Please document me!
+///
+/// To use this, do something like `DBState::DbInProduction as u32`.
+// If conversion in the other direction is required, please add an impl
+// of TryFrom<u32>.
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum DBState {
+    DbStartup = 0,
+    DbShutdowned = 1,
+    DbShutdownedInRecovery = 2,
+    DbShutdowning = 3,
+    DbInCrashRecovery = 4,
+    DbInArchiveRecovery = 5,
+    DbInProduction = 6,
+}
 
 /// FIXME: Please document me!
 #[repr(C)]
@@ -77,7 +89,7 @@ pub struct ControlFileData {
     pub system_identifier: u64,
     pub pg_control_version: u32,
     pub catalog_version_no: u32,
-    pub state: DBState,
+    pub state: DbStateRaw,
     /// Explicit padding to align the 64-bit field that follows.
     pub __padding1: [u8; 4],
     pub time: PgTimeT,

--- a/postgres_ffi/src/non_portable.rs
+++ b/postgres_ffi/src/non_portable.rs
@@ -33,12 +33,14 @@ pub const DBSTATE_DB_IN_CRASH_RECOVERY: DBState = 4;
 pub const DBSTATE_DB_IN_ARCHIVE_RECOVERY: DBState = 5;
 pub const DBSTATE_DB_IN_PRODUCTION: DBState = 6;
 
+/// FIXME: Please document me!
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, AsBytes, FromBytes)]
 pub struct FullTransactionId {
     pub value: u64,
 }
 
+/// FIXME: Please document me!
 #[repr(C)]
 #[derive(Debug, Clone, Default, AsBytes, FromBytes)]
 pub struct CheckPoint {
@@ -68,6 +70,7 @@ pub struct CheckPoint {
     pub __padding5: [u8; 4],
 }
 
+/// FIXME: Please document me!
 #[repr(C)]
 #[derive(Debug, Clone, Default, AsBytes, FromBytes)]
 pub struct ControlFileData {

--- a/postgres_ffi/src/non_portable.rs
+++ b/postgres_ffi/src/non_portable.rs
@@ -21,18 +21,17 @@ pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = u32;
 pub type XLogRecPtr = u64;
 pub type TimeLineID = u32;
-pub type pg_time_t = i64;
-pub type pg_crc32c = u32;
+type PgTimeT = i64;
+type PgCrc32c = u32;
 
-// FIXME: turn this into an enum
 pub type DBState = u32;
-pub const DBState_DB_STARTUP: DBState = 0;
-pub const DBState_DB_SHUTDOWNED: DBState = 1;
-pub const DBState_DB_SHUTDOWNED_IN_RECOVERY: DBState = 2;
-pub const DBState_DB_SHUTDOWNING: DBState = 3;
-pub const DBState_DB_IN_CRASH_RECOVERY: DBState = 4;
-pub const DBState_DB_IN_ARCHIVE_RECOVERY: DBState = 5;
-pub const DBState_DB_IN_PRODUCTION: DBState = 6;
+pub const DBSTATE_DB_STARTUP: DBState = 0;
+pub const DBSTATE_DB_SHUTDOWNED: DBState = 1;
+pub const DBSTATE_DB_SHUTDOWNED_IN_RECOVERY: DBState = 2;
+pub const DBSTATE_DB_SHUTDOWNING: DBState = 3;
+pub const DBSTATE_DB_IN_CRASH_RECOVERY: DBState = 4;
+pub const DBSTATE_DB_IN_ARCHIVE_RECOVERY: DBState = 5;
+pub const DBSTATE_DB_IN_PRODUCTION: DBState = 6;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default, AsBytes, FromBytes)]
@@ -44,26 +43,26 @@ pub struct FullTransactionId {
 #[derive(Debug, Clone, Default, AsBytes, FromBytes)]
 pub struct CheckPoint {
     pub redo: XLogRecPtr,
-    pub ThisTimeLineID: TimeLineID,
-    pub PrevTimeLineID: TimeLineID,
+    pub this_timeline_id: TimeLineID,
+    pub prev_timeline_id: TimeLineID,
     /// Note this is `bool` in C; it is u8 to allow safe conversions.
-    pub fullPageWrites: u8,
+    pub full_page_writes: u8,
     /// Explicit padding to align the 64-bit field that follows.
     pub __padding1: [u8; 7],
-    pub nextXid: FullTransactionId,
-    pub nextOid: Oid,
-    pub nextMulti: MultiXactId,
-    pub nextMultiOffset: MultiXactOffset,
-    pub oldestXid: TransactionId,
-    pub oldestXidDB: Oid,
-    pub oldestMulti: MultiXactId,
-    pub oldestMultiDB: Oid,
+    pub next_xid: FullTransactionId,
+    pub next_oid: Oid,
+    pub next_multi: MultiXactId,
+    pub next_multi_offset: MultiXactOffset,
+    pub oldest_xid: TransactionId,
+    pub oldest_xid_db: Oid,
+    pub oldest_multi: MultiXactId,
+    pub oldest_multi_db: Oid,
     /// Explicit padding to align the 64-bit field that follows.
     pub __padding4: [u8; 4],
-    pub time: pg_time_t,
-    pub oldestCommitTsXid: TransactionId,
-    pub newestCommitTsXid: TransactionId,
-    pub oldestActiveXid: TransactionId,
+    pub time: PgTimeT,
+    pub oldest_commit_ts_xid: TransactionId,
+    pub newest_commit_ts_xid: TransactionId,
+    pub oldest_active_xid: TransactionId,
     /// Explicit padding to align the end of the struct, so this
     /// struct can be included inside other structs.
     pub __padding5: [u8; 4],
@@ -78,18 +77,18 @@ pub struct ControlFileData {
     pub state: DBState,
     /// Explicit padding to align the 64-bit field that follows.
     pub __padding1: [u8; 4],
-    pub time: pg_time_t,
-    pub checkPoint: XLogRecPtr,
-    pub checkPointCopy: CheckPoint,
-    pub unloggedLSN: XLogRecPtr,
-    pub minRecoveryPoint: XLogRecPtr,
-    pub minRecoveryPointTLI: TimeLineID,
+    pub time: PgTimeT,
+    pub checkpoint: XLogRecPtr,
+    pub checkpoint_copy: CheckPoint,
+    pub unlogged_lsn: XLogRecPtr,
+    pub min_recovery_point: XLogRecPtr,
+    pub min_recovery_point_tli: TimeLineID,
     /// Explicit padding to align the 64-bit field that follows.
     pub __padding2: [u8; 4],
-    pub backupStartPoint: XLogRecPtr,
-    pub backupEndPoint: XLogRecPtr,
+    pub backup_start_point: XLogRecPtr,
+    pub backup_end_point: XLogRecPtr,
     /// Note this is `bool` in C; it is u8 to allow safe conversions.
-    pub backupEndRequired: u8,
+    pub backup_end_required: u8,
     /// Explicit padding to align the 32-bit field that follows.
     pub __padding3: [u8; 3],
     pub wal_level: u32,
@@ -97,7 +96,7 @@ pub struct ControlFileData {
     pub wal_log_hints: u8,
     /// Explicit padding to align the 32-bit field that follows.
     pub __padding4: [u8; 3],
-    pub MaxConnections: u32,
+    pub max_connections: u32,
     pub max_worker_processes: u32,
     pub max_wal_senders: u32,
     pub max_prepared_xacts: u32,
@@ -106,23 +105,23 @@ pub struct ControlFileData {
     pub track_commit_timestamp: u8,
     /// Explicit padding to align the 32-bit field that follows.
     pub __padding5: [u8; 3],
-    pub maxAlign: u32,
-    pub floatFormat: f64,
+    pub max_align: u32,
+    pub float_format: f64,
     pub blcksz: u32,
     pub relseg_size: u32,
     pub xlog_blcksz: u32,
     pub xlog_seg_size: u32,
-    pub nameDataLen: u32,
-    pub indexMaxKeys: u32,
+    pub name_data_len: u32,
+    pub index_max_keys: u32,
     pub toast_max_chunk_size: u32,
     pub loblksize: u32,
     // /// Note this is `bool` in C; it is u8 to allow safe conversions.
-    pub float8ByVal: u8,
+    pub float8_by_val: u8,
     /// Explicit padding to align the 32-bit field that follows.
     pub __padding6: [u8; 3],
     pub data_checksum_version: u32,
     pub mock_authentication_nonce: [u8; 32],
-    pub crc: pg_crc32c,
+    pub crc: PgCrc32c,
     /// Explicit padding to align the end of the struct, to satisfy `zerocopy`
     pub __padding7: [u8; 4],
 }

--- a/postgres_ffi/src/non_portable.rs
+++ b/postgres_ffi/src/non_portable.rs
@@ -15,12 +15,12 @@ use anyhow::{anyhow, Result};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified};
 
 pub const PG_CONTROL_FILE_SIZE: usize = 8192;
-pub type Oid = u32;
-pub type TransactionId = u32;
-pub type MultiXactId = TransactionId;
-pub type MultiXactOffset = u32;
-pub type XLogRecPtr = u64;
-pub type TimeLineID = u32;
+type Oid = u32;
+type TransactionId = u32;
+type MultiXactId = TransactionId;
+type MultiXactOffset = u32;
+type XLogRecPtr = u64;
+type TimeLineID = u32;
 type PgTimeT = i64;
 type PgCrc32c = u32;
 

--- a/postgres_ffi/src/non_portable.rs
+++ b/postgres_ffi/src/non_portable.rs
@@ -142,8 +142,11 @@ pub struct ControlFileData {
 }
 
 impl ControlFileData {
-    // FIXME: compute this in a better way, or remove it entirely?
-    const OFFSETOF_CRC: usize = 288;
+    /// Compute the offset of the `crc` field within the `ControlFileData` struct.
+    // Someday this can be const when the right compiler features land.
+    fn crc_offset() -> usize {
+        memoffset::offset_of!(ControlFileData, crc)
+    }
 
     /// Decode a `ControlFileData` struct from a byte array.
     ///
@@ -161,7 +164,7 @@ impl ControlFileData {
         // Compute expected CRC.
         // Note the buffer length was already checked by LayoutVerified, so
         // accessing this offset should never panic.
-        let data_without_crc = &buf[0..Self::OFFSETOF_CRC];
+        let data_without_crc = &buf[0..Self::crc_offset()];
         let expectedcrc = crc32c::crc32c(&data_without_crc);
 
         if expectedcrc != controlfile.crc {
@@ -184,7 +187,7 @@ impl ControlFileData {
         let cf_bytes = self.as_bytes();
 
         // Recompute the CRC
-        let data_without_crc = &cf_bytes[0..Self::OFFSETOF_CRC];
+        let data_without_crc = &cf_bytes[0..Self::crc_offset()];
         let newcrc = crc32c::crc32c(&data_without_crc);
 
         // Drop the immutable reference so we can modify the struct

--- a/postgres_ffi/src/non_portable.rs
+++ b/postgres_ffi/src/non_portable.rs
@@ -1,0 +1,212 @@
+//!
+//! This file contains data structures that are explicitly non-portable.
+//! They are needed for compatibility with upstream postgres, which does
+//! not guarantee portability of data files across CPU architectures.
+//!
+//! These data structures use native endian and alignment in postgres.
+//!
+//! This code is not currently guaranteed to work on architectures other
+//! than x86_64.
+//!
+//! Do not use this file, or copy any of the patterns here, for things
+//! that are meant to be portable (particularly data structures sent)
+
+use anyhow::{anyhow, Result};
+use zerocopy::{AsBytes, FromBytes, LayoutVerified};
+
+pub const PG_CONTROL_FILE_SIZE: usize = 8192;
+pub type Oid = u32;
+pub type TransactionId = u32;
+pub type MultiXactId = TransactionId;
+pub type MultiXactOffset = u32;
+pub type XLogRecPtr = u64;
+pub type TimeLineID = u32;
+pub type pg_time_t = i64;
+pub type pg_crc32c = u32;
+
+// FIXME: turn this into an enum
+pub type DBState = u32;
+pub const DBState_DB_STARTUP: DBState = 0;
+pub const DBState_DB_SHUTDOWNED: DBState = 1;
+pub const DBState_DB_SHUTDOWNED_IN_RECOVERY: DBState = 2;
+pub const DBState_DB_SHUTDOWNING: DBState = 3;
+pub const DBState_DB_IN_CRASH_RECOVERY: DBState = 4;
+pub const DBState_DB_IN_ARCHIVE_RECOVERY: DBState = 5;
+pub const DBState_DB_IN_PRODUCTION: DBState = 6;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, AsBytes, FromBytes)]
+pub struct FullTransactionId {
+    pub value: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Default, AsBytes, FromBytes)]
+pub struct CheckPoint {
+    pub redo: XLogRecPtr,
+    pub ThisTimeLineID: TimeLineID,
+    pub PrevTimeLineID: TimeLineID,
+    /// Note this is `bool` in C; it is u8 to allow safe conversions.
+    pub fullPageWrites: u8,
+    /// Explicit padding to align the 64-bit field that follows.
+    pub __padding1: [u8; 7],
+    pub nextXid: FullTransactionId,
+    pub nextOid: Oid,
+    pub nextMulti: MultiXactId,
+    pub nextMultiOffset: MultiXactOffset,
+    pub oldestXid: TransactionId,
+    pub oldestXidDB: Oid,
+    pub oldestMulti: MultiXactId,
+    pub oldestMultiDB: Oid,
+    /// Explicit padding to align the 64-bit field that follows.
+    pub __padding4: [u8; 4],
+    pub time: pg_time_t,
+    pub oldestCommitTsXid: TransactionId,
+    pub newestCommitTsXid: TransactionId,
+    pub oldestActiveXid: TransactionId,
+    /// Explicit padding to align the end of the struct, so this
+    /// struct can be included inside other structs.
+    pub __padding5: [u8; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Default, AsBytes, FromBytes)]
+pub struct ControlFileData {
+    pub system_identifier: u64,
+    pub pg_control_version: u32,
+    pub catalog_version_no: u32,
+    pub state: DBState,
+    /// Explicit padding to align the 64-bit field that follows.
+    pub __padding1: [u8; 4],
+    pub time: pg_time_t,
+    pub checkPoint: XLogRecPtr,
+    pub checkPointCopy: CheckPoint,
+    pub unloggedLSN: XLogRecPtr,
+    pub minRecoveryPoint: XLogRecPtr,
+    pub minRecoveryPointTLI: TimeLineID,
+    /// Explicit padding to align the 64-bit field that follows.
+    pub __padding2: [u8; 4],
+    pub backupStartPoint: XLogRecPtr,
+    pub backupEndPoint: XLogRecPtr,
+    /// Note this is `bool` in C; it is u8 to allow safe conversions.
+    pub backupEndRequired: u8,
+    /// Explicit padding to align the 32-bit field that follows.
+    pub __padding3: [u8; 3],
+    pub wal_level: u32,
+    /// Note this is `bool` in C; it is u8 to allow safe conversions.
+    pub wal_log_hints: u8,
+    /// Explicit padding to align the 32-bit field that follows.
+    pub __padding4: [u8; 3],
+    pub MaxConnections: u32,
+    pub max_worker_processes: u32,
+    pub max_wal_senders: u32,
+    pub max_prepared_xacts: u32,
+    pub max_locks_per_xact: u32,
+    /// Note this is `bool` in C; it is u8 to allow safe conversions.
+    pub track_commit_timestamp: u8,
+    /// Explicit padding to align the 32-bit field that follows.
+    pub __padding5: [u8; 3],
+    pub maxAlign: u32,
+    pub floatFormat: f64,
+    pub blcksz: u32,
+    pub relseg_size: u32,
+    pub xlog_blcksz: u32,
+    pub xlog_seg_size: u32,
+    pub nameDataLen: u32,
+    pub indexMaxKeys: u32,
+    pub toast_max_chunk_size: u32,
+    pub loblksize: u32,
+    // /// Note this is `bool` in C; it is u8 to allow safe conversions.
+    pub float8ByVal: u8,
+    /// Explicit padding to align the 32-bit field that follows.
+    pub __padding6: [u8; 3],
+    pub data_checksum_version: u32,
+    pub mock_authentication_nonce: [u8; 32],
+    pub crc: pg_crc32c,
+    /// Explicit padding to align the end of the struct, to satisfy `zerocopy`
+    pub __padding7: [u8; 4],
+}
+
+// FIXME: compute this in a better way, or remove it entirely?
+const OFFSETOF_CRC: usize = 288;
+
+/// Decode a `ControlFileData` struct from a byte array.
+///
+/// This action is non-portable; it may fail to read data written by other
+/// CPU architectures.
+///
+pub fn decode_pg_control(buf: &[u8]) -> Result<ControlFileData> {
+    // Verify correct buffer alignment and size.
+    let (layout, _remaining) = LayoutVerified::<_, ControlFileData>::new_from_prefix(buf)
+        .ok_or(anyhow!("failed to get LayoutVerified ref"))?;
+
+    // Safely transmute into &ControlFileData, and then clone to get an owned copy.
+    let controlfile = layout.into_ref().clone();
+
+    // Compute expected CRC.
+    // Note the buffer length was already checked by LayoutVerified, so
+    // accessing this offset should never panic.
+    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
+    data_without_crc.copy_from_slice(&buf[0..OFFSETOF_CRC]);
+    let expectedcrc = crc32c::crc32c(&data_without_crc);
+
+    if expectedcrc != controlfile.crc {
+        anyhow::bail!(
+            "invalid CRC in control file: expected {:08X}, was {:08X}",
+            expectedcrc,
+            controlfile.crc
+        );
+    }
+
+    Ok(controlfile)
+}
+
+/// Encode a `ControlFileData` struct into a byte array.
+///
+/// This action is non-portable; it may fail to read data written by other
+/// CPU architectures.
+///
+pub fn encode_pg_control(mut controlfile: ControlFileData) -> Box<[u8]> {
+    let cf_bytes = controlfile.as_bytes();
+
+    // Recompute the CRC
+    let data_without_crc = &cf_bytes[0..OFFSETOF_CRC];
+    let newcrc = crc32c::crc32c(&data_without_crc);
+
+    // Drop the immutable reference so we can modify the struct
+    drop(cf_bytes);
+    controlfile.crc = newcrc;
+
+    // Reacquire the reference so we can produce the output bytes
+    let cf_bytes = controlfile.as_bytes();
+    cf_bytes.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bindgen_bindings;
+    use std::mem::size_of;
+
+    #[test]
+    fn test_struct_compatibility() {
+        // This test could be a lot more exhaustive. It could, for example, fill in
+        // every field with a unique value and then verify that the "mirror" struct
+        // sees the same values in the same locations. That seems like a lot of work,
+        // probably better handled by a proc-macro of some kind.
+
+        assert_eq!(
+            size_of::<ControlFileData>(),
+            size_of::<bindgen_bindings::ControlFileData>()
+        );
+
+        // Do a spot check by assigning the last field.
+        let mut cfd = ControlFileData::default();
+        cfd.crc = 0x12345678;
+
+        // A transmute from struct-with-explicit-padding to struct-with-implicit-padding
+        // should be well-defined behavior; the other way around is probably UB.
+        let cfd_bindgen: &bindgen_bindings::ControlFileData = unsafe { std::mem::transmute(&cfd) };
+        assert_eq!(cfd_bindgen.crc, 0x12345678);
+    }
+}


### PR DESCRIPTION
Fixes #207.

There's more than one possible way to fix the UB coming from `transmute`. This one tries using hand-written structs plus the `zerocopy` crate.

There's some ugliness there: because it's not possible to reinterpret padding bytes as a byte buffer, I added manual padding. No code should ever need to interact with the padding fields, because the `Default` trait is implemented and it's possible to do partial initialization and fall back on `..Default::default()` for everything else.

As long as I'm trying this solution out, push the code to be more idiomatic:
- add placeholders for documentation
- convert `DBState` to an enum (only partially successful)
- convert field names to snake case

Using `serde` might still be an improvement over this, because it would allow us to use a wider range of types while maintaining the same serialization format. But this should be far enough implemented to get a sense of whether we like this or not.