### PR TITLE
Use xlog utils in waldecoder

### DIFF
--- a/pageserver/src/waldecoder.rs
+++ b/pageserver/src/waldecoder.rs
@@ -19,27 +19,6 @@ pub type MultiXactId = TransactionId;
 pub type MultiXactOffset = u32;
 pub type MultiXactStatus = u32;
 
-// From PostgreSQL headers
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct XLogPageHeaderData {
-    xlp_magic: u16,    /* magic value for correctness checks */
-    xlp_info: u16,     /* flag bits, see below */
-    xlp_tli: u32,      /* TimeLineID of first record on page */
-    xlp_pageaddr: u64, /* XLOG address of this page */
-    xlp_rem_len: u32,  /* total len of remaining data for record */
-}
-
-#[repr(C)]
-#[derive(Debug)]
-pub struct XLogLongPageHeaderData {
-    std: XLogPageHeaderData, /* standard header fields */
-    xlp_sysid: u64,          /* system identifier from pg_control */
-    xlp_seg_size: u32,       /* just as a cross-check */
-    xlp_xlog_blcksz: u32,    /* just as a cross-check */
-}
-
 #[allow(dead_code)]
 pub struct WalStreamDecoder {
     lsn: Lsn,

--- a/postgres_ffi/src/xlog_utils.rs
+++ b/postgres_ffi/src/xlog_utils.rs
@@ -292,3 +292,22 @@ impl XLogRecord {
         self.xl_info == pg_constants::XLOG_SWITCH && self.xl_rmid == pg_constants::RM_XLOG_ID
     }
 }
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct XLogPageHeaderData {
+    pub xlp_magic: u16,    /* magic value for correctness checks */
+    pub xlp_info: u16,     /* flag bits, see below */
+    pub xlp_tli: u32,      /* TimeLineID of first record on page */
+    pub xlp_pageaddr: u64, /* XLOG address of this page */
+    pub xlp_rem_len: u32,  /* total len of remaining data for record */
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct XLogLongPageHeaderData {
+    pub std: XLogPageHeaderData, /* standard header fields */
+    pub xlp_sysid: u64,          /* system identifier from pg_control */
+    pub xlp_seg_size: u32,       /* just as a cross-check */
+    pub xlp_xlog_blcksz: u32,    /* just as a cross-check */
+}

--- a/postgres_ffi/src/xlog_utils.rs
+++ b/postgres_ffi/src/xlog_utils.rs
@@ -301,7 +301,22 @@ pub struct XLogPageHeaderData {
     pub xlp_tli: u32,      /* TimeLineID of first record on page */
     pub xlp_pageaddr: u64, /* XLOG address of this page */
     pub xlp_rem_len: u32,  /* total len of remaining data for record */
+    padding: u32,          /* Add explicit padding */
 }
+
+impl XLogPageHeaderData {
+    pub fn from_bytes<B: Buf>(buf: &mut B) -> XLogPageHeaderData {
+        XLogPageHeaderData {
+            xlp_magic: buf.get_u16_le(),
+            xlp_info: buf.get_u16_le(),
+            xlp_tli: buf.get_u32_le(),
+            xlp_pageaddr: buf.get_u64_le(),
+            xlp_rem_len: buf.get_u32_le(),
+            padding: buf.get_u32_le(),
+        }
+    }
+}
+
 
 #[repr(C)]
 #[derive(Debug)]
@@ -310,4 +325,15 @@ pub struct XLogLongPageHeaderData {
     pub xlp_sysid: u64,          /* system identifier from pg_control */
     pub xlp_seg_size: u32,       /* just as a cross-check */
     pub xlp_xlog_blcksz: u32,    /* just as a cross-check */
+}
+
+impl XLogLongPageHeaderData {
+    pub fn from_bytes<B: Buf>(buf: &mut B) -> XLogLongPageHeaderData {
+        XLogLongPageHeaderData {
+            std: XLogPageHeaderData::from_bytes(buf),
+            xlp_sysid: buf.get_u64_le(),
+            xlp_seg_size: buf.get_u32_le(),
+            xlp_xlog_blcksz: buf.get_u32_le(),
+        }
+    }
 }


### PR DESCRIPTION
I am refactoring code for #220 and #228

If no one objects, I'd prefer to do it in small and quick PRs, rather than one huge commit.
This is the first one, that cleans code in waldecoder.rs.