### PR TITLE
Correct `LeSer` doc: "Big Endian" -> "Little Endian"

### DIFF
--- a/zenith_utils/src/bin_ser.rs
+++ b/zenith_utils/src/bin_ser.rs
@@ -139,7 +139,7 @@ pub trait BeSer: Serialize + DeserializeOwned {
     }
 }
 
-/// Binary serialize/deserialize helper functions (Big Endian)
+/// Binary serialize/deserialize helper functions (Little Endian)
 ///
 pub trait LeSer: Serialize + DeserializeOwned {
     /// Serialize into a byte slice


### PR DESCRIPTION
Leaving this as a PR just to double-check I'm not misinterpreting things - seemed like the docs for the `BeSer` trait had been copy+pasted into this one without changing it to say "Little Endian"

If this sort of thing should just be a direct commit in the future, I'll do that