### PR TITLE
Allow safekeeper to stream till real end of wal.

### DIFF
--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -148,7 +148,7 @@ impl ReplicationConn {
                 break;
             }
         }
-        let (wal_end, timeline) = swh.timeline.find_end_of_wal(&swh.conf.data_dir, false);
+        let (wal_end, timeline) = swh.timeline.find_end_of_wal(&swh.conf.data_dir, true);
         if start_pos == Lsn(0) {
             start_pos = wal_end;
         }


### PR DESCRIPTION
Otherwise it prematurely terminates, e.g. in test_compute_restart.

ref #388