### PR TITLE
Use named structs in object store iterators

### DIFF
--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -757,7 +757,7 @@ struct ObjectHistory<'a> {
     last_relation_size: Option<(BufferTag, u32)>,
 }
 
-impl<'a> Iterator for ObjectHistory<'a> {
+impl Iterator for ObjectHistory<'_> {
     type Item = Result<RelationUpdate>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -765,13 +765,13 @@ impl<'a> Iterator for ObjectHistory<'a> {
     }
 }
 
-impl<'a> History for ObjectHistory<'a> {
+impl History for ObjectHistory<'_> {
     fn lsn(&self) -> Lsn {
         self.lsn
     }
 }
 
-impl<'a> ObjectHistory<'a> {
+impl ObjectHistory<'_> {
     fn handle_relation_size(
         &mut self,
         buf_tag: BufferTag,

--- a/pageserver/src/object_store.rs
+++ b/pageserver/src/object_store.rs
@@ -65,13 +65,13 @@ pub trait ObjectStore: Send + Sync {
     ///
     /// Returns all page versions in descending LSN order, along with the LSN
     /// of each page version.
-    fn object_versions<'a>(&'a self, key: &ObjectKey, lsn: Lsn) -> Result<Box<ObjectsIter<'a>>>;
+    fn object_versions(&self, key: &ObjectKey, lsn: Lsn) -> Result<Box<ObjectsIter>>;
 
     /// Iterate through versions of all objects in a timeline.
     ///
     /// Returns objects in increasing key-version order.
     /// Returns all versions up to and including the specified LSN.
-    fn objects<'a>(&'a self, timeline: ZTimelineId, lsn: Lsn) -> Result<Box<AllObjectsIter<'a>>>;
+    fn objects(&self, timeline: ZTimelineId, lsn: Lsn) -> Result<Box<AllObjectsIter>>;
 
     /// Iterate through all keys with given tablespace and database ID, and LSN <= 'lsn'.
     /// Both dbnode and spcnode can be InvalidId (0) which means get all relations in tablespace/cluster

--- a/pageserver/src/rocksdb_storage.rs
+++ b/pageserver/src/rocksdb_storage.rs
@@ -183,7 +183,7 @@ impl ObjectStore for RocksObjectStore {
     ///
     /// Returns objects in increasing key-version order.
     /// Returns all versions up to and including the specified LSN.
-    fn objects<'a>(&'a self, timeline: ZTimelineId, lsn: Lsn) -> Result<Box<AllObjectsIter<'a>>> {
+    fn objects(&self, timeline: ZTimelineId, lsn: Lsn) -> Result<Box<AllObjectsIter<'_>>> {
         let start_key = StorageKey::timeline_start(timeline);
         let start_key_bytes = StorageKey::ser(&start_key)?;
         let iter = self.db.iterator(rocksdb::IteratorMode::From(


### PR DESCRIPTION
Clippy was complaining about the complexity of the following type, and I agree it's pretty intimidating:
`Box<dyn Iterator<Item = Result<(BufferTag, Lsn, Vec<u8>)>> + 'a>>`

Make the iterators returned by `object_versions` and `objects` return iterators over structs (called `ObjectVersion` and `ObjectAny`, and make type aliases for the `dyn Iterator<...>` that uses them.

I'm unsure about the names. `ObjectVersion` seems pretty straightforward, but I'm not sure what to call the other one, which contains the `BufferTag` as well.

While here, I also made the `value` field a `Box<[u8]>` instead of a `Vec<u8>` because the data is probably immutable.

Clippy then pointed out that I could remove some of the lifetime annotations, so I did that too.