### PR TITLE
Minor clippy fixes; add shell script for running clippy with select lints disabled.

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -458,7 +458,8 @@ impl postgres_backend::Handler for PageServerHandler {
                 .parse()?;
             let timeline = page_cache::get_repository().get_timeline(timeline_id)?;
 
-            let postgres_connection_uri = it.next().ok_or(anyhow!("missing postgres uri"))?;
+            let postgres_connection_uri =
+                it.next().ok_or_else(|| anyhow!("missing postgres uri"))?;
 
             let mut conn = postgres::Client::connect(postgres_connection_uri, postgres::NoTls)?;
             let mut copy_in = conn.copy_in(format!("push {}", timeline_id.to_string()).as_str())?;

--- a/pageserver/src/rocksdb_storage.rs
+++ b/pageserver/src/rocksdb_storage.rs
@@ -68,7 +68,7 @@ impl GarbageCollector {
     fn was_deleted(&self, key: &[u8]) -> bool {
         let key = key.to_vec();
         let mut garbage = self.garbage.lock().unwrap();
-        return garbage.remove(&key);
+        garbage.remove(&key)
     }
 }
 
@@ -198,9 +198,9 @@ impl ObjectStore for RocksObjectStore {
         ));
 
         Ok(Box::new(RocksObjects {
+            iter,
             timeline,
             lsn,
-            iter,
         }))
     }
 }

--- a/run_clippy.sh
+++ b/run_clippy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# If you save this in your path under the name "cargo-zclippy" (or whatever
+# name you like), then you can run it as "cargo zclippy" from the shell prompt.
+#
+# If your text editor has rust-analyzer integration, you can also use this new
+# command as a replacement for "cargo check" or "cargo clippy" and see clippy
+# warnings and errors right in the editor.
+# In vscode, this setting is Rust-analyzer>Check On Save:Command
+
+cargo clippy "${@:2}" -- -A clippy::new_without_default -A clippy::manual_range_contains -A clippy::comparison_chain

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -93,10 +93,9 @@ impl FeMessage {
         let len = stream.read_u32::<BE>()?;
 
         // The message length includes itself, so it better be at least 4
-        let bodylen = len.checked_sub(4).ok_or(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "invalid message length: parsing u32",
-        ))?;
+        let bodylen = len
+            .checked_sub(4)
+            .ok_or_else(|| anyhow!("invalid message length: parsing u32"))?;
 
         // Read message body
         let mut body_buf: Vec<u8> = vec![0; bodylen as usize];


### PR DESCRIPTION
Minor clippy fixes:

Nothing controversial here, though I finally got sick of the tui_event nag so I annotated that code to suppress the clippy warning.

Add a clippy shell script:

The clippy maintainers have not provided an easy way for projects to configure the set of lints they would like enabled/disabled. It's particularly bad for projects using workspaces, which can easily lead to duplicated clippy annotations for every crate, library, binary, etc.
    
The shell script runs clippy, with a few unhelpful lints disabled:
```text
new_without_default
manual_range_contains
comparison_chain
```
