### PR TITLE
Remove obsolete comments for list_nonrel(). Issue #397

### DIFF
--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -843,7 +843,7 @@ impl ObjectTimeline {
                 }
             }
         } else {
-            info!("relation {} not found at {}", rel, lsn);
+            trace!("relation {} not found at {}", rel, lsn);
             Ok(None)
         }
     }

--- a/pageserver/src/object_store.rs
+++ b/pageserver/src/object_store.rs
@@ -72,7 +72,6 @@ pub trait ObjectStore: Send + Sync {
     /// Iterate through non-rel relishes
     ///
     /// This is used to prepare tarball for new node startup.
-    /// Returns objects in increasing key-version order.
     fn list_nonrels<'a>(&'a self, timelineid: ZTimelineId, lsn: Lsn) -> Result<HashSet<RelishTag>>;
 
     /// Iterate through objects tags. If nonrel_only, then only non-relationa data is iterated.

--- a/pageserver/src/relish.rs
+++ b/pageserver/src/relish.rs
@@ -195,7 +195,7 @@ pub enum SlruKind {
 }
 
 impl SlruKind {
-    fn to_str(&self) -> &'static str {
+    pub fn to_str(&self) -> &'static str {
         match self {
             Self::Clog => "pg_xact",
             Self::MultiXactMembers => "pg_multixact/members",

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -557,7 +557,10 @@ fn save_xlog_dbase_create(timeline: &dyn Timeline, lsn: Lsn, rec: &XlCreateDatab
 
         num_rels_copied += 1;
     }
+
     // Copy relfilemap
+    // TODO This implementation is very inefficient -
+    // it scans all non-rels only to find FileNodeMaps
     for tag in timeline.list_nonrels(req_lsn)? {
         match tag {
             RelishTag::FileNodeMap { spcnode, dbnode } => {

--- a/pageserver/src/rocksdb_storage.rs
+++ b/pageserver/src/rocksdb_storage.rs
@@ -212,6 +212,7 @@ impl ObjectStore for RocksObjectStore {
     }
 
     /// Get a list of all distinct NON-relations in timeline
+    /// that are visible at given lsn.
     ///
     /// TODO: This implementation is very inefficient, it scans
     /// through all non-rel page versions in the system. In practice, this


### PR DESCRIPTION
list_nonrels() returns elements in arbitrary order.
Remove incorrect comments that say otherwise.