### PR TITLE
Explicit compact

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -26,7 +26,7 @@ use pageserver::{branches, page_cache, page_service, tui, PageServerConf};
 const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:64000";
 
 const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
-const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(10);
+const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(100);
 
 /// String arguments that can be declared via CLI or config file
 #[derive(Serialize, Deserialize)]

--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -632,7 +632,7 @@ impl Timeline for ObjectTimeline {
         }))
     }
 
-    fn gc_iteration(&self, horizon: u64) -> Result<GcResult> {
+    fn gc_iteration(&self, horizon: u64, compact: bool) -> Result<GcResult> {
         let last_lsn = self.get_last_valid_lsn();
         let mut result: GcResult = Default::default();
 
@@ -793,7 +793,9 @@ impl Timeline for ObjectTimeline {
             result.elapsed = now.elapsed();
             info!("Garbage collection completed in {:?}: {} relations inspected, {} object inspected, {} version histories truncated, {} versions deleted, {} relations dropped",
                   result.elapsed, result.n_relations, result.inspected, result.truncated, result.deleted, result.dropped);
-            self.obj_store.compact();
+            if compact {
+                self.obj_store.compact();
+            }
         }
         Ok(result)
     }
@@ -900,7 +902,7 @@ impl ObjectTimeline {
     fn gc_loop(&self, conf: &'static PageServerConf) -> Result<()> {
         loop {
             thread::sleep(conf.gc_period);
-            self.gc_iteration(conf.gc_horizon)?;
+            self.gc_iteration(conf.gc_horizon, false)?;
         }
     }
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -532,7 +532,7 @@ impl postgres_backend::Handler for PageServerHandler {
                 .unwrap_or(&self.conf.gc_horizon.to_string())
                 .parse()?;
 
-            let result = timeline.gc_iteration(horizon)?;
+            let result = timeline.gc_iteration(horizon, true)?;
 
             pgb.write_message_noflush(&BeMessage::RowDescription(&[
                 RowDescriptor {

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -144,7 +144,7 @@ pub trait Timeline: Send + Sync {
     /// but it can be explicitly requested through page server API.
     ///
     /// `horizon` specifies delta from last LSN to preserve all object versions (PITR interval).
-    fn gc_iteration(&self, horizon: u64) -> Result<GcResult>;
+    fn gc_iteration(&self, horizon: u64, compact: bool) -> Result<GcResult>;
 
     // Check transaction status
     fn get_tx_status(&self, xid: TransactionId, lsn: Lsn) -> anyhow::Result<u8> {

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -144,6 +144,13 @@ pub trait Timeline: Send + Sync {
     /// but it can be explicitly requested through page server API.
     ///
     /// `horizon` specifies delta from last LSN to preserve all object versions (PITR interval).
+	/// `compact` parameter is used to force compaction of storage.
+	/// Some storage implementation are based on LSM tree and require periodic merge (compaction).
+	/// Usually storage implementation determines itself when compaction should be performed.
+	/// But for GC tests it way be useful to force compaction just after completion of GC iteration
+	/// to make sure that all detected garbage is removed.
+	/// So right now `compact` is set to true when GC explicitly requested through page srver API,
+	/// and is st to false in GC threads which infinitely repeats GC iterations in loop.
     fn gc_iteration(&self, horizon: u64, compact: bool) -> Result<GcResult>;
 
     // Check transaction status


### PR DESCRIPTION
Do not enforce compaction after each GC iteration to let RocksDB to choose compaction period itself.
Also increase timeout between GC iterations to make GC tests more determenistic.