### PR TITLE
Refactor and clean up the decode/encode_pg_control functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1373,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "memoffset",
  "rand",
  "regex",
  "thiserror",

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -7,7 +7,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use fs::File;
-use postgres_ffi::{pg_constants, xlog_utils};
+use postgres_ffi::{controlfile_utils, pg_constants, xlog_utils};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -80,7 +80,7 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
 
     // Read control file to extract the LSN and system id
     let controlfile_path = tmppath.join("global").join("pg_control");
-    let controlfile = postgres_ffi::decode_pg_control(Bytes::from(fs::read(controlfile_path)?))?;
+    let controlfile = controlfile_utils::decode_pg_control(Bytes::from(fs::read(controlfile_path)?))?;
     // let systemid = controlfile.system_identifier;
     let lsn = controlfile.checkPoint;
     let lsnstr = format!("{:016X}", lsn);
@@ -212,7 +212,7 @@ pub(crate) fn get_system_id(conf: &PageServerConf) -> Result<u64> {
 
     let (_, main_snap_dir) = find_latest_snapshot(conf, *main_tli)?;
     let controlfile_path = main_snap_dir.join("global").join("pg_control");
-    let controlfile = postgres_ffi::decode_pg_control(Bytes::from(fs::read(controlfile_path)?))?;
+    let controlfile = controlfile_utils::decode_pg_control(Bytes::from(fs::read(controlfile_path)?))?;
     Ok(controlfile.system_identifier)
 }
 
@@ -356,13 +356,13 @@ fn force_crash_recovery(datadir: &Path) -> Result<()> {
     // Read in the control file
     let controlfilepath = datadir.to_path_buf().join("global").join("pg_control");
     let mut controlfile =
-        postgres_ffi::decode_pg_control(Bytes::from(fs::read(controlfilepath.as_path())?))?;
+        controlfile_utils::decode_pg_control(Bytes::from(fs::read(controlfilepath.as_path())?))?;
 
     controlfile.state = postgres_ffi::DBState_DB_IN_PRODUCTION;
 
     fs::write(
         controlfilepath.as_path(),
-        postgres_ffi::encode_pg_control(controlfile),
+        controlfile_utils::encode_pg_control(controlfile),
     )?;
 
     Ok(())

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use fs::File;
-use postgres_ffi::{controlfile_utils, pg_constants, xlog_utils};
+use postgres_ffi::{pg_constants, xlog_utils, ControlFileData};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -79,7 +79,7 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
 
     // Read control file to extract the LSN and system id
     let controlfile_path = tmppath.join("global").join("pg_control");
-    let controlfile = controlfile_utils::decode_pg_control(&fs::read(controlfile_path)?)?;
+    let controlfile = ControlFileData::decode(&fs::read(controlfile_path)?)?;
     // let systemid = controlfile.system_identifier;
     let lsn = controlfile.checkPoint;
     let lsnstr = format!("{:016X}", lsn);
@@ -211,7 +211,7 @@ pub(crate) fn get_system_id(conf: &PageServerConf) -> Result<u64> {
 
     let (_, main_snap_dir) = find_latest_snapshot(conf, *main_tli)?;
     let controlfile_path = main_snap_dir.join("global").join("pg_control");
-    let controlfile = controlfile_utils::decode_pg_control(&fs::read(controlfile_path)?)?;
+    let controlfile = ControlFileData::decode(&fs::read(controlfile_path)?)?;
     Ok(controlfile.system_identifier)
 }
 
@@ -354,15 +354,11 @@ fn parse_point_in_time(conf: &PageServerConf, s: &str) -> Result<PointInTime> {
 fn force_crash_recovery(datadir: &Path) -> Result<()> {
     // Read in the control file
     let controlfilepath = datadir.to_path_buf().join("global").join("pg_control");
-    let mut controlfile =
-        controlfile_utils::decode_pg_control(&fs::read(controlfilepath.as_path())?)?;
+    let mut controlfile = ControlFileData::decode(&fs::read(controlfilepath.as_path())?)?;
 
     controlfile.state = postgres_ffi::DBState_DB_IN_PRODUCTION;
 
-    fs::write(
-        controlfilepath.as_path(),
-        controlfile_utils::encode_pg_control(&controlfile),
-    )?;
+    fs::write(controlfilepath.as_path(), controlfile.encode())?;
 
     Ok(())
 }

--- a/postgres_ffi/Cargo.toml
+++ b/postgres_ffi/Cargo.toml
@@ -17,6 +17,7 @@ crc32c = "0.6.0"
 hex = "0.4.3"
 lazy_static = "1.4"
 log = "0.4.14"
+memoffset = "0.6.2"
 thiserror = "1.0"
 workspace_hack = { path = "../workspace_hack" }
 

--- a/postgres_ffi/README
+++ b/postgres_ffi/README
@@ -1,3 +1,25 @@
-This module contains utility functions for interacting with PostgreSQL
-file formats.
+This module contains utilities for working with PostgreSQL file
+formats. It's a collection of structs that are auto-generated from the
+PostgreSQL header files using bindgen, and Rust functions to read and
+manipulate them.
 
+There are also a bunch of constants in `pg_constants.rs` that are copied
+from various PostgreSQL headers, rather than auto-generated. They mostly
+should be auto-generated too, but that's a TODO.
+
+The PostgreSQL on-disk file format is not portable across different
+CPU architectures and operating systems. It is also subject to change
+in each major PostgreSQL version. Currently, this module is based on
+PostgreSQL v14, but in the future we will probably need a separate
+copy for each PostgreSQL version.
+
+To interact with the C structs, there is some unsafe code in this
+module. Do not copy-paste that to the rest of the codebase! Keep the
+amount of unsafe code to a minimum, and limited to this module only,
+and only where it's truly needed.
+
+TODO: Currently, there is also some code that deals with WAL records
+in pageserver/src/waldecoder.rs.  That should be moved into this
+module. The rest of the codebase should not have intimate knowledge of
+PostgreSQL file formats or WAL layout, that knowledge should be
+encapsulated in this module.

--- a/postgres_ffi/build.rs
+++ b/postgres_ffi/build.rs
@@ -11,27 +11,36 @@ fn main() {
     // to bindgen, and lets you build up options for
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
-        // The input header we would like to generate
-        // bindings for.
+        //
+        // All the needed PostgreSQL headers are included from 'pg_control_ffi.h'
+        //
         .header("pg_control_ffi.h")
+        //
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
+        //
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        //
+        // These are the types and constants that we want to generate bindings for
+        //
         .whitelist_type("ControlFileData")
         .whitelist_var("PG_CONTROL_FILE_SIZE")
         .whitelist_var("PG_CONTROLFILEDATA_OFFSETOF_CRC")
         .whitelist_type("DBState")
+        //
         // Path the server include dir. It is in tmp_install/include/server, if you did
         // "configure --prefix=<path to tmp_install>". But if you used "configure --prefix=/",
         // and used DESTDIR to move it into tmp_install, then it's in
         // tmp_install/include/postgres/server
         // 'pg_config --includedir-server' would perhaps be the more proper way to find it,
         // but this will do for now.
+        //
         .clang_arg("-I../tmp_install/include/server")
         .clang_arg("-I../tmp_install/include/postgresql/server")
+        //
         // Finish the builder and generate the bindings.
+        //
         .generate()
-        // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.

--- a/postgres_ffi/build.rs
+++ b/postgres_ffi/build.rs
@@ -25,7 +25,6 @@ fn main() {
         //
         .whitelist_type("ControlFileData")
         .whitelist_var("PG_CONTROL_FILE_SIZE")
-        .whitelist_var("PG_CONTROLFILEDATA_OFFSETOF_CRC")
         .whitelist_type("DBState")
         //
         // Path the server include dir. It is in tmp_install/include/server, if you did

--- a/postgres_ffi/pg_control_ffi.h
+++ b/postgres_ffi/pg_control_ffi.h
@@ -6,10 +6,3 @@
  */
 #include "c.h"
 #include "catalog/pg_control.h"
-
-/*
- * PostgreSQL uses "offsetof(ControlFileData, crc)" in multiple places to get the
- * size of the control file up to the CRC, which is the last field, but there is
- * no constant for it. We also need it in the Rust code.
- */
-const uint32 PG_CONTROLFILEDATA_OFFSETOF_CRC = offsetof(ControlFileData, crc);

--- a/postgres_ffi/pg_control_ffi.h
+++ b/postgres_ffi/pg_control_ffi.h
@@ -1,4 +1,15 @@
+/*
+ * This header file is the input to bindgen. It includes all the
+ * PostgreSQL headers that we need to auto-generate Rust structs
+ * from. If you need to expose a new struct to Rust code, add the
+ * header here, and whitelist the struct in the build.rs file.
+ */
 #include "c.h"
 #include "catalog/pg_control.h"
 
+/*
+ * PostgreSQL uses "offsetof(ControlFileData, crc)" in multiple places to get the
+ * size of the control file up to the CRC, which is the last field, but there is
+ * no constant for it. We also need it in the Rust code.
+ */
 const uint32 PG_CONTROLFILEDATA_OFFSETOF_CRC = offsetof(ControlFileData, crc);

--- a/postgres_ffi/src/controlfile_utils.rs
+++ b/postgres_ffi/src/controlfile_utils.rs
@@ -31,93 +31,94 @@ use bytes::{Bytes, BytesMut};
 /// Equivalent to sizeof(ControlFileData) in C
 const SIZEOF_CONTROLDATA: usize = std::mem::size_of::<ControlFileData>();
 
-/// Compute the offset of the `crc` field within the `ControlFileData` struct.
-/// Equivalent to offsetof(ControlFileData, crc) in C.
-// Someday this can be const when the right compiler features land.
-fn pg_control_crc_offset() -> usize {
-    memoffset::offset_of!(ControlFileData, crc)
-}
-
-
-///
-/// Interpret a slice of bytes as a Postgres control file.
-///
-pub fn decode_pg_control(buf: &[u8]) -> Result<ControlFileData> {
-    // Check that the slice has the expected size. The control file is
-    // padded with zeros up to a 512 byte sector size, so accept a
-    // larger size too, so that the caller can just the whole file
-    // contents without knowing the exact size of the struct.
-    if buf.len() < SIZEOF_CONTROLDATA {
-        bail!("control file is too short");
+impl ControlFileData {
+    /// Compute the offset of the `crc` field within the `ControlFileData` struct.
+    /// Equivalent to offsetof(ControlFileData, crc) in C.
+    // Someday this can be const when the right compiler features land.
+    fn pg_control_crc_offset() -> usize {
+        memoffset::offset_of!(ControlFileData, crc)
     }
 
-    // Compute the expected CRC of the content.
-    let OFFSETOF_CRC = pg_control_crc_offset();
-    let expectedcrc = crc32c::crc32c(&buf[0..OFFSETOF_CRC]);
+    ///
+    /// Interpret a slice of bytes as a Postgres control file.
+    ///
+    pub fn decode(buf: &[u8]) -> Result<ControlFileData> {
+        // Check that the slice has the expected size. The control file is
+        // padded with zeros up to a 512 byte sector size, so accept a
+        // larger size too, so that the caller can just the whole file
+        // contents without knowing the exact size of the struct.
+        if buf.len() < SIZEOF_CONTROLDATA {
+            bail!("control file is too short");
+        }
 
-    // Convert the slice into an array of the right size, and use `transmute` to
-    // reinterpret the raw bytes as a ControlFileData struct.
-    //
-    // NB: Ideally we would use 'zerocopy::FromBytes' for this, but bindgen doesn't
-    // derive FromBytes for us. The safety of this depends on the same constraints
-    // as for FromBytes, namely, all of its fields must implement FromBytes. That
-    // includes the primitive integer types, like `u8`, `u16`, `u32`, `u64` and their
-    // signed variants. But `bool` is not safe, because the contents of the high bits
-    // in a rust bool are undefined. In practice, PostgreSQL uses 1 to represent
-    // true and 0 for false, which is compatible with Rust bool, but let's try not to
-    // depend on it.
-    //
-    // FIXME: ControlFileData does contain 'bool's at the moment.
-    //
-    // See https://github.com/zenithdb/zenith/issues/207 for discussion on the safety
-    // of this.
-    let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
-    b.copy_from_slice(&buf[0..SIZEOF_CONTROLDATA]);
-    let controlfile: ControlFileData =
-        unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
+        // Compute the expected CRC of the content.
+        let OFFSETOF_CRC = Self::pg_control_crc_offset();
+        let expectedcrc = crc32c::crc32c(&buf[0..OFFSETOF_CRC]);
 
-    // Check the CRC
-    if expectedcrc != controlfile.crc {
-        bail!(
-            "invalid CRC in control file: expected {:08X}, was {:08X}",
-            expectedcrc,
-            controlfile.crc
-        );
+        // Convert the slice into an array of the right size, and use `transmute` to
+        // reinterpret the raw bytes as a ControlFileData struct.
+        //
+        // NB: Ideally we would use 'zerocopy::FromBytes' for this, but bindgen doesn't
+        // derive FromBytes for us. The safety of this depends on the same constraints
+        // as for FromBytes, namely, all of its fields must implement FromBytes. That
+        // includes the primitive integer types, like `u8`, `u16`, `u32`, `u64` and their
+        // signed variants. But `bool` is not safe, because the contents of the high bits
+        // in a rust bool are undefined. In practice, PostgreSQL uses 1 to represent
+        // true and 0 for false, which is compatible with Rust bool, but let's try not to
+        // depend on it.
+        //
+        // FIXME: ControlFileData does contain 'bool's at the moment.
+        //
+        // See https://github.com/zenithdb/zenith/issues/207 for discussion on the safety
+        // of this.
+        let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
+        b.copy_from_slice(&buf[0..SIZEOF_CONTROLDATA]);
+        let controlfile: ControlFileData =
+            unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
+
+        // Check the CRC
+        if expectedcrc != controlfile.crc {
+            bail!(
+                "invalid CRC in control file: expected {:08X}, was {:08X}",
+                expectedcrc,
+                controlfile.crc
+            );
+        }
+
+        Ok(controlfile)
     }
 
-    Ok(controlfile)
-}
+    ///
+    /// Convert a struct representing a Postgres control file into raw bytes.
+    ///
+    /// The CRC is recomputed to match the contents of the fields.
+    pub fn encode(&self) -> Bytes {
+        //
+        // Use `transmute` to reinterpret struct as raw bytes.
+        //
+        // FIXME: This triggers undefined behavior, because the contents
+        // of the padding bytes are undefined, and this leaks those
+        // undefined bytes into the resulting array. The Rust code won't
+        // care what's in those bytes, and PostgreSQL doesn't care
+        // either. HOWEVER, it is a potential security issue, because the
+        // bytes can contain arbitrary pieces of memory from the page
+        // server. In the worst case, that could be private keys or
+        // another tenant's data.
+        //
+        // See https://github.com/zenithdb/zenith/issues/207 for discussion.
+        let b: [u8; SIZEOF_CONTROLDATA] =
+            unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(*self) };
 
-///
-/// Convert a struct representing a Postgres control file into raw bytes.
-///
-/// The CRC is recomputed to match the contents of the fields.
-pub fn encode_pg_control(controlfile: &ControlFileData) -> Bytes {
-    //
-    // Use `transmute` to reinterpret struct as raw bytes.
-    //
-    // FIXME: This triggers undefined behavior, because the contents
-    // of the padding bytes are undefined, and this leaks those
-    // undefined bytes into the resulting array. The Rust code won't
-    // care what's in those bytes, and PostgreSQL doesn't care
-    // either. HOWEVER, it is a potential security issue, because the
-    // bytes can contain arbitrary pieces of memory from the page
-    // server. In the worst case, that could be private keys or
-    // another tenant's data.
-    //
-    // See https://github.com/zenithdb/zenith/issues/207 for discussion.
-    let b: [u8; SIZEOF_CONTROLDATA] =
-        unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(*controlfile) };
+        // Recompute the CRC
+        let OFFSETOF_CRC = Self::pg_control_crc_offset();
+        let newcrc = crc32c::crc32c(&b[0..OFFSETOF_CRC]);
 
-    // Recompute the CRC
-    let OFFSETOF_CRC = pg_control_crc_offset();
-    let newcrc = crc32c::crc32c(&b[0..OFFSETOF_CRC]);
+        let mut buf = BytesMut::with_capacity(PG_CONTROL_FILE_SIZE as usize);
+        buf.extend_from_slice(&b[0..OFFSETOF_CRC]);
+        buf.extend_from_slice(&newcrc.to_ne_bytes());
+        // Fill the rest of the control file with zeros.
+        buf.resize(PG_CONTROL_FILE_SIZE as usize, 0);
 
-    let mut buf = BytesMut::with_capacity(PG_CONTROL_FILE_SIZE as usize);
-    buf.extend_from_slice(&b[0..OFFSETOF_CRC]);
-    buf.extend_from_slice(&newcrc.to_ne_bytes());
-    // Fill the rest of the control file with zeros.
-    buf.resize(PG_CONTROL_FILE_SIZE as usize, 0);
-
-    buf.into()
+        buf.into()
+    }
 }

--- a/postgres_ffi/src/controlfile_utils.rs
+++ b/postgres_ffi/src/controlfile_utils.rs
@@ -45,14 +45,32 @@ pub fn decode_pg_control(buf: &[u8]) -> Result<ControlFileData> {
     if buf.len() < SIZEOF_CONTROLDATA {
         bail!("control file is too short");
     }
-    let controlfile: ControlFileData;
 
+    // Compute the expected CRC of the content.
+    let expectedcrc = crc32c::crc32c(&buf[0..OFFSETOF_CRC]);
+
+    // Convert the slice into an array of the right size, and use `transmute` to
+    // reinterpret the raw bytes as a ControlFileData struct.
+    //
+    // NB: Ideally we would use 'zerocopy::FromBytes' for this, but bindgen doesn't
+    // derive FromBytes for us. The safety of this depends on the same constraints
+    // as for FromBytes, namely, all of its fields must implement FromBytes. That
+    // includes the primitive integer types, like `u8`, `u16`, `u32`, `u64` and their
+    // signed variants. But `bool` is not safe, because the contents of the high bits
+    // in a rust bool are undefined. In practice, PostgreSQL uses 1 to represent
+    // true and 0 for false, which is compatible with Rust bool, but let's try not to
+    // depend on it.
+    //
+    // FIXME: ControlFileData does contain 'bool's at the moment.
+    //
+    // See https://github.com/zenithdb/zenith/issues/207 for discussion on the safety
+    // of this.
     let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
     b.copy_from_slice(&buf[0..SIZEOF_CONTROLDATA]);
-    let expectedcrc = crc32c::crc32c(&b[0..OFFSETOF_CRC]);
+    let controlfile: ControlFileData =
+        unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
 
-    controlfile = unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
-
+    // Check the CRC
     if expectedcrc != controlfile.crc {
         bail!(
             "invalid CRC in control file: expected {:08X}, was {:08X}",
@@ -69,9 +87,21 @@ pub fn decode_pg_control(buf: &[u8]) -> Result<ControlFileData> {
 ///
 /// The CRC is recomputed to match the contents of the fields.
 pub fn encode_pg_control(controlfile: &ControlFileData) -> Bytes {
-    let b: [u8; SIZEOF_CONTROLDATA];
-
-    b = unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(*controlfile) };
+    //
+    // Use `transmute` to reinterpret struct as raw bytes.
+    //
+    // FIXME: This triggers undefined behavior, because the contents
+    // of the padding bytes are undefined, and this leaks those
+    // undefined bytes into the resulting array. The Rust code won't
+    // care what's in those bytes, and PostgreSQL doesn't care
+    // either. HOWEVER, it is a potential security issue, because the
+    // bytes can contain arbitrary pieces of memory from the page
+    // server. In the worst case, that could be private keys or
+    // another tenant's data.
+    //
+    // See https://github.com/zenithdb/zenith/issues/207 for discussion.
+    let b: [u8; SIZEOF_CONTROLDATA] =
+        unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(*controlfile) };
 
     // Recompute the CRC
     let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
@@ -79,7 +109,6 @@ pub fn encode_pg_control(controlfile: &ControlFileData) -> Bytes {
     let newcrc = crc32c::crc32c(&data_without_crc);
 
     let mut buf = BytesMut::with_capacity(PG_CONTROL_FILE_SIZE as usize);
-
     buf.extend_from_slice(&b[0..OFFSETOF_CRC]);
     buf.extend_from_slice(&newcrc.to_ne_bytes());
     // Fill the rest of the control file with zeros.

--- a/postgres_ffi/src/controlfile_utils.rs
+++ b/postgres_ffi/src/controlfile_utils.rs
@@ -1,3 +1,28 @@
+//!
+//! Utilities for reading and writing the PostgreSQL control file.
+//!
+//! The PostgreSQL control file is one the first things that the PostgreSQL
+//! server reads when it starts up. It indicates whether the server was shut
+//! down cleanly, or if it crashed or was restored from online backup so that
+//! WAL recovery needs to be performed. It also contains a copy of the latest
+//! checkpoint record and its location in the WAL.
+//!
+//! The control file also contains fields for detecting whether the
+//! data directory is compatible with a postgres binary. That includes
+//! a version number, configuration options that can be set at
+//! compilation time like the block size, and the platform's alignment
+//! and endianess information. (The PostgreSQL on-disk file format is
+//! not portable across platforms.)
+//!
+//! The control file is stored in the PostgreSQL data directory, as
+//! `global/pg_control`. The data stored in it is designed to be smaller than
+//! 512 bytes, on the assumption that it can be updated atomically. The actual
+//! file is larger, 8192 bytes, but the rest of it is just filled with zeros.
+//!
+//! See src/include/catalog/pg_control.h in the PostgreSQL sources for more
+//! information. You can use PostgreSQL's pg_controldata utility to view its
+//! contents.
+//!
 use crate::{ControlFileData, PG_CONTROLFILEDATA_OFFSETOF_CRC, PG_CONTROL_FILE_SIZE};
 
 use bytes::{Buf, Bytes, BytesMut};

--- a/postgres_ffi/src/controlfile_utils.rs
+++ b/postgres_ffi/src/controlfile_utils.rs
@@ -1,0 +1,52 @@
+use crate::{ControlFileData, PG_CONTROLFILEDATA_OFFSETOF_CRC, PG_CONTROL_FILE_SIZE};
+
+use bytes::{Buf, Bytes, BytesMut};
+
+// sizeof(ControlFileData)
+const SIZEOF_CONTROLDATA: usize = std::mem::size_of::<ControlFileData>();
+// offsetof(ControlFileData, crc)
+const OFFSETOF_CRC: usize = PG_CONTROLFILEDATA_OFFSETOF_CRC as usize;
+
+pub fn decode_pg_control(mut buf: Bytes) -> Result<ControlFileData, anyhow::Error> {
+    let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
+    buf.copy_to_slice(&mut b);
+
+    let controlfile: ControlFileData;
+
+    // TODO: verify CRC
+    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
+    data_without_crc.copy_from_slice(&b[0..OFFSETOF_CRC]);
+    let expectedcrc = crc32c::crc32c(&data_without_crc);
+
+    controlfile = unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
+
+    if expectedcrc != controlfile.crc {
+        anyhow::bail!(
+            "invalid CRC in control file: expected {:08X}, was {:08X}",
+            expectedcrc,
+            controlfile.crc
+        );
+    }
+
+    Ok(controlfile)
+}
+
+pub fn encode_pg_control(controlfile: ControlFileData) -> Bytes {
+    let b: [u8; SIZEOF_CONTROLDATA];
+
+    b = unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(controlfile) };
+
+    // Recompute the CRC
+    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
+    data_without_crc.copy_from_slice(&b[0..OFFSETOF_CRC]);
+    let newcrc = crc32c::crc32c(&data_without_crc);
+
+    let mut buf = BytesMut::with_capacity(PG_CONTROL_FILE_SIZE as usize);
+
+    buf.extend_from_slice(&b[0..OFFSETOF_CRC]);
+    buf.extend_from_slice(&newcrc.to_ne_bytes());
+    // Fill the rest of the control file with zeros.
+    buf.resize(PG_CONTROL_FILE_SIZE as usize, 0);
+
+    buf.into()
+}

--- a/postgres_ffi/src/lib.rs
+++ b/postgres_ffi/src/lib.rs
@@ -3,56 +3,7 @@
 #![allow(non_snake_case)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+pub mod controlfile_utils;
 pub mod pg_constants;
 pub mod relfile_utils;
 pub mod xlog_utils;
-
-use bytes::{Buf, Bytes, BytesMut};
-
-// sizeof(ControlFileData)
-const SIZEOF_CONTROLDATA: usize = std::mem::size_of::<ControlFileData>();
-const OFFSETOF_CRC: usize = PG_CONTROLFILEDATA_OFFSETOF_CRC as usize;
-
-pub fn decode_pg_control(mut buf: Bytes) -> Result<ControlFileData, anyhow::Error> {
-    let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
-    buf.copy_to_slice(&mut b);
-
-    let controlfile: ControlFileData;
-
-    // TODO: verify CRC
-    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
-    data_without_crc.copy_from_slice(&b[0..OFFSETOF_CRC]);
-    let expectedcrc = crc32c::crc32c(&data_without_crc);
-
-    controlfile = unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
-
-    if expectedcrc != controlfile.crc {
-        anyhow::bail!(
-            "invalid CRC in control file: expected {:08X}, was {:08X}",
-            expectedcrc,
-            controlfile.crc
-        );
-    }
-
-    Ok(controlfile)
-}
-
-pub fn encode_pg_control(controlfile: ControlFileData) -> Bytes {
-    let b: [u8; SIZEOF_CONTROLDATA];
-
-    b = unsafe { std::mem::transmute::<ControlFileData, [u8; SIZEOF_CONTROLDATA]>(controlfile) };
-
-    // Recompute the CRC
-    let mut data_without_crc: [u8; OFFSETOF_CRC] = [0u8; OFFSETOF_CRC];
-    data_without_crc.copy_from_slice(&b[0..OFFSETOF_CRC]);
-    let newcrc = crc32c::crc32c(&data_without_crc);
-
-    let mut buf = BytesMut::with_capacity(PG_CONTROL_FILE_SIZE as usize);
-
-    buf.extend_from_slice(&b[0..OFFSETOF_CRC]);
-    buf.extend_from_slice(&newcrc.to_ne_bytes());
-    // Fill the rest of the control file with zeros.
-    buf.resize(PG_CONTROL_FILE_SIZE as usize, 0);
-
-    buf.into()
-}

--- a/postgres_ffi/src/lib.rs
+++ b/postgres_ffi/src/lib.rs
@@ -13,19 +13,6 @@ use bytes::{Buf, Bytes, BytesMut};
 const SIZEOF_CONTROLDATA: usize = std::mem::size_of::<ControlFileData>();
 const OFFSETOF_CRC: usize = PG_CONTROLFILEDATA_OFFSETOF_CRC as usize;
 
-impl ControlFileData {
-    // Initialize an all-zeros ControlFileData struct
-    pub fn new() -> ControlFileData {
-        let controlfile: ControlFileData;
-
-        let b = [0u8; SIZEOF_CONTROLDATA];
-        controlfile =
-            unsafe { std::mem::transmute::<[u8; SIZEOF_CONTROLDATA], ControlFileData>(b) };
-
-        controlfile
-    }
-}
-
 pub fn decode_pg_control(mut buf: Bytes) -> Result<ControlFileData, anyhow::Error> {
     let mut b: [u8; SIZEOF_CONTROLDATA] = [0u8; SIZEOF_CONTROLDATA];
     buf.copy_to_slice(&mut b);

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -1,6 +1,11 @@
 //!
 //! Misc constants, copied from PostgreSQL headers.
 //!
+//! TODO: These probably should be auto-generated using bindgen,
+//! rather than copied by hand. Although on the other hand, it's nice
+//! to have them all here in one place, and have the ability to add
+//! comments on them.
+//!
 
 //
 // From pg_tablespace_d.h


### PR DESCRIPTION
See commit messages.

This tries to document the transmute issues (https://github.com/zenithdb/zenith/issues/207) in code comments. How to solve that is a separate discussion, but let's at least add warnings to the code about it, until it's fixed.