### PR TITLE
Use 'zenith_admin' as superuser name in `initdb`

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -382,10 +382,11 @@ impl PostgresNode {
 
     pub fn connstr(&self) -> String {
         format!(
-            "host={} port={} user={}",
+            "host={} port={} user={} dbname={}",
             self.address.ip(),
             self.address.port(),
-            self.whoami()
+            "zenith_admin",
+            "postgres"
         )
     }
 

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -28,6 +28,8 @@ const DEFAULT_LISTEN_ADDR: &str = "127.0.0.1:64000";
 const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
 const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(100);
 
+const DEFAULT_SUPERUSER: &str = "zenith_admin";
+
 /// String arguments that can be declared via CLI or config file
 #[derive(Serialize, Deserialize)]
 struct CfgFileParams {
@@ -95,6 +97,8 @@ impl CfgFileParams {
             listen_addr,
             gc_horizon,
             gc_period,
+
+            superuser: String::from(DEFAULT_SUPERUSER),
 
             workdir: PathBuf::from("."),
 

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -65,6 +65,7 @@ pub fn init_repo(conf: &'static PageServerConf, repo_dir: &Path) -> Result<()> {
     let initdb_path = conf.pg_bin_dir().join("initdb");
     let initdb_otput = Command::new(initdb_path)
         .args(&["-D", tmppath.to_str().unwrap()])
+        .args(&["-U", &conf.superuser])
         .arg("--no-instructions")
         .env_clear()
         .env("LD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -29,6 +29,7 @@ pub struct PageServerConf {
     pub listen_addr: String,
     pub gc_horizon: u64,
     pub gc_period: Duration,
+    pub superuser: String,
 
     // Repository directory, relative to current working directory.
     // Normally, the page server changes the current working directory

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -356,6 +356,7 @@ mod tests {
             gc_horizon: 64 * 1024 * 1024,
             gc_period: Duration::from_secs(10),
             listen_addr: "127.0.0.1:5430".to_string(),
+            superuser: "zenith_admin".to_string(),
             workdir: repo_dir,
             pg_distrib_dir: "".into(),
         };

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -83,7 +83,7 @@ class PgProtocol:
     def __init__(self, host: str, port: int, username: Optional[str] = None):
         self.host = host
         self.port = port
-        self.username = username or getpass.getuser()
+        self.username = username or "zenith_admin"
 
     def connstr(self, *, dbname: str = 'postgres', username: Optional[str] = None) -> str:
         """


### PR DESCRIPTION
Pretty straightforward: addresses #345, tests do not pass yet.

I ran into issues with the tests blocking mid execution, and found `psql` connections using the command in the repo README doing the same. Somehow managed to mess up my system-wide postgres installation in the process, so I've put this here as a draft PR in case there's any ideas as to what the cause could be in the meantime.

The thing that seems the most suspicious to me is that - after creating a new postgres node - it lists `user=<unix user>`, but my assumption is being made with limited experience.

I've listed the things that I tried in the process of debugging below. I'm not sure at what point the offending changes to my system's installation occurred, so I've listed the things I tried in order. It's also worth noting that I was originally using 'postgres' as the superuser name, until I decided to push this to a branch and saw @mklgallegos's [comment](https://github.com/zenithdb/zenith/issues/345#issuecomment-883040419), so the user changing was relative to that.

---

Things I've tried:

* Direct copying of the instructions from the README -- hangs
* Using `psql -U postgres ...` -- also hangs
* Using `sudo -u postgres psql ...` -- also hangs
* Executing all commands prefixed with `sudo -u postgres` -- eventually gets "db error: ERROR: No such file or directory" using `zenith pg start main`. At this point, I think the installation was broken, because attempting to the unmodified commands (i.e. no `sudo -u ...`) from the unmodified repo produced the same error where it didn't before