### PR TITLE
Use ObjectTag enum instead of special fork number to store metadata objects.

### DIFF
--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 pub mod basebackup;
 pub mod branches;
+pub mod object_key;
 pub mod object_repository;
 pub mod object_store;
 pub mod page_cache;

--- a/pageserver/src/object_key.rs
+++ b/pageserver/src/object_key.rs
@@ -1,0 +1,27 @@
+use crate::repository::{BufferTag, RelTag};
+use crate::ZTimelineId;
+use serde::{Deserialize, Serialize};
+
+///
+/// ObjectKey is the key type used to identify objects stored in an object
+/// repository. It is shared between object_repository.rs and object_store.rs.
+/// It is mostly opaque to ObjectStore, it just stores and retrieves objects
+/// using the key given by the caller.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectKey {
+    pub timeline: ZTimelineId,
+    pub tag: ObjectTag,
+}
+
+/// ObjectTag is a part of ObjectKey that is specific to the type of
+/// the stored object.
+///
+/// NB: the order of the enum values is significant!  In particular,
+/// rocksdb_storage.rs assumes that TimelineMetadataTag is first
+///
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ObjectTag {
+    TimelineMetadataTag,
+    RelationMetadata(RelTag),
+    RelationBuffer(BufferTag),
+}

--- a/pageserver/src/object_store.rs
+++ b/pageserver/src/object_store.rs
@@ -1,18 +1,12 @@
 //! Low-level key-value storage abstraction.
 //!
-use crate::repository::{BufferTag, RelTag};
+use crate::object_key::*;
+use crate::repository::RelTag;
 use crate::ZTimelineId;
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::iter::Iterator;
 use zenith_utils::lsn::Lsn;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ObjectKey {
-    pub timeline: ZTimelineId,
-    pub buf_tag: BufferTag,
-}
 
 ///
 /// Low-level storage abstraction.
@@ -58,7 +52,7 @@ pub trait ObjectStore: Send + Sync {
         &'a self,
         timeline: ZTimelineId,
         lsn: Lsn,
-    ) -> Result<Box<dyn Iterator<Item = Result<(BufferTag, Lsn, Vec<u8>)>> + 'a>>;
+    ) -> Result<Box<dyn Iterator<Item = Result<(ObjectTag, Lsn, Vec<u8>)>> + 'a>>;
 
     /// Iterate through all keys with given tablespace and database ID, and LSN <= 'lsn'.
     /// Both dbnode and spcnode can be InvalidId (0) which means get all relations in tablespace/cluster

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -21,8 +21,6 @@ pub const FSM_FORKNUM: u8 = 1;
 pub const VISIBILITYMAP_FORKNUM: u8 = 2;
 pub const INIT_FORKNUM: u8 = 3;
 
-pub const ROCKSDB_SPECIAL_FORKNUM: u8 = 50;
-
 // From storage_xlog.h
 pub const SMGR_TRUNCATE_HEAP: u32 = 0x0001;
 pub const SMGR_TRUNCATE_VM: u32 = 0x0002;


### PR DESCRIPTION
Extracted from Konstantin's larger PR:
https://github.com/zenithdb/zenith/pull/268