### PR TITLE
add incremental tracking of logical timeline size

### DIFF
--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -54,7 +54,52 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ForbiddenError"
-
+        "500":
+          description: Generic operation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /v1/branch/{tenant_id}/{branch_name}:
+    parameters:
+      - name: tenant_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: hex
+      - name: branch_name
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      description: Get branches for tenant
+      responses:
+        "200":
+          description: BranchInfo
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BranchInfo"
+        "400":
+          description: Error when no tenant id found in path or no branch name
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: Forbidden Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
         "500":
           description: Generic operation error
           content:
@@ -203,6 +248,9 @@ components:
       required:
         - name
         - timeline_id
+        - latest_valid_lsn
+        - current_logical_size
+        - current_logical_size_non_incremental
       properties:
         name:
           type: string
@@ -213,6 +261,10 @@ components:
           type: string
         ancestor_lsn:
           type: string
+        current_logical_size:
+          type: integer
+        current_logical_size_non_incremental:
+          type: integer
     Error:
       type: object
       required:

--- a/test_runner/batch_others/test_timeline_size.py
+++ b/test_runner/batch_others/test_timeline_size.py
@@ -1,0 +1,39 @@
+from contextlib import closing
+from uuid import UUID
+import psycopg2.extras
+from fixtures.zenith_fixtures import PostgresFactory, ZenithPageserver
+
+
+def test_timeline_size(
+    zenith_cli, pageserver: ZenithPageserver, postgres: PostgresFactory, pg_bin
+):
+    # Branch at the point where only 100 rows were inserted
+    zenith_cli.run(["branch", "test_timeline_size", "empty"])
+
+    client = pageserver.http_client()
+    res = client.branch_detail(UUID(pageserver.initial_tenant), "test_timeline_size")
+    assert res["current_logical_size"] == res["current_logical_size_non_incremental"]
+
+    pgmain = postgres.create_start("test_timeline_size")
+    print("postgres is running on 'test_timeline_size' branch")
+
+    with closing(pgmain.connect()) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SHOW zenith.zenith_timeline")
+
+            # Create table, and insert the first 100 rows
+            cur.execute("CREATE TABLE foo (t text)")
+            cur.execute(
+                """
+                INSERT INTO foo
+                    SELECT 'long string to consume some space' || g
+                    FROM generate_series(1, 10) g
+            """
+            )
+
+            res = client.branch_detail(UUID(pageserver.initial_tenant), "test_timeline_size")
+            assert res["current_logical_size"] == res["current_logical_size_non_incremental"]
+            cur.execute("TRUNCATE foo")
+
+            res = client.branch_detail(UUID(pageserver.initial_tenant), "test_timeline_size")
+            assert res["current_logical_size"] == res["current_logical_size_non_incremental"]

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -224,6 +224,13 @@ class ZenithPageserverHttpClient(requests.Session):
         res.raise_for_status()
         return res.json()
 
+    def branch_detail(self, tenant_id: uuid.UUID, name: str) -> Dict:
+        res = self.get(
+            f"http://localhost:{self.port}/v1/branch/{tenant_id.hex}/{name}",
+        )
+        res.raise_for_status()
+        return res.json()
+
     def tenant_list(self) -> List[str]:
         res = self.get(f"http://localhost:{self.port}/v1/tenant")
         res.raise_for_status()

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -13,7 +13,6 @@ use zenith_utils::postgres_backend::AuthType;
 use zenith_utils::zid::{ZTenantId, ZTimelineId};
 
 use pageserver::branches::BranchInfo;
-use zenith_utils::lsn::Lsn;
 
 ///
 /// Branches tree element used as a value in the HashMap.
@@ -393,9 +392,7 @@ fn handle_branch(branch_match: &ArgMatches, env: &local_env::LocalEnv) -> Result
         let branch = pageserver.branch_create(branchname, startpoint_str, &tenantid)?;
         println!(
             "Created branch '{}' at {:?} for tenant: {}",
-            branch.name,
-            branch.latest_valid_lsn.unwrap_or(Lsn(0)),
-            tenantid,
+            branch.name, branch.latest_valid_lsn, tenantid,
         );
     } else {
         let tenantid: ZTenantId = branch_match
@@ -434,9 +431,7 @@ fn handle_pg(pg_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
                     node.address,
                     branch_infos
                         .get(&node.timelineid)
-                        .map(|bi| bi
-                            .latest_valid_lsn
-                            .map_or("?".to_string(), |lsn| lsn.to_string()))
+                        .map(|bi| bi.latest_valid_lsn.to_string())
                         .unwrap_or_else(|| "?".to_string()),
                     node.status(),
                 );


### PR DESCRIPTION
This is a one of the first steps towards introduction of quotas and their enforcement

Contains incremental tracking of logical timeline size (without versioning overhead) and new endpoint in pageserver http api which provides access to details about particular branch.

- [x] TODO: use new endpoint in zenith cli instead of retrieval of all branches when needed

ref #316 