### PR TITLE
Add 'dump_snapfile' utility for debugging.

### DIFF
--- a/pageserver/src/bin/dump_layerfile.rs
+++ b/pageserver/src/bin/dump_layerfile.rs
@@ -1,0 +1,25 @@
+//! Main entry point for the dump_layerfile executable
+//!
+//! A handy tool for debugging, that's all.
+use anyhow::Result;
+use clap::{App, Arg};
+use pageserver::layered_repository::dump_layerfile_from_path;
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let arg_matches = App::new("Zenith dump_layerfile utility")
+        .about("Dump contents of one layer file, for debugging")
+        .arg(
+            Arg::with_name("path")
+                .help("Path to file to dump")
+                .required(true)
+                .index(1),
+        )
+        .get_matches();
+
+    let path = PathBuf::from(arg_matches.value_of("path").unwrap());
+
+    dump_layerfile_from_path(&path)?;
+
+    Ok(())
+}

--- a/pageserver/src/layered_repository/filename.rs
+++ b/pageserver/src/layered_repository/filename.rs
@@ -7,6 +7,7 @@ use crate::PageServerConf;
 use crate::{ZTenantId, ZTimelineId};
 use std::fmt;
 use std::fs;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use log::*;
@@ -34,7 +35,7 @@ impl DeltaFileName {
     /// Parse a string as a delta file name. Returns None if the filename does not
     /// match the expected pattern.
     ///
-    fn from_str(fname: &str) -> Option<Self> {
+    pub fn from_str(fname: &str) -> Option<Self> {
         let rel;
         let mut parts;
         if let Some(rest) = fname.strip_prefix("rel_") {
@@ -170,7 +171,7 @@ impl ImageFileName {
     /// Parse a string as an image file name. Returns None if the filename does not
     /// match the expected pattern.
     ///
-    fn from_str(fname: &str) -> Option<Self> {
+    pub fn from_str(fname: &str) -> Option<Self> {
         let rel;
         let mut parts;
         if let Some(rest) = fname.strip_prefix("rel_") {
@@ -302,4 +303,17 @@ pub fn list_files(
         }
     }
     return Ok((imgfiles, deltafiles));
+}
+
+/// Helper enum to hold a PageServerConf, or a path
+///
+/// This is used by DeltaLayer and ImageLayer. Normally, this holds a reference to the
+/// global config, and paths to layer files are constructed using the tenant/timeline
+/// path from the config. But in the 'dump_layerfile' binary, we need to construct a Layer
+/// struct for a file on disk, without having a page server running, so that we have no
+/// config. In that case, we use the Path variant to hold the full path to the file on
+/// disk.
+pub enum PathOrConf {
+    Path(PathBuf),
+    Conf(&'static PageServerConf),
 }

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -227,6 +227,31 @@ impl Layer for InMemoryLayer {
     fn is_incremental(&self) -> bool {
         self.img_layer.is_some()
     }
+
+    /// debugging function to print out the contents of the layer
+    fn dump(&self) -> Result<()> {
+        let inner = self.inner.lock().unwrap();
+
+        let end_str = inner
+            .drop_lsn
+            .as_ref()
+            .map(|drop_lsn| drop_lsn.to_string())
+            .unwrap_or_default();
+
+        println!(
+            "----- in-memory layer for {} {}-{} ----",
+            self.seg, self.start_lsn, end_str
+        );
+
+        for (k, v) in inner.segsizes.iter() {
+            println!("{}: {}", k, v);
+        }
+        //for (k, v) in inner.page_versions.iter() {
+        //    println!("blk {} at {}: {}/{}", k.0, k.1, v.page_image.is_some(), v.record.is_some());
+        //}
+
+        Ok(())
+    }
 }
 
 impl InMemoryLayer {

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -145,4 +145,7 @@ pub trait Layer: Send + Sync {
 
     /// Permanently remove this layer from disk.
     fn delete(&self) -> Result<()>;
+
+    /// Dump summary of the contents of the layer to stdout
+    fn dump(&self) -> Result<()>;
 }

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -87,6 +87,8 @@ pub const XACT_XINFO_HAS_TWOPHASE: u32 = 1u32 << 4;
 pub const XLOG_NEXTOID: u8 = 0x30;
 pub const XLOG_SWITCH: u8 = 0x40;
 pub const XLOG_SMGR_TRUNCATE: u8 = 0x20;
+pub const XLOG_FPI_FOR_HINT: u8 = 0xA0;
+pub const XLOG_FPI: u8 = 0xB0;
 pub const DB_SHUTDOWNED: u32 = 1;
 
 // From multixact.h


### PR DESCRIPTION
Seems handy for getting a quick idea of what's stored in a snapshot
file.

Example output on a file after runnnig pgbench for a while:

    target/debug/dump_snapfile .zenith/tenants/6f44ae619e1b63f0e72a74d5ab026492/timelines/a6ba8411bfabb563f4be59717857d49f/rel_1663_13990_16396_0_4_0000000006101FE9_000000000D98B608
    --- relsizes ---
      0/6101FE9: 1 blocks
      0/6105B39: 2 blocks
      0/6109689: 3 blocks
      0/610D1D9: 4 blocks
    ...
      0/7380F29: 1278 blocks
      0/7384A79: 1279 blocks
      0/73885C9: 1280 blocks
    --- page versions ---
      blk 5120 at 0/6101FE9:  rec 8241 bytes, will_init true
      blk 5120 at 0/6103AE9:  rec 6881 bytes, will_init true
      blk 5120 at 0/8E1727B:  rec 59 bytes, will_init false
    ...
      blk 6398 at 0/7384A79:  rec 8241 bytes, will_init true
      blk 6398 at 0/7386579:  rec 6881 bytes, will_init true
      blk 6398 at 0/8E2B2EB:  rec 59 bytes, will_init false
      blk 6398 at 0/C00EDC5:  rec 8125 bytes, will_init true
      blk 6398 at 0/D93B924:  rec 60 bytes, will_init false
      blk 6398 at 0/D93B9DB:  rec 179 bytes, will_init false
      blk 6399 at 0/73885C9:  rec 8241 bytes, will_init true
      blk 6399 at 0/738A0C9:  rec 6881 bytes, will_init true
      blk 6399 at 0/8E2B32B:  rec 59 bytes, will_init false
      blk 6399 at 0/C010D9D:  rec 8125 bytes, will_init true