### PR TITLE
Update Cargo.lock for addition of 'bincode'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,7 @@ name = "walkeeper"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "byteorder",
  "bytes",
  "clap",


### PR DESCRIPTION
Commit 5eb1738e8b added a dependency to the 'bincode' crate. 'cargo build'
adds it to Cargo.lock automatically, so let's remember it.