### PR TITLE
Change behavior of ComputeControlPlane::new_node()

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -151,8 +151,11 @@ impl ComputeControlPlane {
         node.append_conf(
             "postgresql.conf",
             format!(
-                "shared_preload_libraries = zenith\n\
-                zenith.callmemaybe_connstring = '{}'\n", // FIXME escaping
+                concat!(
+                    "shared_preload_libraries = zenith\n",
+                    "synchronous_standby_names = 'pageserver'\n", // TODO: add a new function arg?
+                    "zenith.callmemaybe_connstring = '{}'\n", // FIXME escaping
+                ),
                 node.connstr()
             )
             .as_str(),

--- a/test_runner/batch_others/test_restart_compute.py
+++ b/test_runner/batch_others/test_restart_compute.py
@@ -1,5 +1,4 @@
 import psycopg2
-import time
 
 pytest_plugins = ("fixtures.zenith_fixtures")
 
@@ -37,13 +36,6 @@ def test_restart_compute(zenith_cli, pageserver, postgres, pg_bin):
     cur.execute("INSERT INTO foo VALUES ('bar2')")
     cur.execute('SELECT count(*) FROM foo')
     assert cur.fetchone() == (2, )
-
-    # FIXME: Currently, there is no guarantee that by the time the INSERT commits, the WAL
-    # has been streamed safely to the WAL safekeeper or page server. It is merely stored
-    # on the Postgres instance's local disk. Sleep a little, to give it time to be
-    # streamed. This should be removed, when we have the ability to run the Postgres
-    # instance -> safekeeper streaming in synchronous mode.
-    time.sleep(5)
 
     # Stop, and destroy the Postgres instance. Then recreate and restart it.
     pg_conn.close()


### PR DESCRIPTION
Previously, transaction commit could happen regardless of whether
pageserver has caught up or not. This patch aims to fix that.

There are two notable changes:

1. ComputeControlPlane::new_node() now sets the
`synchronous_standby_names = 'pageserver'` parameter to delay
transaction commit until pageserver acting as a standby has
fetched and ack'd a relevant portion of WAL.

2. pageserver now has to:
    - Specify the `application_name = pageserver` which matches the
    one in `synchronous_standby_names`.
    - Properly reply with the ack'd LSNs.

TODO: We should probably make this behavior configurable.

Fixes #187.