### PR TITLE
Zenith init from pgdata

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -41,16 +41,27 @@ impl PageServerNode {
         }
     }
 
-    pub fn init(&self) -> Result<()> {
+    pub fn init(&self, snapshot_path: Option<&str>) -> Result<()> {
         let mut cmd = Command::new(self.env.pageserver_bin()?);
+
+        let mut args_vec: Vec<&str> = vec![ "--init",
+            "-D",
+            self.env.base_data_dir.to_str().unwrap(),
+            "--postgres-distrib",
+            self.env.pg_distrib_dir.to_str().unwrap()];
+
+        match snapshot_path
+        {
+            Some(init_pgdata_path) =>
+            {
+                args_vec.push("--init_pgdata_path");
+                args_vec.push(init_pgdata_path);
+            },
+            None => {}
+        };
+
         let status = cmd
-            .args(&[
-                "--init",
-                "-D",
-                self.env.base_data_dir.to_str().unwrap(),
-                "--postgres-distrib",
-                self.env.pg_distrib_dir.to_str().unwrap(),
-            ])
+            .args(&args_vec)
             .env_clear()
             .env("RUST_BACKTRACE", "1")
             .status()

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -136,6 +136,12 @@ fn main() -> Result<()> {
                 .help("Initialize pageserver repo"),
         )
         .arg(
+            Arg::with_name("init_pgdata_path")
+                .long("init_pgdata_path")
+                .takes_value(true)
+                .help("Source pgdata to initialize pageserver repo from"),
+        )
+        .arg(
             Arg::with_name("gc_horizon")
                 .long("gc_horizon")
                 .takes_value(true)
@@ -201,7 +207,9 @@ fn main() -> Result<()> {
 
     // Create repo and exit if init was requested
     if init {
-        branches::init_repo(conf, &workdir)?;
+        let init_pgdata_path = arg_matches.value_of("init_pgdata_path");
+
+        branches::init_repo(conf, &workdir, init_pgdata_path)?;
 
         // write the config file
         let cfg_file_contents = toml::to_string_pretty(&params)?;

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -96,7 +96,26 @@ fn init_from_repo(conf: &'static PageServerConf,
 {
     let pgdata_path = match init_pgdata_path
     {
-        Some(init_pgdata_path) => std::path::Path::new(init_pgdata_path),
+        Some(init_pgdata_path) =>
+        {
+            let mut s = init_pgdata_path.split(':');
+            let prefix = s.next().unwrap();
+            if prefix == "fs"
+            {
+                let path = s.next().unwrap();
+                std::path::Path::new(path)
+            }
+            else if prefix == "s3"
+            {
+                let bucket = s.next().unwrap();
+                bail!("{} storage method is not implemented yet. bucket {}", prefix, bucket)
+            }
+            else
+            {
+                bail!("{} storage method is unknown", prefix)
+            }
+        }
+
         None => {
             let initdb_path = std::path::Path::new("tmp");
             // Init temporarily repo to get bootstrap data

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -157,7 +157,7 @@ fn init_from_repo(conf: &'static PageServerConf,
     Ok(())
 }
 
-pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
+pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path, init_pgdata_path: Option<&str>) -> Result<()> {
     // top-level dir may exist if we are creating it through CLI
     fs::create_dir_all(repo_dir)
         .with_context(|| format!("could not create directory {}", repo_dir.display()))?;
@@ -170,10 +170,6 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
     fs::create_dir(std::path::Path::new("refs").join("tags"))?;
 
     println!("created directory structure in {}", repo_dir.display());
-
-    // Bootstrap the repository by loading the newly-initdb'd cluster into 'main' branch.
-    // TODO pass it as a parameter to import from existing pgdata
-    let init_pgdata_path = None;
 
     let tli = create_timeline(conf, None)?;
 

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -66,6 +66,7 @@ pub fn import_timeline_from_postgres_datadir(
             None => continue,
 
             // These special files appear in the snapshot, but are not needed by the page server
+            Some("pg_internal.init") => {},
             Some("pg_control") => {
                 import_nonrel_file(timeline, lsn, ObjectTag::ControlFile, &direntry.path())?
             }
@@ -103,6 +104,7 @@ pub fn import_timeline_from_postgres_datadir(
                 None => continue,
 
                 // These special files appear in the snapshot, but are not needed by the page server
+                Some("pg_internal.init") => {},
                 Some("PG_VERSION") => continue,
                 Some("pg_filenode.map") => import_nonrel_file(
                     timeline,

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -46,6 +46,14 @@ fn main() -> Result<()> {
                         .long("remote-pageserver")
                         .required(false)
                         .value_name("pageserver-url"),
+                )
+                .arg(
+                    Arg::with_name("snapshot-path")
+                        .long("snapshot-path")
+                        .required(false)
+                        .value_name("snapshot-path")
+                        .help("Source to init repository from")
+                        ,
                 ),
         )
         .subcommand(
@@ -115,9 +123,11 @@ fn main() -> Result<()> {
     };
 
     match matches.subcommand() {
-        ("init", Some(_)) => {
+        ("init", Some(sub_args)) => {
+            let snapshot_path = sub_args.value_of("snapshot-path");
+
             let pageserver = PageServerNode::from_env(&env);
-            if let Err(e) = pageserver.init() {
+            if let Err(e) = pageserver.init(snapshot_path) {
                 eprintln!("pageserver init failed: {}", e);
                 exit(1);
             }


### PR DESCRIPTION
WIP for  #230 retore part.

This PR implements initialization of pageserver from existing pgdata:
To test it run
```
./target/debug/initdb -D /home/anastasia/zenith/pgdata_load
//Now start pgdata and create some tables
...
./target/debug/zenith init --snapshot-path=fs:/home/anastasia/zenith/pgdata_load
./target/debug/zenith start
./target/debug/zenith pg create main
./target/debug/zenith pg start main
//connect to pageserver and ensure that you see tables from local pgdata

```

Build on top of #284