### PR TITLE
WIP basebackup.rs refactoring

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -141,6 +141,7 @@ impl<'a> Basebackup<'a> {
 
     //
     // Extract pg_filenode.map files from repository
+    // Along with them also send PG_VERSION for each database.
     //
     fn add_relmap_file(&mut self, tag: &ObjectTag, db: &DatabaseTag) -> anyhow::Result<()> {
         let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
@@ -148,6 +149,7 @@ impl<'a> Basebackup<'a> {
         let path = if db.spcnode == pg_constants::GLOBALTABLESPACE_OID {
 
             let dst_path = format!("PG_VERSION");
+            //TODO fix hardcoded value. Get this version num somewhere
             let data = "14".as_bytes();
             let header = new_tar_header(&dst_path, data.len() as u64)?;
             self.ar.append(&header, &data[..])?;
@@ -165,6 +167,7 @@ impl<'a> Basebackup<'a> {
             // Append dir path for each database
             let path = format!("base/{}", db.dbnode);
             let fullpath = std::path::Path::new(&self.snappath).join(path.clone());
+
             //FIXME It's a hack to send dir with append_dir()
             info!("create dir before {:?}", fullpath.clone());
             fs::create_dir_all(fullpath.clone())?;

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -15,9 +15,9 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tar::{Builder, Header};
+use std::fs;
 
 use crate::repository::{DatabaseTag, ObjectTag, Timeline};
-use postgres_ffi::relfile_utils::*;
 use postgres_ffi::xlog_utils::*;
 use postgres_ffi::*;
 use zenith_utils::lsn::Lsn;
@@ -161,6 +161,17 @@ impl<'a> Basebackup<'a> {
         } else {
             // User defined tablespaces are not supported
             assert!(db.spcnode == pg_constants::DEFAULTTABLESPACE_OID);
+
+            // Append dir path for each database
+            let path = format!("base/{}", db.dbnode);
+            let fullpath = std::path::Path::new(&self.snappath).join(path.clone());
+            //FIXME It's a hack to send dir with append_dir()
+            info!("create dir before {:?}", fullpath.clone());
+            fs::create_dir_all(fullpath.clone())?;
+            info!("create dir {:?}", fullpath.clone());
+            self.ar.append_dir(path, fullpath.clone())?;
+            info!("append dir done {:?}", fullpath.clone());
+
             let dst_path = format!("base/{}/PG_VERSION", db.dbnode);
             let data = "14".as_bytes();
             let header = new_tar_header(&dst_path, data.len() as u64)?;

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -15,7 +15,6 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tar::{Builder, Header};
-use walkdir::WalkDir;
 
 use crate::repository::{DatabaseTag, ObjectTag, Timeline};
 use postgres_ffi::relfile_utils::*;
@@ -58,39 +57,14 @@ impl<'a> Basebackup<'a> {
     #[rustfmt::skip] // otherwise "cargo fmt" produce very strange formatting for macch arms of self.timeline.list_nonrels
     pub fn send_tarball(&mut self) -> anyhow::Result<()> {
         debug!("sending tarball of snapshot in {}", self.snappath);
-        for entry in WalkDir::new(&self.snappath) {
-            let entry = entry?;
-            let fullpath = entry.path();
-            let relpath = entry.path().strip_prefix(&self.snappath).unwrap();
 
-            if relpath.to_str().unwrap() == "" {
-                continue;
-            }
-
-            if entry.file_type().is_dir() {
-                trace!(
-                    "sending dir {} as {}",
-                    fullpath.display(),
-                    relpath.display()
-                );
-                self.ar.append_dir(relpath, fullpath)?;
-            } else if entry.file_type().is_symlink() {
-                error!("ignoring symlink in snapshot dir");
-            } else if entry.file_type().is_file() {
-                if !is_rel_file_path(relpath.to_str().unwrap()) {
-                    if entry.file_name() != "pg_filenode.map" // this files will be generated from object storage
-                        && !relpath.starts_with("pg_xact/")
-                        && !relpath.starts_with("pg_multixact/")
-                    {
-                        trace!("sending {}", relpath.display());
-                        self.ar.append_path_with_name(fullpath, relpath)?;
-                    }
-                } else {  // relation pages are loaded on demand and should not be included in tarball
-                    trace!("not sending {}", relpath.display());
-                }
-            } else {
-                error!("unknown file type: {}", fullpath.display());
-            }
+        // We need a few config files to start compute node and now we don't store/generate them in pageserver.
+        // So we preserve them in snappath directory at zenith-init.
+        // FIXME this is a temporary hack. Config files should be handled by some other service.
+        for i in 0..pg_constants::PGDATA_SPECIAL_FILES.len()
+        {
+            let path = pg_constants::PGDATA_SPECIAL_FILES[i];
+            self.ar.append_path_with_name(std::path::Path::new(&self.snappath).join(path), path)?;
         }
 
         // Generate non-relational files.
@@ -172,13 +146,26 @@ impl<'a> Basebackup<'a> {
         let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
         info!("add_relmap_file {:?}", db);
         let path = if db.spcnode == pg_constants::GLOBALTABLESPACE_OID {
+
+            let dst_path = format!("PG_VERSION");
+            let data = "14".as_bytes();
+            let header = new_tar_header(&dst_path, data.len() as u64)?;
+            self.ar.append(&header, &data[..])?;
+
+            let dst_path = format!("global/PG_VERSION");
+            let data = "14".as_bytes();
+            let header = new_tar_header(&dst_path, data.len() as u64)?;
+            self.ar.append(&header, &data[..])?;
+
             String::from("global/pg_filenode.map") // filenode map for global tablespace
         } else {
             // User defined tablespaces are not supported
             assert!(db.spcnode == pg_constants::DEFAULTTABLESPACE_OID);
-            let src_path = format!("{}/base/1/PG_VERSION", self.snappath);
             let dst_path = format!("base/{}/PG_VERSION", db.dbnode);
-            self.ar.append_path_with_name(&src_path, &dst_path)?;
+            let data = "14".as_bytes();
+            let header = new_tar_header(&dst_path, data.len() as u64)?;
+            self.ar.append(&header, &data[..])?;
+
             format!("base/{}/pg_filenode.map", db.dbnode)
         };
         assert!(img.len() == 512);
@@ -260,59 +247,63 @@ impl<'a> Basebackup<'a> {
     }
 }
 
-///
-/// Parse a path, relative to the root of PostgreSQL data directory, as
-/// a PostgreSQL relation data file.
-///
-fn parse_rel_file_path(path: &str) -> Result<(), FilePathError> {
-    /*
-     * Relation data files can be in one of the following directories:
-     *
-     * global/
-     *		shared relations
-     *
-     * base/<db oid>/
-     *		regular relations, default tablespace
-     *
-     * pg_tblspc/<tblspc oid>/<tblspc version>/
-     *		within a non-default tablespace (the name of the directory
-     *		depends on version)
-     *
-     * And the relation data files themselves have a filename like:
-     *
-     * <oid>.<segment number>
-     */
-    if let Some(fname) = path.strip_prefix("global/") {
-        let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
+// -------------- TODO move this code to relfile_utils.rs or remove
 
-        Ok(())
-    } else if let Some(dbpath) = path.strip_prefix("base/") {
-        let mut s = dbpath.split('/');
-        let dbnode_str = s.next().ok_or(FilePathError::InvalidFileName)?;
-        let _dbnode = dbnode_str.parse::<u32>()?;
-        let fname = s.next().ok_or(FilePathError::InvalidFileName)?;
-        if s.next().is_some() {
-            return Err(FilePathError::InvalidFileName);
-        };
+// ///
+// /// Parse a path, relative to the root of PostgreSQL data directory, as
+// /// a PostgreSQL relation data file.
+// ///
+// fn parse_rel_file_path(path: &str) -> Result<(), FilePathError> {
+//     /*
+//      * Relation data files can be in one of the following directories:
+//      *
+//      * global/
+//      *		shared relations
+//      *
+//      * base/<db oid>/
+//      *		regular relations, default tablespace
+//      *
+//      * pg_tblspc/<tblspc oid>/<tblspc version>/
+//      *		within a non-default tablespace (the name of the directory
+//      *		depends on version)
+//      *
+//      * And the relation data files themselves have a filename like:
+//      *
+//      * <oid>.<segment number>
+//      */
+//     if let Some(fname) = path.strip_prefix("global/") {
+//         let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
 
-        let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
+//         Ok(())
+//     } else if let Some(dbpath) = path.strip_prefix("base/") {
+//         let mut s = dbpath.split('/');
+//         let dbnode_str = s.next().ok_or(FilePathError::InvalidFileName)?;
+//         let _dbnode = dbnode_str.parse::<u32>()?;
+//         let fname = s.next().ok_or(FilePathError::InvalidFileName)?;
+//         if s.next().is_some() {
+//             return Err(FilePathError::InvalidFileName);
+//         };
 
-        Ok(())
-    } else if path.strip_prefix("pg_tblspc/").is_some() {
-        // TODO
-        error!("tablespaces not implemented yet");
-        Err(FilePathError::InvalidFileName)
-    } else {
-        Err(FilePathError::InvalidFileName)
-    }
-}
+//         let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
 
-//
-// Check if it is relational file
-//
-fn is_rel_file_path(path: &str) -> bool {
-    parse_rel_file_path(path).is_ok()
-}
+//         Ok(())
+//     } else if path.strip_prefix("pg_tblspc/").is_some() {
+//         // TODO
+//         error!("tablespaces not implemented yet");
+//         Err(FilePathError::InvalidFileName)
+//     } else {
+//         Err(FilePathError::InvalidFileName)
+//     }
+// }
+
+// //
+// // Check if it is relational file
+// //
+// fn is_rel_file_path(path: &str) -> bool {
+//     parse_rel_file_path(path).is_ok()
+// }
+
+// ---------------
 
 //
 // Create new tarball entry header

--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -140,6 +140,7 @@ impl Repository for ObjectRepository {
     fn branch_timeline(&self, src: ZTimelineId, dst: ZTimelineId, at_lsn: Lsn) -> Result<()> {
         let src_timeline = self.get_timeline(src)?;
 
+        trace!("branch_timeline at lsn {}", at_lsn);
         // Write a metadata key, noting the ancestor of th new timeline. There is initially
         // no data in it, but all the read-calls know to look into the ancestor.
         let metadata = MetadataEntry {
@@ -156,6 +157,8 @@ impl Repository for ObjectRepository {
         )?;
 
         // Copy non-rel objects
+        // TODO Why do we need to copy them into new branch?
+        // Can't we just look for them in timeline's ancestor.
         for tag in src_timeline.list_nonrels(at_lsn)? {
             match tag {
                 ObjectTag::TimelineMetadataTag => {} // skip it

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -184,3 +184,38 @@ pub const XLOG_BLCKSZ: usize = 8192;
 pub const XLOG_CHECKPOINT_SHUTDOWN: u8 = 0x00;
 pub const XLOG_CHECKPOINT_ONLINE: u8 = 0x10;
 pub const XLP_LONG_HEADER: u16 = 0x0002;
+
+
+pub const PGDATA_SUBDIRS: [&'static str; 22] =
+[
+    "global",
+	"pg_wal/archive_status",
+	"pg_commit_ts",
+	"pg_dynshmem",
+	"pg_notify",
+	"pg_serial",
+	"pg_snapshots",
+	"pg_subtrans",
+	"pg_twophase",
+	"pg_multixact",
+	"pg_multixact/members",
+	"pg_multixact/offsets",
+	"base",
+	"base/1",
+	"pg_replslot",
+	"pg_tblspc",
+	"pg_stat",
+	"pg_stat_tmp",
+	"pg_xact",
+	"pg_logical",
+	"pg_logical/snapshots",
+	"pg_logical/mappings"
+];
+
+pub const PGDATA_SPECIAL_FILES: [&'static str; 4] =
+[
+    "pg_hba.conf",
+    "pg_ident.conf",
+    "postgresql.conf",
+    "postgresql.auto.conf"
+];


### PR DESCRIPTION
Attempt to straighten up basebackup code. This code will be used in `export` command and I want to get rid of some hacks, while on it.
The goal is to avoid copying pgdata to snapshot/ subdir and generate all files needed for compute node bootstrap on-the-fly.

Special treatment is needed for:
1. subdir structure - generated on the fly
2. PG_VERSION files - generated on the fly
3. config files (see list in pg_constants::PGDATA_SPECIAL_FILES). Now these are preserved in snapshot/ subdir.
Any ideas on how we should handle them are welcome.

4. critical index files - they are stored in pageserver and can be gathered like non_rel files. 
It passes simple tests, but fails on createdb (all regression tests that use create db also fail) with following error:
`TRCE relation 1663/14012/2662 not found; it was dropped at lsn 0/16F3B71`. And I don't understand why.
@knizhnik , could you take a look, please?