### PR TITLE
Fix another accidental endless loop in WalAcceptor

### DIFF
--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -38,7 +38,6 @@ pub fn thread_main(conf: WalAcceptorConf) -> Result<()> {
 }
 
 /// This is run by main_loop, inside a background thread.
-///
 fn handle_socket(mut socket: TcpStream, conf: WalAcceptorConf) -> Result<()> {
     socket.set_nodelay(true)?;
 
@@ -58,14 +57,14 @@ fn handle_socket(mut socket: TcpStream, conf: WalAcceptorConf) -> Result<()> {
 }
 
 /// Fetch the first 4 bytes from the network (big endian), without consuming them.
-///
 /// This is used to help determine what protocol the peer is using.
 fn peek_u32(stream: &mut TcpStream) -> Result<u32> {
     let mut buf = [0u8; 4];
     loop {
-        let num_bytes = stream.peek(&mut buf)?;
-        if num_bytes == 4 {
-            return Ok(u32::from_be_bytes(buf));
+        match stream.peek(&mut buf)? {
+            0 => anyhow::bail!("unexpected end of stream"),
+            4 => return Ok(u32::from_be_bytes(buf)),
+            _ => continue,
         }
     }
 }


### PR DESCRIPTION
TcpSteam::peek calls recvmsg, which may return 0 in case of EOF (per `man 2 recvmsg`).

I didn't bother to write a test for this one, since:

* the function is trivial and unlikely to change further,
* `socketpair` (which would be very convenient here) requires a bit of unsafe code,
* ostensibly @arssher is going to land a big code refactoring here.