### PR TITLE
Adjust docker container for console's CI pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN rm -rf postgres_install/build && \
     cd postgres_install && tar -czf /data/postgres_install.tar.gz . && cd .. && \
     rm -rf postgres_install
 
-RUN useradd -m -d /data zenith
+RUN useradd -d /data zenith && chown -R zenith:zenith /data
 
 VOLUME ["/data"]
 USER zenith

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -eux
+
 if [ "$1" = 'pageserver' ]; then
     if [ ! -d "/data/tenants" ]; then
         echo "Initializing pageserver data directory"


### PR DESCRIPTION
Some CI pipelines might not be able to use docker volumes, so we'd better have a writable `/data` directory.