### PR TITLE
(Idea) Symlink Pipfile (& Pipfile.lock) at the top level

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,1 @@
+./test_runner/Pipfile

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,1 @@
+./test_runner/Pipfile.lock


### PR DESCRIPTION
When executed, pipenv shell creates a fresh Pipfile if none is found in the current directory. This is confusing, hence the patch to symlink it at the top level, which is a good starting point for various commands.