### PR TITLE
[refer #182] Make walkeeper periodically send callme requests to page server

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -343,7 +343,7 @@ impl WalAcceptorNode {
 
         let ps_arg = if self.pass_to_pageserver {
             // Tell page server it can receive WAL from this WAL safekeeper
-            ["--pageserver", "127.0.0.1:64000"].to_vec()
+            ["--pageserver", "127.0.0.1:64000", "--recall", "1 second"].to_vec()
         } else {
             [].to_vec()
         };

--- a/walkeeper/src/bin/wal_acceptor.rs
+++ b/walkeeper/src/bin/wal_acceptor.rs
@@ -54,6 +54,12 @@ fn main() -> Result<()> {
                 .help("interval for keeping WAL as walkeeper node, after which them will be uploaded to S3 and removed locally"),
         )
         .arg(
+            Arg::with_name("recall-period")
+                .long("recall")
+                .takes_value(true)
+                .help("Period for requestion pageserver to call for replication"),
+        )
+        .arg(
             Arg::with_name("daemonize")
                 .short("d")
                 .long("daemonize")
@@ -80,6 +86,7 @@ fn main() -> Result<()> {
         pageserver_addr: None,
         listen_addr: "127.0.0.1:5454".parse()?,
         ttl: None,
+        recall_period: None,
     };
 
     if let Some(dir) = arg_matches.value_of("datadir") {
@@ -107,6 +114,10 @@ fn main() -> Result<()> {
 
     if let Some(ttl) = arg_matches.value_of("ttl") {
         conf.ttl = Some::<Duration>(parse(ttl)?);
+    }
+
+    if let Some(recall) = arg_matches.value_of("recall") {
+        conf.recall_period = Some::<Duration>(parse(recall)?);
     }
 
     start_wal_acceptor(conf)

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -22,4 +22,5 @@ pub struct WalAcceptorConf {
     pub listen_addr: SocketAddr,
     pub pageserver_addr: Option<SocketAddr>,
     pub ttl: Option<Duration>,
+    pub recall_period: Option<Duration>,
 }


### PR DESCRIPTION
Walkeeper tests may hang no because pageserver is bounded to particular walkeepr.
If we stop walkeeper, then we also suspend pageserver's replication channel and it doesn't receive WAL.
As a result get_page@lsn request may wait  infinitely and so block execution of SQL query and test script
which will not be able to restart walkeeper.

One of the possible  solutions is to rewrite tests and always perform start/stop of walkeepers in separate threads.
But it seems to be be useful in real use cases to be able to reconnect pageserver to some other walkeeper if original is crashed and not available. 

In this commit I make walkeeper to periodically send callme requerst to pageserver. If pageserver has already active replication stream, then this query is ignored. Otherwise pageserver should establish replication connection with new walkeeper.
 
