### PR TITLE
Fix particular typo: `s/cofig/config/g`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To view your documentation in a browser, try running `cargo doc --no-deps --open
 `/control_plane`:
 
 Local control plane.
-Functions to start, cofigure and stop pageserver and postgres instances running as a local processes.
+Functions to start, configure and stop pageserver and postgres instances running as a local processes.
 Intended to be used in integration tests and in CLI tools for local installations.
 
 `/zenith`

--- a/control_plane/src/lib.rs
+++ b/control_plane/src/lib.rs
@@ -1,7 +1,7 @@
 //
 // Local control plane.
 //
-// Can start, cofigure and stop postgres instances running as a local processes.
+// Can start, configure and stop postgres instances running as a local processes.
 //
 // Intended to be used in integration tests and in CLI tools for
 // local installations.

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -102,7 +102,7 @@ fn main() -> Result<()> {
     // Create config file
     if let ("init", Some(sub_args)) = matches.subcommand() {
         let pageserver_uri = sub_args.value_of("pageserver-url");
-        local_env::init(pageserver_uri).with_context(|| "Failed to create cofig file")?;
+        local_env::init(pageserver_uri).with_context(|| "Failed to create config file")?;
     }
 
     // all other commands would need config


### PR DESCRIPTION
I had noticed the error message; found a couple other occurrences of the same typo.