### PR TITLE
Fix compilation with Rust versions < 1.50

### DIFF
--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -245,7 +245,11 @@ fn walreceiver_main(
                     reply_requested,
                 );
 
-                reply_requested.then(|| timeline.get_last_valid_lsn())
+                if reply_requested {
+                    Some(timeline.get_last_valid_lsn())
+                } else {
+                    None
+                }
             }
 
             _ => None,


### PR DESCRIPTION
The bool::then function was added in Rust 1.50. I'm still using 1.48 on
my laptop. We haven't decided what Rust version we will require
(https://github.com/zenithdb/zenith/issues/138), and I'll probably need
to upgrade sooner or later, but this will do for now.