### PR TITLE
Add a missing `[cfg(test)]`

### DIFF
--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -229,14 +229,17 @@ impl ReplicationConn {
     }
 }
 
+#[cfg(test)]
 mod tests {
+    use super::*;
+
     // A no-op impl for tests
-    impl super::HsFeedbackSubscriber for () {}
+    impl HsFeedbackSubscriber for () {}
 
     #[test]
     fn test_replication_conn_background_thread_eof() {
         // Test that background_thread recognizes EOF
         let stream: &[u8] = &[];
-        super::ReplicationConn::background_thread(stream, ()).unwrap();
+        ReplicationConn::background_thread(stream, ()).unwrap();
     }
 }

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -88,9 +88,11 @@ impl FeMessage {
     /// ```
     /// # use std::io::Read;
     /// # use zenith_utils::pq_proto::FeMessage;
+    /// #
     /// # fn process_message(msg: FeMessage) -> anyhow::Result<()> {
     /// #     Ok(())
     /// # };
+    /// #
     /// fn do_the_job(stream: &mut impl Read) -> anyhow::Result<()> {
     ///     while let Some(msg) = FeMessage::read(stream)? {
     ///         process_message(msg)?;


### PR DESCRIPTION
We don't always need to compile tests.