### PR TITLE
Do not update relation metadata when materializing page in get_page_at_lsn

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -417,7 +417,7 @@ impl postgres_backend::Handler for PageServerHandler {
                                     blknum,
                                 };
 
-                                timeline.put_page_image(tag, relation_update.lsn, img)?;
+                                timeline.put_page_image(tag, relation_update.lsn, img, true)?;
                             }
                             Update::WALRecord { blknum, rec } => {
                                 let tag = BufferTag {

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -71,7 +71,7 @@ pub trait Timeline: Send + Sync {
     fn put_wal_record(&self, tag: BufferTag, rec: WALRecord) -> Result<()>;
 
     /// Like put_wal_record, but with ready-made image of the page.
-    fn put_page_image(&self, tag: BufferTag, lsn: Lsn, img: Bytes) -> Result<()>;
+    fn put_page_image(&self, tag: BufferTag, lsn: Lsn, img: Bytes, update_meta: bool) -> Result<()>;
 
     /// Truncate relation
     fn put_truncation(&self, rel: RelTag, lsn: Lsn, nblocks: u32) -> Result<()>;
@@ -334,11 +334,11 @@ mod tests {
         let tline = repo.create_empty_timeline(timelineid, Lsn(0))?;
 
         tline.init_valid_lsn(Lsn(1));
-        tline.put_page_image(TEST_BUF(0), Lsn(2), TEST_IMG("foo blk 0 at 2"))?;
-        tline.put_page_image(TEST_BUF(0), Lsn(2), TEST_IMG("foo blk 0 at 2"))?;
-        tline.put_page_image(TEST_BUF(0), Lsn(3), TEST_IMG("foo blk 0 at 3"))?;
-        tline.put_page_image(TEST_BUF(1), Lsn(4), TEST_IMG("foo blk 1 at 4"))?;
-        tline.put_page_image(TEST_BUF(2), Lsn(5), TEST_IMG("foo blk 2 at 5"))?;
+        tline.put_page_image(TEST_BUF(0), Lsn(2), TEST_IMG("foo blk 0 at 2"), true)?;
+        tline.put_page_image(TEST_BUF(0), Lsn(2), TEST_IMG("foo blk 0 at 2"), true)?;
+        tline.put_page_image(TEST_BUF(0), Lsn(3), TEST_IMG("foo blk 0 at 3"), true)?;
+        tline.put_page_image(TEST_BUF(1), Lsn(4), TEST_IMG("foo blk 1 at 4"), true)?;
+        tline.put_page_image(TEST_BUF(2), Lsn(5), TEST_IMG("foo blk 2 at 5"), true)?;
 
         tline.advance_last_valid_lsn(Lsn(5));
 
@@ -425,7 +425,7 @@ mod tests {
         for i in 0..pg_constants::RELSEG_SIZE + 1 {
             let img = TEST_IMG(&format!("foo blk {} at {}", i, Lsn(lsn)));
             lsn += 1;
-            tline.put_page_image(TEST_BUF(i as u32), Lsn(lsn), img)?;
+            tline.put_page_image(TEST_BUF(i as u32), Lsn(lsn), img, true)?;
         }
         tline.advance_last_valid_lsn(Lsn(lsn));
 
@@ -468,7 +468,7 @@ mod tests {
 
         // add a page and advance the last valid LSN
         let buf = TEST_BUF(1);
-        tline.put_page_image(buf, Lsn(1), TEST_IMG("blk 1 @ lsn 1"))?;
+        tline.put_page_image(buf, Lsn(1), TEST_IMG("blk 1 @ lsn 1"), true)?;
         tline.advance_last_valid_lsn(Lsn(1));
         let mut snapshot = tline.history()?;
         assert_eq!(snapshot.lsn(), Lsn(1));

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -145,7 +145,7 @@ fn import_relfile(
                     },
                     blknum,
                 };
-                timeline.put_page_image(tag, lsn, Bytes::copy_from_slice(&buf))?;
+                timeline.put_page_image(tag, lsn, Bytes::copy_from_slice(&buf), true)?;
                 /*
                 if oldest_lsn == 0 || p.lsn < oldest_lsn {
                     oldest_lsn = p.lsn;
@@ -357,7 +357,7 @@ fn save_xlog_dbase_create(timeline: &dyn Timeline, lsn: Lsn, rec: &XlCreateDatab
 
             info!("copying block {:?} to {:?}", src_key, dst_key);
 
-            timeline.put_page_image(dst_key, lsn, content)?;
+            timeline.put_page_image(dst_key, lsn, content, true)?;
             num_blocks_copied += 1;
         }
 


### PR DESCRIPTION
Looks like I found the reasons of #301.
The problem is caused by updating relation metadata when page is materialized by get_page_at_lsn.
When get_page_at_lsn is called by GC at some horizon, then we update elation metadata according to this horizon. And in conjunction with relatin metadata cache it doesn't work correctly.