### PR TITLE
Marginally improve walkeeper error visibility

### DIFF
--- a/zenith_utils/src/postgres_backend.rs
+++ b/zenith_utils/src/postgres_backend.rs
@@ -301,8 +301,9 @@ impl PostgresBackend {
             FeMessage::Query(m) => {
                 trace!("got query {:?}", m.body);
                 // xxx distinguish fatal and recoverable errors?
-                if let Err(e) = handler.process_query(self, m.body) {
+                if let Err(e) = handler.process_query(self, m.body.clone()) {
                     let errmsg = format!("{}", e);
+                    warn!("query handler for {:?} failed: {}", m.body, errmsg);
                     self.write_message_noflush(&BeMessage::ErrorResponse(errmsg))?;
                 }
                 self.write_message(&BeMessage::ReadyForQuery)?;


### PR DESCRIPTION
Currently, debugging walkeeper <-> walproposer communication failures is made more difficult by the fact that, if an error occurs while handling the walproposer's request, the only way it's reported is by sending an error response back to the walproposer. (walproposer doesn't currently handle these, and so the original error is never actually written to a log!)

So I figured it might be a good idea to both (a) add a little bit of context to walkeeper errors and (b) guarantee they're reported by displaying them in the walkeeper's logs.

There's perhaps a more thorough solution we could implement here (in addition to properly handling error responses in walproposer), so this PR could also serve as a point of discussion if people have more thoughts.