### PR TITLE
Zenith init from s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,7 +2471,9 @@ dependencies = [
  "bytes",
  "hex-literal",
  "log",
+ "rust-s3",
  "serde",
  "thiserror",
+ "tokio",
  "workspace_hack",
 ]

--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -41,16 +41,27 @@ impl PageServerNode {
         }
     }
 
-    pub fn init(&self) -> Result<()> {
+    pub fn init(&self, snapshot_path: Option<&str>) -> Result<()> {
         let mut cmd = Command::new(self.env.pageserver_bin()?);
+
+        let mut args_vec: Vec<&str> = vec![ "--init",
+            "-D",
+            self.env.base_data_dir.to_str().unwrap(),
+            "--postgres-distrib",
+            self.env.pg_distrib_dir.to_str().unwrap()];
+
+        match snapshot_path
+        {
+            Some(init_pgdata_path) =>
+            {
+                args_vec.push("--init_pgdata_path");
+                args_vec.push(init_pgdata_path);
+            },
+            None => {}
+        };
+
         let status = cmd
-            .args(&[
-                "--init",
-                "-D",
-                self.env.base_data_dir.to_str().unwrap(),
-                "--postgres-distrib",
-                self.env.pg_distrib_dir.to_str().unwrap(),
-            ])
+            .args(&args_vec)
             .env_clear()
             .env("RUST_BACKTRACE", "1")
             .status()

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -141,6 +141,7 @@ impl<'a> Basebackup<'a> {
 
     //
     // Extract pg_filenode.map files from repository
+    // Along with them also send PG_VERSION for each database.
     //
     fn add_relmap_file(&mut self, tag: &ObjectTag, db: &DatabaseTag) -> anyhow::Result<()> {
         let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
@@ -148,6 +149,7 @@ impl<'a> Basebackup<'a> {
         let path = if db.spcnode == pg_constants::GLOBALTABLESPACE_OID {
 
             let dst_path = format!("PG_VERSION");
+            //TODO fix hardcoded value. Get this version num somewhere
             let data = "14".as_bytes();
             let header = new_tar_header(&dst_path, data.len() as u64)?;
             self.ar.append(&header, &data[..])?;
@@ -165,6 +167,7 @@ impl<'a> Basebackup<'a> {
             // Append dir path for each database
             let path = format!("base/{}", db.dbnode);
             let fullpath = std::path::Path::new(&self.snappath).join(path.clone());
+
             //FIXME It's a hack to send dir with append_dir()
             info!("create dir before {:?}", fullpath.clone());
             fs::create_dir_all(fullpath.clone())?;

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -15,9 +15,9 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tar::{Builder, Header};
+use std::fs;
 
 use crate::repository::{DatabaseTag, ObjectTag, Timeline};
-use postgres_ffi::relfile_utils::*;
 use postgres_ffi::xlog_utils::*;
 use postgres_ffi::*;
 use zenith_utils::lsn::Lsn;
@@ -161,6 +161,17 @@ impl<'a> Basebackup<'a> {
         } else {
             // User defined tablespaces are not supported
             assert!(db.spcnode == pg_constants::DEFAULTTABLESPACE_OID);
+
+            // Append dir path for each database
+            let path = format!("base/{}", db.dbnode);
+            let fullpath = std::path::Path::new(&self.snappath).join(path.clone());
+            //FIXME It's a hack to send dir with append_dir()
+            info!("create dir before {:?}", fullpath.clone());
+            fs::create_dir_all(fullpath.clone())?;
+            info!("create dir {:?}", fullpath.clone());
+            self.ar.append_dir(path, fullpath.clone())?;
+            info!("append dir done {:?}", fullpath.clone());
+
             let dst_path = format!("base/{}/PG_VERSION", db.dbnode);
             let data = "14".as_bytes();
             let header = new_tar_header(&dst_path, data.len() as u64)?;

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -15,7 +15,6 @@ use std::io::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 use tar::{Builder, Header};
-use walkdir::WalkDir;
 
 use crate::repository::{DatabaseTag, ObjectTag, Timeline};
 use postgres_ffi::relfile_utils::*;
@@ -58,39 +57,14 @@ impl<'a> Basebackup<'a> {
     #[rustfmt::skip] // otherwise "cargo fmt" produce very strange formatting for macch arms of self.timeline.list_nonrels
     pub fn send_tarball(&mut self) -> anyhow::Result<()> {
         debug!("sending tarball of snapshot in {}", self.snappath);
-        for entry in WalkDir::new(&self.snappath) {
-            let entry = entry?;
-            let fullpath = entry.path();
-            let relpath = entry.path().strip_prefix(&self.snappath).unwrap();
 
-            if relpath.to_str().unwrap() == "" {
-                continue;
-            }
-
-            if entry.file_type().is_dir() {
-                trace!(
-                    "sending dir {} as {}",
-                    fullpath.display(),
-                    relpath.display()
-                );
-                self.ar.append_dir(relpath, fullpath)?;
-            } else if entry.file_type().is_symlink() {
-                error!("ignoring symlink in snapshot dir");
-            } else if entry.file_type().is_file() {
-                if !is_rel_file_path(relpath.to_str().unwrap()) {
-                    if entry.file_name() != "pg_filenode.map" // this files will be generated from object storage
-                        && !relpath.starts_with("pg_xact/")
-                        && !relpath.starts_with("pg_multixact/")
-                    {
-                        trace!("sending {}", relpath.display());
-                        self.ar.append_path_with_name(fullpath, relpath)?;
-                    }
-                } else {  // relation pages are loaded on demand and should not be included in tarball
-                    trace!("not sending {}", relpath.display());
-                }
-            } else {
-                error!("unknown file type: {}", fullpath.display());
-            }
+        // We need a few config files to start compute node and now we don't store/generate them in pageserver.
+        // So we preserve them in snappath directory at zenith-init.
+        // FIXME this is a temporary hack. Config files should be handled by some other service.
+        for i in 0..pg_constants::PGDATA_SPECIAL_FILES.len()
+        {
+            let path = pg_constants::PGDATA_SPECIAL_FILES[i];
+            self.ar.append_path_with_name(std::path::Path::new(&self.snappath).join(path), path)?;
         }
 
         // Generate non-relational files.
@@ -172,13 +146,26 @@ impl<'a> Basebackup<'a> {
         let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
         info!("add_relmap_file {:?}", db);
         let path = if db.spcnode == pg_constants::GLOBALTABLESPACE_OID {
+
+            let dst_path = format!("PG_VERSION");
+            let data = "14".as_bytes();
+            let header = new_tar_header(&dst_path, data.len() as u64)?;
+            self.ar.append(&header, &data[..])?;
+
+            let dst_path = format!("global/PG_VERSION");
+            let data = "14".as_bytes();
+            let header = new_tar_header(&dst_path, data.len() as u64)?;
+            self.ar.append(&header, &data[..])?;
+
             String::from("global/pg_filenode.map") // filenode map for global tablespace
         } else {
             // User defined tablespaces are not supported
             assert!(db.spcnode == pg_constants::DEFAULTTABLESPACE_OID);
-            let src_path = format!("{}/base/1/PG_VERSION", self.snappath);
             let dst_path = format!("base/{}/PG_VERSION", db.dbnode);
-            self.ar.append_path_with_name(&src_path, &dst_path)?;
+            let data = "14".as_bytes();
+            let header = new_tar_header(&dst_path, data.len() as u64)?;
+            self.ar.append(&header, &data[..])?;
+
             format!("base/{}/pg_filenode.map", db.dbnode)
         };
         assert!(img.len() == 512);
@@ -260,59 +247,63 @@ impl<'a> Basebackup<'a> {
     }
 }
 
-///
-/// Parse a path, relative to the root of PostgreSQL data directory, as
-/// a PostgreSQL relation data file.
-///
-fn parse_rel_file_path(path: &str) -> Result<(), FilePathError> {
-    /*
-     * Relation data files can be in one of the following directories:
-     *
-     * global/
-     *		shared relations
-     *
-     * base/<db oid>/
-     *		regular relations, default tablespace
-     *
-     * pg_tblspc/<tblspc oid>/<tblspc version>/
-     *		within a non-default tablespace (the name of the directory
-     *		depends on version)
-     *
-     * And the relation data files themselves have a filename like:
-     *
-     * <oid>.<segment number>
-     */
-    if let Some(fname) = path.strip_prefix("global/") {
-        let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
+// -------------- TODO move this code to relfile_utils.rs or remove
 
-        Ok(())
-    } else if let Some(dbpath) = path.strip_prefix("base/") {
-        let mut s = dbpath.split('/');
-        let dbnode_str = s.next().ok_or(FilePathError::InvalidFileName)?;
-        let _dbnode = dbnode_str.parse::<u32>()?;
-        let fname = s.next().ok_or(FilePathError::InvalidFileName)?;
-        if s.next().is_some() {
-            return Err(FilePathError::InvalidFileName);
-        };
+// ///
+// /// Parse a path, relative to the root of PostgreSQL data directory, as
+// /// a PostgreSQL relation data file.
+// ///
+// fn parse_rel_file_path(path: &str) -> Result<(), FilePathError> {
+//     /*
+//      * Relation data files can be in one of the following directories:
+//      *
+//      * global/
+//      *		shared relations
+//      *
+//      * base/<db oid>/
+//      *		regular relations, default tablespace
+//      *
+//      * pg_tblspc/<tblspc oid>/<tblspc version>/
+//      *		within a non-default tablespace (the name of the directory
+//      *		depends on version)
+//      *
+//      * And the relation data files themselves have a filename like:
+//      *
+//      * <oid>.<segment number>
+//      */
+//     if let Some(fname) = path.strip_prefix("global/") {
+//         let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
 
-        let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
+//         Ok(())
+//     } else if let Some(dbpath) = path.strip_prefix("base/") {
+//         let mut s = dbpath.split('/');
+//         let dbnode_str = s.next().ok_or(FilePathError::InvalidFileName)?;
+//         let _dbnode = dbnode_str.parse::<u32>()?;
+//         let fname = s.next().ok_or(FilePathError::InvalidFileName)?;
+//         if s.next().is_some() {
+//             return Err(FilePathError::InvalidFileName);
+//         };
 
-        Ok(())
-    } else if path.strip_prefix("pg_tblspc/").is_some() {
-        // TODO
-        error!("tablespaces not implemented yet");
-        Err(FilePathError::InvalidFileName)
-    } else {
-        Err(FilePathError::InvalidFileName)
-    }
-}
+//         let (_relnode, _forknum, _segno) = parse_relfilename(fname)?;
 
-//
-// Check if it is relational file
-//
-fn is_rel_file_path(path: &str) -> bool {
-    parse_rel_file_path(path).is_ok()
-}
+//         Ok(())
+//     } else if path.strip_prefix("pg_tblspc/").is_some() {
+//         // TODO
+//         error!("tablespaces not implemented yet");
+//         Err(FilePathError::InvalidFileName)
+//     } else {
+//         Err(FilePathError::InvalidFileName)
+//     }
+// }
+
+// //
+// // Check if it is relational file
+// //
+// fn is_rel_file_path(path: &str) -> bool {
+//     parse_rel_file_path(path).is_ok()
+// }
+
+// ---------------
 
 //
 // Create new tarball entry header

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -136,6 +136,12 @@ fn main() -> Result<()> {
                 .help("Initialize pageserver repo"),
         )
         .arg(
+            Arg::with_name("init_pgdata_path")
+                .long("init_pgdata_path")
+                .takes_value(true)
+                .help("Source pgdata to initialize pageserver repo from"),
+        )
+        .arg(
             Arg::with_name("gc_horizon")
                 .long("gc_horizon")
                 .takes_value(true)
@@ -201,7 +207,9 @@ fn main() -> Result<()> {
 
     // Create repo and exit if init was requested
     if init {
-        branches::init_repo(conf, &workdir)?;
+        let init_pgdata_path = arg_matches.value_of("init_pgdata_path");
+
+        branches::init_repo(conf, &workdir, init_pgdata_path)?;
 
         // write the config file
         let cfg_file_contents = toml::to_string_pretty(&params)?;

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -96,7 +96,26 @@ fn init_from_repo(conf: &'static PageServerConf,
 {
     let pgdata_path = match init_pgdata_path
     {
-        Some(init_pgdata_path) => std::path::Path::new(init_pgdata_path),
+        Some(init_pgdata_path) =>
+        {
+            let mut s = init_pgdata_path.split(':');
+            let prefix = s.next().unwrap();
+            if prefix == "fs"
+            {
+                let path = s.next().unwrap();
+                std::path::Path::new(path)
+            }
+            else if prefix == "s3"
+            {
+                let bucket = s.next().unwrap();
+                bail!("{} storage method is not implemented yet. bucket {}", prefix, bucket)
+            }
+            else
+            {
+                bail!("{} storage method is unknown", prefix)
+            }
+        }
+
         None => {
             let initdb_path = std::path::Path::new("tmp");
             // Init temporarily repo to get bootstrap data

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -157,7 +157,7 @@ fn init_from_repo(conf: &'static PageServerConf,
     Ok(())
 }
 
-pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
+pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path, init_pgdata_path: Option<&str>) -> Result<()> {
     // top-level dir may exist if we are creating it through CLI
     fs::create_dir_all(repo_dir)
         .with_context(|| format!("could not create directory {}", repo_dir.display()))?;
@@ -170,10 +170,6 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
     fs::create_dir(std::path::Path::new("refs").join("tags"))?;
 
     println!("created directory structure in {}", repo_dir.display());
-
-    // Bootstrap the repository by loading the newly-initdb'd cluster into 'main' branch.
-    // TODO pass it as a parameter to import from existing pgdata
-    let init_pgdata_path = None;
 
     let tli = create_timeline(conf, None)?;
 

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -14,6 +14,7 @@ pub mod page_cache;
 pub mod page_service;
 pub mod repository;
 pub mod restore_local_repo;
+pub mod restore_s3_repo;
 pub mod rocksdb_storage;
 pub mod tui;
 pub mod tui_event;

--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -140,6 +140,7 @@ impl Repository for ObjectRepository {
     fn branch_timeline(&self, src: ZTimelineId, dst: ZTimelineId, at_lsn: Lsn) -> Result<()> {
         let src_timeline = self.get_timeline(src)?;
 
+        trace!("branch_timeline at lsn {}", at_lsn);
         // Write a metadata key, noting the ancestor of th new timeline. There is initially
         // no data in it, but all the read-calls know to look into the ancestor.
         let metadata = MetadataEntry {
@@ -156,6 +157,8 @@ impl Repository for ObjectRepository {
         )?;
 
         // Copy non-rel objects
+        // TODO Why do we need to copy them into new branch?
+        // Can't we just look for them in timeline's ancestor.
         for tag in src_timeline.list_nonrels(at_lsn)? {
             match tag {
                 ObjectTag::TimelineMetadataTag => {} // skip it

--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -592,7 +592,7 @@ impl Timeline for ObjectTimeline {
             ancestor_timeline: self.ancestor_timeline,
             ancestor_lsn: self.ancestor_lsn,
         };
-        trace!("checkpoint at {}", metadata.last_valid_lsn);
+        trace!("checkpoint at last_valid_lsn {} last_record_lsn {}", metadata.last_valid_lsn, metadata.last_record_lsn);
 
         let val = ObjectValue::TimelineMetadata(metadata);
         self.obj_store.put(

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -66,6 +66,7 @@ pub fn import_timeline_from_postgres_datadir(
             None => continue,
 
             // These special files appear in the snapshot, but are not needed by the page server
+            Some("pg_internal.init") => {},
             Some("pg_control") => {
                 import_nonrel_file(timeline, lsn, ObjectTag::ControlFile, &direntry.path())?
             }
@@ -103,6 +104,7 @@ pub fn import_timeline_from_postgres_datadir(
                 None => continue,
 
                 // These special files appear in the snapshot, but are not needed by the page server
+                Some("pg_internal.init") => {},
                 Some("PG_VERSION") => continue,
                 Some("pg_filenode.map") => import_nonrel_file(
                     timeline,

--- a/pageserver/src/restore_s3_repo.rs
+++ b/pageserver/src/restore_s3_repo.rs
@@ -1,0 +1,286 @@
+//!
+//! Import data and WAL from a PostgreSQL data directory in s3
+//!
+use log::*;
+
+use anyhow::Result;
+use bytes::{Buf, Bytes, BytesMut};
+
+use crate::repository::{
+    BufferTag, DatabaseTag, ObjectTag, PrepareTag, RelTag, SlruBufferTag, Timeline,
+};
+
+use postgres_ffi::pg_constants;
+use postgres_ffi::relfile_utils::*;
+use postgres_ffi::*;
+use zenith_utils::lsn::Lsn;
+use zenith_utils::s3_utils::S3Storage;
+
+///
+/// Import all relation data pages from s3
+///
+pub fn import_timeline_from_postgres_s3(
+    bucket_name: &str,
+    timeline: &dyn Timeline,
+    lsn: Lsn,
+) -> Result<()> {
+    let s3_storage = S3Storage::new_from_env(bucket_name).unwrap();
+
+    // List out contents of directory
+    let results = s3_storage.list_bucket("global/".to_string()).unwrap();
+
+    for result in results {
+        for object in result.contents {
+            // Download every relation file, slurping them into memory
+
+            let key = object.key;
+            let relpath = key.strip_prefix("global/");
+
+            match relpath {
+                None => continue,
+
+                // These special files appear in the snapshot, but are not needed by the page server
+                Some("pg_internal.init") => {}
+                Some("PG_VERSION") => {}
+                Some("pg_control") => import_nonrel_file_from_s3(
+                    &s3_storage,
+                    timeline,
+                    lsn,
+                    ObjectTag::ControlFile,
+                    &key,
+                )?,
+                Some("pg_filenode.map") => import_nonrel_file_from_s3(
+                    &s3_storage,
+                    timeline,
+                    lsn,
+                    ObjectTag::FileNodeMap(DatabaseTag {
+                        spcnode: pg_constants::GLOBALTABLESPACE_OID,
+                        dbnode: 0,
+                    }),
+                    &key,
+                )?,
+
+                // Load any relation files into the page server
+                _ => import_relfile_from_s3(
+                    &s3_storage,
+                    &key,
+                    &relpath.unwrap(),
+                    timeline,
+                    lsn,
+                    pg_constants::GLOBALTABLESPACE_OID,
+                    0,
+                )?,
+            }
+        }
+    }
+
+    // // Scan 'base'. It contains database dirs, the database OID is the filename.
+    // // E.g. 'base/12345', where 12345 is the database OID.
+    let results = s3_storage.list_bucket("base/".to_string()).unwrap();
+    for result in results {
+        for object in result.contents {
+            // Download every relation file, slurping them into memory
+
+            let key = object.key;
+            let dbpath = key.strip_prefix("base/").unwrap();
+
+            let mut s = dbpath.split('/');
+            let dboid_str = s.next().ok_or(FilePathError::InvalidFileName)?;
+            let dboid = dboid_str.parse::<u32>()?;
+            let relpath = s.next();
+
+            match relpath {
+                None => continue,
+
+                // These special files appear in the snapshot, but are not needed by the page server
+                Some("pg_internal.init") => {}
+                Some("PG_VERSION") => continue,
+                Some("pg_filenode.map") => import_nonrel_file_from_s3(
+                    &s3_storage,
+                    timeline,
+                    lsn,
+                    ObjectTag::FileNodeMap(DatabaseTag {
+                        spcnode: pg_constants::DEFAULTTABLESPACE_OID,
+                        dbnode: dboid,
+                    }),
+                    &key,
+                )?,
+
+                // Load any relation files into the page server
+                _ => import_relfile_from_s3(
+                    &s3_storage,
+                    &key,
+                    &relpath.unwrap(),
+                    timeline,
+                    lsn,
+                    pg_constants::DEFAULTTABLESPACE_OID,
+                    dboid,
+                )?,
+            }
+        }
+    }
+
+    let results = s3_storage.list_bucket("pg_xact/".to_string()).unwrap();
+    for result in results {
+        for object in result.contents {
+            let key = object.key;
+            let relpath = key.strip_prefix("pg_xact/").unwrap();
+
+            import_slru_file_from_s3(
+                &s3_storage,
+                timeline,
+                lsn,
+                |blknum| ObjectTag::Clog(SlruBufferTag { blknum }),
+                &key,
+                &relpath,
+            )?;
+        }
+    }
+
+    let results = s3_storage
+        .list_bucket("pg_multixact/members/".to_string())
+        .unwrap();
+    for result in results {
+        for object in result.contents {
+            let key = object.key;
+            let relpath = key.strip_prefix("pg_multixact/members/").unwrap();
+
+            import_slru_file_from_s3(
+                &s3_storage,
+                timeline,
+                lsn,
+                |blknum| ObjectTag::MultiXactMembers(SlruBufferTag { blknum }),
+                &key,
+                &relpath,
+            )?;
+        }
+    }
+
+    let results = s3_storage
+        .list_bucket("pg_multixact/offsets/".to_string())
+        .unwrap();
+    for result in results {
+        for object in result.contents {
+            let key = object.key;
+            let relpath = key.strip_prefix("pg_multixact/offsets/").unwrap();
+
+            import_slru_file_from_s3(
+                &s3_storage,
+                timeline,
+                lsn,
+                |blknum| ObjectTag::MultiXactOffsets(SlruBufferTag { blknum }),
+                &key,
+                &relpath,
+            )?;
+        }
+    }
+
+    let results = s3_storage.list_bucket("pg_twophase/".to_string()).unwrap();
+    for result in results {
+        for object in result.contents {
+            let key = object.key;
+            let relpath = key.strip_prefix("pg_twophase/").unwrap();
+
+            let xid = u32::from_str_radix(&relpath, 16)?;
+            import_nonrel_file_from_s3(
+                &s3_storage,
+                timeline,
+                lsn,
+                ObjectTag::TwoPhase(PrepareTag { xid }),
+                &key,
+            )?;
+        }
+    }
+    // TODO: Scan pg_tblspc
+
+    timeline.checkpoint()?;
+
+    Ok(())
+}
+
+// subroutine of import_timeline_from_postgres_datadir(), to load one relation file.
+fn import_relfile_from_s3(
+    s3_storage: &S3Storage,
+    path: &str,
+    filename: &str,
+    timeline: &dyn Timeline,
+    lsn: Lsn,
+    spcoid: Oid,
+    dboid: Oid,
+) -> Result<()> {
+    let p = parse_relfilename(filename);
+    if let Err(e) = p {
+        warn!("unrecognized file in snapshot: {:?} ({})", path, e);
+        return Err(e.into());
+    }
+    let (relnode, forknum, segno) = p.unwrap();
+
+    //Retrieve file from s3
+    let data = s3_storage.get_object(path).unwrap();
+    let mut bytes = BytesMut::from(data.as_slice()).freeze();
+
+    let mut blknum: u32 = segno * (1024 * 1024 * 1024 / pg_constants::BLCKSZ as u32);
+
+    while bytes.remaining() >= 8192 {
+        let tag = ObjectTag::RelationBuffer(BufferTag {
+            rel: RelTag {
+                spcnode: spcoid,
+                dbnode: dboid,
+                relnode,
+                forknum,
+            },
+            blknum,
+        });
+        timeline.put_page_image(tag, lsn, bytes.copy_to_bytes(8192))?;
+        blknum += 1;
+    }
+
+    Ok(())
+}
+
+fn import_nonrel_file_from_s3(
+    s3_storage: &S3Storage,
+    timeline: &dyn Timeline,
+    lsn: Lsn,
+    tag: ObjectTag,
+    path: &str,
+) -> Result<()> {
+    // read the whole file
+    let data = s3_storage.get_object(path).unwrap();
+
+    timeline.put_page_image(tag, lsn, Bytes::copy_from_slice(&data[..]))?;
+    Ok(())
+}
+
+fn import_slru_file_from_s3(
+    s3_storage: &S3Storage,
+    timeline: &dyn Timeline,
+    lsn: Lsn,
+    gen_tag: fn(blknum: u32) -> ObjectTag,
+    path: &str,
+    filename: &str,
+) -> Result<()> {
+    let data = s3_storage.get_object(path).unwrap();
+    let mut bytes = BytesMut::from(data.as_slice()).freeze();
+
+    let segno = u32::from_str_radix(filename, 16)?;
+    let mut blknum: u32 = segno * pg_constants::SLRU_PAGES_PER_SEGMENT;
+
+    while bytes.remaining() >= 8192 {
+        timeline.put_page_image(gen_tag(blknum), lsn, bytes.copy_to_bytes(8192))?;
+        blknum += 1;
+    }
+
+    Ok(())
+}
+
+// Returns checkpoint LSN from controlfile
+pub fn get_lsn_from_controlfile_s3(bucket_name: &str) -> Result<Lsn> {
+    let s3_storage = S3Storage::new_from_env(bucket_name).unwrap();
+    let path = "global/pg_control";
+
+    let controlfile = ControlFileData::decode(&s3_storage.get_object(path).unwrap())?;
+    let lsn = controlfile.checkPoint;
+
+    Ok(Lsn(lsn))
+}

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -184,3 +184,38 @@ pub const XLOG_BLCKSZ: usize = 8192;
 pub const XLOG_CHECKPOINT_SHUTDOWN: u8 = 0x00;
 pub const XLOG_CHECKPOINT_ONLINE: u8 = 0x10;
 pub const XLP_LONG_HEADER: u16 = 0x0002;
+
+
+pub const PGDATA_SUBDIRS: [&'static str; 22] =
+[
+    "global",
+	"pg_wal/archive_status",
+	"pg_commit_ts",
+	"pg_dynshmem",
+	"pg_notify",
+	"pg_serial",
+	"pg_snapshots",
+	"pg_subtrans",
+	"pg_twophase",
+	"pg_multixact",
+	"pg_multixact/members",
+	"pg_multixact/offsets",
+	"base",
+	"base/1",
+	"pg_replslot",
+	"pg_tblspc",
+	"pg_stat",
+	"pg_stat_tmp",
+	"pg_xact",
+	"pg_logical",
+	"pg_logical/snapshots",
+	"pg_logical/mappings"
+];
+
+pub const PGDATA_SPECIAL_FILES: [&'static str; 4] =
+[
+    "pg_hba.conf",
+    "pg_ident.conf",
+    "postgresql.conf",
+    "postgresql.auto.conf"
+];

--- a/postgres_ffi/src/relfile_utils.rs
+++ b/postgres_ffi/src/relfile_utils.rs
@@ -54,6 +54,9 @@ pub fn forknumber_to_name(forknum: u8) -> Option<&'static str> {
 /// See functions relpath() and _mdfd_segpath() in PostgreSQL sources.
 ///
 pub fn parse_relfilename(fname: &str) -> Result<(u32, u8, u32), FilePathError> {
+
+    println!("parse_filename {}", fname);
+
     lazy_static! {
         static ref RELFILE_RE: Regex =
             Regex::new(r"^(?P<relnode>\d+)(_(?P<forkname>[a-z]+))?(\.(?P<segno>\d+))?$").unwrap();

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -46,6 +46,14 @@ fn main() -> Result<()> {
                         .long("remote-pageserver")
                         .required(false)
                         .value_name("pageserver-url"),
+                )
+                .arg(
+                    Arg::with_name("snapshot-path")
+                        .long("snapshot-path")
+                        .required(false)
+                        .value_name("snapshot-path")
+                        .help("Source to init repository from")
+                        ,
                 ),
         )
         .subcommand(
@@ -115,9 +123,11 @@ fn main() -> Result<()> {
     };
 
     match matches.subcommand() {
-        ("init", Some(_)) => {
+        ("init", Some(sub_args)) => {
+            let snapshot_path = sub_args.value_of("snapshot-path");
+
             let pageserver = PageServerNode::from_env(&env);
-            if let Err(e) = pageserver.init() {
+            if let Err(e) = pageserver.init(snapshot_path) {
                 eprintln!("pageserver init failed: {}", e);
                 exit(1);
             }

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -13,6 +13,8 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 thiserror = "1.0"
 workspace_hack = { path = "../workspace_hack" }
+rust-s3 = { version = "0.27.0-rc4", features = ["no-verify-ssl"] }
+tokio = { version = "1.3.0", features = ["full"] }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/zenith_utils/src/lib.rs
+++ b/zenith_utils/src/lib.rs
@@ -13,3 +13,5 @@ pub mod bin_ser;
 
 pub mod postgres_backend;
 pub mod pq_proto;
+
+pub mod s3_utils;

--- a/zenith_utils/src/s3_utils.rs
+++ b/zenith_utils/src/s3_utils.rs
@@ -1,0 +1,83 @@
+use std::{env, str};
+
+use anyhow::Result;
+use s3::bucket::Bucket;
+use s3::creds::Credentials;
+use s3::region::Region;
+use serde::{Deserialize, Serialize};
+use tokio::runtime;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct S3Storage {
+    pub region: String,
+    pub endpoint: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub bucket_name: String,
+}
+
+impl S3Storage {
+    pub fn new_from_env(bucket_name: &str) -> Result<S3Storage> {
+        Ok(S3Storage {
+            region: env::var("S3_REGION").unwrap(),
+            endpoint: env::var("S3_ENDPOINT").unwrap(),
+            access_key: env::var("S3_ACCESSKEY").unwrap(),
+            secret_key: env::var("S3_SECRET").unwrap(),
+            bucket_name: bucket_name.to_string(),
+        })
+    }
+
+    pub fn get_credentials(&self) -> Result<Credentials> {
+        Credentials::new(
+            Some(&self.access_key),
+            Some(&self.secret_key),
+            None,
+            None,
+            None,
+        )
+    }
+
+    pub fn get_region(&self) -> Region {
+        Region::Custom {
+            region: self.region.clone(),
+            endpoint: self.endpoint.clone(),
+        }
+    }
+
+    pub fn get_bucket(&self) -> Result<Bucket> {
+        Bucket::new_with_path_style(
+            &self.bucket_name,
+            self.get_region(),
+            self.get_credentials().unwrap(),
+        )
+    }
+
+    pub fn list_bucket(&self, path: String) -> Result<Vec<s3::serde_types::ListBucketResult>> {
+        let runtime = runtime::Runtime::new().unwrap();
+        let bucket = self.get_bucket().unwrap();
+
+        runtime.block_on(async { bucket.list(path, Some("".to_string())).await })
+    }
+
+    pub fn put_object(&self, path: String, content: &[u8]) {
+        let runtime = runtime::Runtime::new().unwrap();
+
+        runtime.block_on(async {
+            self.get_bucket()
+                .unwrap()
+                .put_object(path.clone(), content)
+                .await
+                .unwrap();
+        });
+    }
+
+    pub fn get_object(&self, path: &str) -> Result<Vec<u8>> {
+        let runtime = runtime::Runtime::new().unwrap();
+        let bucket = self.get_bucket().unwrap();
+
+        let (retdata, retcode) = runtime.block_on(async { bucket.get_object(path).await.unwrap() });
+
+        assert_eq!(200, retcode);
+        Ok(retdata)
+    }
+}


### PR DESCRIPTION
Implements  #230 restore part.

This PR implements the initialization of pageserver from existing pgdata that is located on local fs or in s3 (minio).

To test it run
```
./target/debug/initdb -D /home/anastasia/zenith/pgdata_load
//Now start pgdata and create some tables
...
./target/debug/zenith init --snapshot-path=fs:/home/anastasia/zenith/pgdata_load
./target/debug/zenith start
./target/debug/zenith pg create main
./target/debug/zenith pg start main
//connect to pageserver and ensure that you see tables from local pgdata

```

Built on top of #284