### PR TITLE
Preliminary push test

### DIFF
--- a/test_runner/batch_others/test_push.py
+++ b/test_runner/batch_others/test_push.py
@@ -1,0 +1,28 @@
+from contextlib import closing
+import json
+
+pytest_plugins = ("fixtures.zenith_fixtures")
+
+
+def test_push(zenith_cli, pageserver, postgres, standalone_pageserver):
+    zenith_cli.run(['branch', 'test_push', 'empty'])
+
+    pg = postgres.create_start('test_push')
+
+    with closing(pg.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute('CREATE DATABASE foodb')
+
+    # TODO push by name instead of timeline id
+    with closing(pageserver.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute('branch_list')
+            branches = json.loads(cur.fetchone()[0])
+    branches = {branch['name']: branch for branch in branches}
+    timeline_id = bytearray(branches['test_push']['timeline_id']).hex()
+
+    zenith_cli.run(['remote', 'add', 'standalone', 'postgresql://127.0.0.1:64001'])
+
+    zenith_cli.run(['push', timeline_id, 'standalone'])
+
+    # TODO verify the presence of test_push on the standalone pageserver


### PR DESCRIPTION
Currently, this test isn't able to observe the new timeline/branch on the standalone pageserver.

A future PR should update the branch information upon push, so that the branch can be seen by `pg list` and our test.
We will also want to be able to push using branch names.

I'm not sure the standalone pageserver is the right fixture. Being able to control many CLIs seems more powerful.