### PR TITLE
Use get_page_at_lsn() instead of nowait variant in base backups.

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -132,7 +132,7 @@ impl<'a> Basebackup<'a> {
         tag: &ObjectTag,
         page: u32,
     ) -> anyhow::Result<()> {
-        let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
+        let img = self.timeline.get_page_at_lsn(*tag, self.lsn)?;
         // Zero length image indicates truncated segment: just skip it
         if !img.is_empty() {
             assert!(img.len() == pg_constants::BLCKSZ as usize);
@@ -172,7 +172,7 @@ impl<'a> Basebackup<'a> {
     // Extract pg_filenode.map files from repository
     //
     fn add_relmap_file(&mut self, tag: &ObjectTag, db: &DatabaseTag) -> anyhow::Result<()> {
-        let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
+        let img = self.timeline.get_page_at_lsn(*tag, self.lsn)?;
         info!("add_relmap_file {:?}", db);
         let path = if db.spcnode == pg_constants::GLOBALTABLESPACE_OID {
             String::from("global/pg_filenode.map") // filenode map for global tablespace
@@ -198,7 +198,7 @@ impl<'a> Basebackup<'a> {
         if self.timeline.get_tx_status(xid, self.lsn)?
             == pg_constants::TRANSACTION_STATUS_IN_PROGRESS
         {
-            let img = self.timeline.get_page_at_lsn_nowait(*tag, self.lsn)?;
+            let img = self.timeline.get_page_at_lsn(*tag, self.lsn)?;
             let mut buf = BytesMut::new();
             buf.extend_from_slice(&img[..]);
             let crc = crc32c::crc32c(&img[..]);
@@ -216,10 +216,10 @@ impl<'a> Basebackup<'a> {
     fn add_pgcontrol_file(&mut self) -> anyhow::Result<()> {
         let checkpoint_bytes = self
             .timeline
-            .get_page_at_lsn_nowait(ObjectTag::Checkpoint, self.lsn)?;
+            .get_page_at_lsn(ObjectTag::Checkpoint, self.lsn)?;
         let pg_control_bytes = self
             .timeline
-            .get_page_at_lsn_nowait(ObjectTag::ControlFile, self.lsn)?;
+            .get_page_at_lsn(ObjectTag::ControlFile, self.lsn)?;
         let mut pg_control = ControlFileData::decode(&pg_control_bytes)?;
         let mut checkpoint = CheckPoint::decode(&checkpoint_bytes)?;
 

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -58,9 +58,6 @@ pub trait Timeline: Send + Sync {
     /// Look up given page in the cache.
     fn get_page_at_lsn(&self, tag: ObjectTag, lsn: Lsn) -> Result<Bytes>;
 
-    /// Look up given page in the cache.
-    fn get_page_at_lsn_nowait(&self, tag: ObjectTag, lsn: Lsn) -> Result<Bytes>;
-
     /// Get size of relation
     fn get_rel_size(&self, tag: RelTag, lsn: Lsn) -> Result<u32>;
 


### PR DESCRIPTION
Commit eb0a56eb22 exposed the get_page_at_lsn_nowait() variant, which
was previously private to the Timeline implementation. It's used in
the code to build the base backup tarball. Was it a performance
optimization? Seems premature. When taking a base backup, we surely
must wait for the WAL to arrive before it's safe.  Perhaps we could
wait for it once, and skip the check on subsequent calls, but that
would be an optimization that we should do for the GetPage@LSN calls
in general. And it's surely not measurable in the performance testing
yet. Revert that part of eb0a56eb22, making get_page_at_lsn_nowait()
private again.