### PR TITLE
Fix command tag returned to client on IDENTIFY_SYSTEM command.

### DIFF
--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -104,7 +104,7 @@ impl SendWalHandler {
             Some(lsn_bytes),
             None,
         ]))?
-        .write_message(&BeMessage::CommandComplete(b"IDENTIFY_SYSTEM"))?;
+        .write_message(&BeMessage::CommandComplete(b"SELECT 1"))?;
         Ok(())
     }
 }


### PR DESCRIPTION
It's like a SELECT that returns one row.