### PR TITLE
Fix list_rels visibility check

### DIFF
--- a/pageserver/src/rocksdb_storage.rs
+++ b/pageserver/src/rocksdb_storage.rs
@@ -168,7 +168,7 @@ impl ObjectStore for RocksObjectStore {
                 {
                     break;
                 }
-                if key.lsn < lsn {
+                if key.lsn <= lsn {
                     // visible in this snapshot
                     rels.insert(rel_tag);
                 }


### PR DESCRIPTION
Some relations after initdb may have lsn equal to last_valid_lsn()