### PR TITLE
Test & fix clog truncation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ postgres: postgres-configure
 	$(MAKE) -C tmp_install/build MAKELEVEL=0 install
 	+@echo "Compiling contrib/zenith"
 	$(MAKE) -C tmp_install/build/contrib/zenith install
+	+@echo "Compiling contrib/zenith_test_utils"
+	$(MAKE) -C tmp_install/build/contrib/zenith_test_utils install
 
 postgres-clean:
 	$(MAKE) -C tmp_install/build MAKELEVEL=0 clean

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -100,9 +100,12 @@ impl<'a> Basebackup<'a> {
             .timeline
             .get_relish_size(RelishTag::Slru { slru, segno }, self.lsn)?;
 
-        if seg_size == None
-        {
-            info!("SLRU segment {}/{:>04X} was truncated", slru.to_str(), segno);
+        if seg_size == None {
+            trace!(
+                "SLRU segment {}/{:>04X} was truncated",
+                slru.to_str(),
+                segno
+            );
             return Ok(());
         }
 

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -177,8 +177,7 @@ impl<'a> Basebackup<'a> {
     //
     fn add_twophase_file(&mut self, xid: TransactionId) -> anyhow::Result<()> {
         // Include in tarball two-phase files only of in-progress transactions
-        if self.timeline.get_tx_status(xid, self.lsn)?
-            == pg_constants::TRANSACTION_STATUS_IN_PROGRESS
+        if self.timeline.get_tx_is_in_progress(xid, self.lsn)
         {
             let img =
                 self.timeline

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -96,9 +96,17 @@ impl<'a> Basebackup<'a> {
     // Generate SLRU segment files from repository.
     //
     fn add_slru_segment(&mut self, slru: SlruKind, segno: u32) -> anyhow::Result<()> {
-        let nblocks = self
+        let seg_size = self
             .timeline
-            .get_rel_size(RelishTag::Slru { slru, segno }, self.lsn)?;
+            .get_relish_size(RelishTag::Slru { slru, segno }, self.lsn)?;
+
+        if seg_size == None
+        {
+            info!("SLRU segment {}/{:>04X} was truncated", slru.to_str(), segno);
+            return Ok(());
+        }
+
+        let nblocks = seg_size.unwrap();
 
         let mut slru_buf: Vec<u8> =
             Vec::with_capacity(nblocks as usize * pg_constants::BLCKSZ as usize);

--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -23,7 +23,7 @@ use crate::{PageServerConf, ZTimelineId};
 use anyhow::{anyhow, bail, Context, Result};
 use bytes::Bytes;
 use log::*;
-use postgres_ffi::pg_constants;
+
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
@@ -712,9 +712,9 @@ impl Timeline for ObjectTimeline {
                         for vers in self.obj_store.object_versions(&key, horizon)? {
                             let lsn = vers.0;
                             prepared_horizon = Lsn::min(lsn, prepared_horizon);
-                            if self.get_tx_status(xid, horizon)?
-                                != pg_constants::TRANSACTION_STATUS_IN_PROGRESS
+                            if !self.get_tx_is_in_progress(xid, horizon)
                             {
+                                info!("unlink twophase_file NOT TRANSACTION_STATUS_IN_PROGRESS {}", xid);
                                 self.obj_store.unlink(&key, lsn)?;
                                 result.prep_deleted += 1;
                             }

--- a/pageserver/src/object_repository.rs
+++ b/pageserver/src/object_repository.rs
@@ -338,7 +338,10 @@ impl Timeline for ObjectTimeline {
     /// Return None if the relish was truncated
     fn get_relish_size(&self, rel: RelishTag, lsn: Lsn) -> Result<Option<u32>> {
         if !rel.is_blocky() {
-            bail!("invalid get_relish_size request for non-blocky relish {}", rel);
+            bail!(
+                "invalid get_relish_size request for non-blocky relish {}",
+                rel
+            );
         }
 
         let lsn = self.wait_lsn(lsn)?;
@@ -577,10 +580,9 @@ impl Timeline for ObjectTimeline {
     /// To truncate SLRU segments use put_unlink() function.
     ///
     fn put_truncation(&self, rel: RelishTag, lsn: Lsn, nblocks: u32) -> Result<()> {
-
         match rel {
-            RelishTag::Relation(_) => {},
-            _ =>  bail!("invalid truncation for non-rel relish {}", rel)
+            RelishTag::Relation(_) => {}
+            _ => bail!("invalid truncation for non-rel relish {}", rel),
         };
 
         info!("Truncate relation {} to {} blocks at {}", rel, nblocks, lsn);

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -268,7 +268,10 @@ impl PageServerHandler {
                         .observe_closure_duration(|| {
                             // Return 0 if relation is not found.
                             // This is what postgres smgr expects.
-                            timeline.get_relish_size(tag, req.lsn).unwrap_or(Some(0)).unwrap_or(0)
+                            timeline
+                                .get_relish_size(tag, req.lsn)
+                                .unwrap_or(Some(0))
+                                .unwrap_or(0)
                         });
 
                     PagestreamBeMessage::Nblocks(PagestreamStatusResponse { ok: true, n_blocks })

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -266,7 +266,9 @@ impl PageServerHandler {
                     let n_blocks = SMGR_QUERY_TIME
                         .with_label_values(&["get_rel_size"])
                         .observe_closure_duration(|| {
-                            timeline.get_rel_size(tag, req.lsn).unwrap_or(0)
+                            // Return 0 if relation is not found.
+                            // This is what postgres smgr expects.
+                            timeline.get_relish_size(tag, req.lsn).unwrap_or(Some(0)).unwrap_or(0)
                         });
 
                     PagestreamBeMessage::Nblocks(PagestreamStatusResponse { ok: true, n_blocks })

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -708,14 +708,15 @@ fn save_xact_record(
 fn save_clog_truncate_record(
     checkpoint: &mut CheckPoint,
     _timeline: &dyn Timeline,
-    _lsn: Lsn,
+    lsn: Lsn,
     xlrec: &XlClogTruncate,
 ) -> Result<()> {
-    trace!(
-        "RM_CLOG_ID truncate pageno {} oldestXid {} oldestXidDB {}",
+    info!(
+        "RM_CLOG_ID truncate pageno {} oldestXid {} oldestXidDB {} lsn {}",
         xlrec.pageno,
         xlrec.oldest_xid,
-        xlrec.oldest_xid_db
+        xlrec.oldest_xid_db,
+        lsn
     );
 
     checkpoint.oldestXid = xlrec.oldest_xid;

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -531,7 +531,7 @@ fn save_xlog_dbase_create(timeline: &dyn Timeline, lsn: Lsn, rec: &XlCreateDatab
         assert_eq!(src_rel.spcnode, src_tablespace_id);
         assert_eq!(src_rel.dbnode, src_db_id);
 
-        let nblocks = timeline.get_rel_size(RelishTag::Relation(src_rel), req_lsn)?;
+        let nblocks = timeline.get_relish_size(RelishTag::Relation(src_rel), req_lsn)?.unwrap_or(0);
         let dst_rel = RelTag {
             spcnode: tablespace_id,
             dbnode: db_id,

--- a/test_runner/batch_others/test_clog_truncate.py
+++ b/test_runner/batch_others/test_clog_truncate.py
@@ -1,0 +1,72 @@
+import time
+import os
+
+from contextlib import closing
+
+from fixtures.zenith_fixtures import PostgresFactory, ZenithPageserver
+
+pytest_plugins = ("fixtures.zenith_fixtures")
+
+
+#
+# Test compute node start after clog truncation
+#
+def test_clog_truncate(zenith_cli, pageserver: ZenithPageserver, postgres: PostgresFactory, pg_bin):
+    # Create a branch for us
+    zenith_cli.run(["branch", "test_clog_truncate", "empty"])
+
+    # set agressive autovacuum to make sure that truncation will happen
+    config = [
+        'autovacuum_max_workers=10', 'autovacuum_vacuum_threshold=0',
+        'autovacuum_vacuum_insert_threshold=0', 'autovacuum_vacuum_cost_delay=0',
+        'autovacuum_vacuum_cost_limit=10000', 'autovacuum_naptime =1s',
+        'autovacuum_freeze_max_age=100000'
+    ]
+
+    pg = postgres.create_start('test_clog_truncate', config_lines=config)
+    print('postgres is running on test_clog_truncate branch')
+
+    # Install extension containing function needed for test
+    pg.safe_psql('CREATE EXTENSION zenith_test_utils')
+
+    # Consume many xids to advance clog
+    with closing(pg.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute('select test_consume_xids(1000*1000*10);')
+            print('xids consumed')
+
+            # call a checkpoint to trigger TruncateSubtrans
+            cur.execute('CHECKPOINT;')
+
+            # ensure WAL flush
+            cur.execute('select txid_current()')
+            print(cur.fetchone())
+
+    # wait for autovacuum to truncate the pg_xact
+    # XXX Is it worth to add a timeout here?
+    pg_xact_0000_path = os.path.join(pg.pg_xact_dir_path(), '0000')
+    print("pg_xact_0000_path = " + pg_xact_0000_path)
+
+    while os.path.isfile(pg_xact_0000_path):
+        print("file exists. wait for truncation. " "pg_xact_0000_path = " + pg_xact_0000_path)
+        time.sleep(5)
+
+    # checkpoint to advance latest lsn
+    with closing(pg.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute('CHECKPOINT;')
+            cur.execute('select pg_current_wal_insert_lsn()')
+            lsn_after_truncation = cur.fetchone()[0]
+
+    # create new branch after clog truncation and start a compute node on it
+    print('create branch at lsn_after_truncation ' + lsn_after_truncation)
+    zenith_cli.run(
+        ["branch", "test_clog_truncate_new", "test_clog_truncate@" + lsn_after_truncation])
+
+    pg2 = postgres.create_start('test_clog_truncate_new')
+    print('postgres is running on test_clog_truncate_new branch')
+
+    # check that new node doesn't contain truncated segment
+    pg_xact_0000_path_new = os.path.join(pg2.pg_xact_dir_path(), '0000')
+    print("pg_xact_0000_path_new = " + pg_xact_0000_path_new)
+    assert os.path.isfile(pg_xact_0000_path_new) is False

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -284,6 +284,11 @@ class Postgres(PgProtocol):
 
         return self
 
+    def pg_xact_dir_path(self) -> str:
+        """ Path to pg_xact dir """
+        path = pathlib.Path('pgdatadirs') / 'tenants' / self.tenant_id / self.branch / 'pg_xact'
+        return os.path.join(self.repo_dir, path)
+
     def config_file_path(self) -> str:
         """ Path to postgresql.conf """
         filename = pathlib.Path('pgdatadirs') / 'tenants' / self.tenant_id / self.branch / 'postgresql.conf'


### PR DESCRIPTION
This PR uses [test_consume_xids](https://github.com/zenithdb/postgres/tree/test_consume_xids ) branch of vendor/postgres,
which adds test_consume_xids() function (I picked it from the greenplum tests) to generate clog quickly. 
It will be used in upcoming xid wraparound tests too.

Also, this PR contains a few cleanup/refactoring commits.

The clog truncate fix is not polished yet, but at least it passes the test.