### PR TITLE
fix clippy warnings

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -74,7 +74,10 @@ impl PageServerNode {
             args.extend(&["--auth-type", "ZenithJWT"]);
         }
 
-        create_tenant.map(|tenantid| args.extend(&["--create-tenant", tenantid]));
+        if let Some(tenantid) = create_tenant {
+            args.extend(&["--create-tenant", tenantid])
+        }
+
         let status = cmd
             .args(args)
             .env_clear()

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -84,10 +84,10 @@ impl<'a> Basebackup<'a> {
         for filepath in pg_constants::PGDATA_SPECIAL_FILES.iter() {
             if *filepath == "pg_hba.conf" {
                 let data = pg_constants::PG_HBA.as_bytes();
-                let header = new_tar_header(&filepath, data.len() as u64)?;
-                self.ar.append(&header, &data[..])?;
+                let header = new_tar_header(filepath, data.len() as u64)?;
+                self.ar.append(&header, data)?;
             } else {
-                let header = new_tar_header(&filepath, 0)?;
+                let header = new_tar_header(filepath, 0)?;
                 self.ar.append(&header, &mut io::empty())?;
             }
         }
@@ -166,14 +166,12 @@ impl<'a> Basebackup<'a> {
             self.lsn,
         )?;
         let path = if spcnode == pg_constants::GLOBALTABLESPACE_OID {
-            let dst_path = "PG_VERSION";
             let version_bytes = pg_constants::PG_MAJORVERSION.as_bytes();
-            let header = new_tar_header(&dst_path, version_bytes.len() as u64)?;
-            self.ar.append(&header, &version_bytes[..])?;
+            let header = new_tar_header("PG_VERSION", version_bytes.len() as u64)?;
+            self.ar.append(&header, version_bytes)?;
 
-            let dst_path = format!("global/PG_VERSION");
-            let header = new_tar_header(&dst_path, version_bytes.len() as u64)?;
-            self.ar.append(&header, &version_bytes[..])?;
+            let header = new_tar_header("global/PG_VERSION", version_bytes.len() as u64)?;
+            self.ar.append(&header, version_bytes)?;
 
             String::from("global/pg_filenode.map") // filenode map for global tablespace
         } else {
@@ -188,7 +186,7 @@ impl<'a> Basebackup<'a> {
             let dst_path = format!("base/{}/PG_VERSION", dbnode);
             let version_bytes = pg_constants::PG_MAJORVERSION.as_bytes();
             let header = new_tar_header(&dst_path, version_bytes.len() as u64)?;
-            self.ar.append(&header, &version_bytes[..])?;
+            self.ar.append(&header, version_bytes)?;
 
             format!("base/{}/pg_filenode.map", dbnode)
         };

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -113,7 +113,7 @@ impl CfgFileParams {
             .auth_type
             .as_ref()
             .map_or(Ok(AuthType::Trust), |auth_type| {
-                AuthType::from_str(&auth_type)
+                AuthType::from_str(auth_type)
             })?;
 
         if !pg_distrib_dir.join("bin/postgres").exists() {
@@ -273,7 +273,7 @@ fn main() -> Result<()> {
 
 fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
     // Initialize logger
-    let (_scope_guard, log_file) = logger::init_logging(&conf, "pageserver.log")?;
+    let (_scope_guard, log_file) = logger::init_logging(conf, "pageserver.log")?;
     let _log_guard = slog_stdlog::init()?;
 
     // Note: this `info!(...)` macro comes from `log` crate

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -43,7 +43,7 @@ pub struct PointInTime {
 
 pub fn init_pageserver(conf: &'static PageServerConf, create_tenant: Option<&str>) -> Result<()> {
     // Initialize logger
-    let (_scope_guard, _log_file) = logger::init_logging(&conf, "pageserver.log")?;
+    let (_scope_guard, _log_file) = logger::init_logging(conf, "pageserver.log")?;
     let _log_guard = slog_stdlog::init()?;
 
     // We don't use the real WAL redo manager, because we don't want to spawn the WAL redo
@@ -284,7 +284,7 @@ pub(crate) fn create_branch(
     // FIXME: there's a race condition, if you create a branch with the same
     // name concurrently.
     let data = newtli.to_string();
-    fs::write(conf.branch_path(&branchname, tenantid), data)?;
+    fs::write(conf.branch_path(branchname, tenantid), data)?;
 
     Ok(BranchInfo {
         name: branchname.to_string(),
@@ -333,21 +333,21 @@ fn parse_point_in_time(
 
     // Check if it's a tag
     if lsn.is_none() {
-        let tagpath = conf.tag_path(name, &tenantid);
+        let tagpath = conf.tag_path(name, tenantid);
         if tagpath.exists() {
             let pointstr = fs::read_to_string(tagpath)?;
 
-            return parse_point_in_time(conf, &pointstr, &tenantid);
+            return parse_point_in_time(conf, &pointstr, tenantid);
         }
     }
 
     // Check if it's a branch
     // Check if it's branch @ LSN
-    let branchpath = conf.branch_path(name, &tenantid);
+    let branchpath = conf.branch_path(name, tenantid);
     if branchpath.exists() {
         let pointstr = fs::read_to_string(branchpath)?;
 
-        let mut result = parse_point_in_time(conf, &pointstr, &tenantid)?;
+        let mut result = parse_point_in_time(conf, &pointstr, tenantid)?;
 
         result.lsn = lsn.unwrap_or(Lsn(0));
         return Ok(result);
@@ -356,7 +356,7 @@ fn parse_point_in_time(
     // Check if it's a timelineid
     // Check if it's timelineid @ LSN
     if let Ok(timelineid) = ZTimelineId::from_str(name) {
-        let tlipath = conf.timeline_path(&timelineid, &tenantid);
+        let tlipath = conf.timeline_path(&timelineid, tenantid);
         if tlipath.exists() {
             return Ok(PointInTime {
                 timelineid,

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -130,23 +130,23 @@ pub struct DeltaLayerInner {
 
 impl Layer for DeltaLayer {
     fn get_timeline_id(&self) -> ZTimelineId {
-        return self.timelineid;
+        self.timelineid
     }
 
     fn get_seg_tag(&self) -> SegmentTag {
-        return self.seg;
+        self.seg
     }
 
     fn is_dropped(&self) -> bool {
-        return self.dropped;
+        self.dropped
     }
 
     fn get_start_lsn(&self) -> Lsn {
-        return self.start_lsn;
+        self.start_lsn
     }
 
     fn get_end_lsn(&self) -> Lsn {
-        return self.end_lsn;
+        self.end_lsn
     }
 
     fn filename(&self) -> PathBuf {
@@ -358,6 +358,7 @@ impl DeltaLayer {
     /// This is used to write the in-memory layer to disk. The in-memory layer uses the same
     /// data structure with two btreemaps as we do, so passing the btreemaps is currently
     /// expedient.
+    #[allow(clippy::too_many_arguments)]
     pub fn create(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
@@ -372,16 +373,16 @@ impl DeltaLayer {
     ) -> Result<DeltaLayer> {
         let delta_layer = DeltaLayer {
             path_or_conf: PathOrConf::Conf(conf),
-            timelineid: timelineid,
-            tenantid: tenantid,
-            seg: seg,
-            start_lsn: start_lsn,
+            timelineid,
+            tenantid,
+            seg,
+            start_lsn,
             end_lsn,
             dropped,
             inner: Mutex::new(DeltaLayerInner {
                 loaded: true,
                 page_version_metas: BTreeMap::new(),
-                relsizes: relsizes,
+                relsizes,
             }),
             predecessor,
         };

--- a/pageserver/src/layered_repository/filename.rs
+++ b/pageserver/src/layered_repository/filename.rs
@@ -111,8 +111,10 @@ impl DeltaFileName {
             dropped,
         })
     }
+}
 
-    fn to_string(&self) -> String {
+impl fmt::Display for DeltaFileName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let basename = match self.seg.rel {
             RelishTag::Relation(reltag) => format!(
                 "rel_{}_{}_{}_{}",
@@ -134,11 +136,12 @@ impl DeltaFileName {
                 format!("pg_filenodemap_{}_{}", spcnode, dbnode)
             }
             RelishTag::TwoPhase { xid } => format!("pg_twophase_{}", xid),
-            RelishTag::Checkpoint => format!("pg_control_checkpoint"),
-            RelishTag::ControlFile => format!("pg_control"),
+            RelishTag::Checkpoint => "pg_control_checkpoint".to_string(),
+            RelishTag::ControlFile => "pg_control".to_string(),
         };
 
-        format!(
+        write!(
+            f,
             "{}_{}_{:016X}_{:016X}{}",
             basename,
             self.seg.segno,
@@ -146,12 +149,6 @@ impl DeltaFileName {
             u64::from(self.end_lsn),
             if self.dropped { "_DROPPED" } else { "" }
         )
-    }
-}
-
-impl fmt::Display for DeltaFileName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_string())
     }
 }
 
@@ -233,8 +230,10 @@ impl ImageFileName {
 
         Some(ImageFileName { seg, lsn })
     }
+}
 
-    fn to_string(&self) -> String {
+impl fmt::Display for ImageFileName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let basename = match self.seg.rel {
             RelishTag::Relation(reltag) => format!(
                 "rel_{}_{}_{}_{}",
@@ -256,22 +255,17 @@ impl ImageFileName {
                 format!("pg_filenodemap_{}_{}", spcnode, dbnode)
             }
             RelishTag::TwoPhase { xid } => format!("pg_twophase_{}", xid),
-            RelishTag::Checkpoint => format!("pg_control_checkpoint"),
-            RelishTag::ControlFile => format!("pg_control"),
+            RelishTag::Checkpoint => "pg_control_checkpoint".to_string(),
+            RelishTag::ControlFile => "pg_control".to_string(),
         };
 
-        format!(
+        write!(
+            f,
             "{}_{}_{:016X}",
             basename,
             self.seg.segno,
             u64::from(self.lsn),
         )
-    }
-}
-
-impl fmt::Display for ImageFileName {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_string())
     }
 }
 
@@ -302,7 +296,7 @@ pub fn list_files(
             warn!("unrecognized filename in timeline dir: {}", fname);
         }
     }
-    return Ok((imgfiles, deltafiles));
+    Ok((imgfiles, deltafiles))
 }
 
 /// Helper enum to hold a PageServerConf, or a path

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -97,23 +97,23 @@ impl Layer for ImageLayer {
     }
 
     fn get_timeline_id(&self) -> ZTimelineId {
-        return self.timelineid;
+        self.timelineid
     }
 
     fn get_seg_tag(&self) -> SegmentTag {
-        return self.seg;
+        self.seg
     }
 
     fn is_dropped(&self) -> bool {
-        return false;
+        false
     }
 
     fn get_start_lsn(&self) -> Lsn {
-        return self.lsn;
+        self.lsn
     }
 
     fn get_end_lsn(&self) -> Lsn {
-        return self.lsn;
+        self.lsn
     }
 
     /// Look up given page in the file
@@ -255,10 +255,10 @@ impl ImageLayer {
 
         let layer = ImageLayer {
             path_or_conf: PathOrConf::Conf(conf),
-            timelineid: timelineid,
-            tenantid: tenantid,
-            seg: seg,
-            lsn: lsn,
+            timelineid,
+            tenantid,
+            seg,
+            lsn,
             inner: Mutex::new(ImageLayerInner {
                 loaded: true,
                 image_type: image_type.clone(),

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -109,7 +109,7 @@ impl LayerMap {
 
         if let Some(open) = &segentry.open {
             if open.get_start_lsn() <= lsn {
-                let x: Arc<dyn Layer> = Arc::clone(&open) as _;
+                let x: Arc<dyn Layer> = Arc::clone(open) as _;
                 return Some(x);
             }
         }
@@ -119,7 +119,7 @@ impl LayerMap {
             .range((Included(Lsn(0)), Included(lsn)))
             .next_back()
         {
-            let x: Arc<dyn Layer> = Arc::clone(&v) as _;
+            let x: Arc<dyn Layer> = Arc::clone(v) as _;
             Some(x)
         } else {
             None
@@ -132,12 +132,7 @@ impl LayerMap {
     ///
     pub fn get_open(&self, tag: &SegmentTag) -> Option<Arc<InMemoryLayer>> {
         let segentry = self.segs.get(tag)?;
-
-        if let Some(open) = &segentry.open {
-            Some(Arc::clone(open))
-        } else {
-            None
-        }
+        segentry.open.as_ref().map(Arc::clone)
     }
 
     ///
@@ -161,7 +156,7 @@ impl LayerMap {
 
         let opensegentry = OpenSegEntry {
             oldest_pending_lsn: layer.get_oldest_pending_lsn(),
-            layer: layer,
+            layer,
             generation: self.current_generation,
         };
         self.open_segs.push(opensegentry);

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -372,7 +372,7 @@ impl PageServerHandler {
             .claims
             .as_ref()
             .expect("claims presence already checked");
-        Ok(auth::check_permission(claims, tenantid)?)
+        auth::check_permission(claims, tenantid)
     }
 }
 
@@ -389,7 +389,7 @@ impl postgres_backend::Handler for PageServerHandler {
             .as_ref()
             .as_ref()
             .unwrap()
-            .decode(&str::from_utf8(jwt_response)?)?;
+            .decode(str::from_utf8(jwt_response)?)?;
 
         if matches!(data.claims.scope, Scope::Tenant) {
             ensure!(
@@ -425,7 +425,7 @@ impl postgres_backend::Handler for PageServerHandler {
             self.handle_controlfile(pgb)?;
         } else if query_string.starts_with("pagestream ") {
             let (_, params_raw) = query_string.split_at("pagestream ".len());
-            let params = params_raw.split(" ").collect::<Vec<_>>();
+            let params = params_raw.split(' ').collect::<Vec<_>>();
             ensure!(
                 params.len() == 2,
                 "invalid param number for pagestream command"
@@ -484,7 +484,7 @@ impl postgres_backend::Handler for PageServerHandler {
                 .get_timeline(timelineid)
                 .context(format!("error fetching timeline {}", timelineid))?;
 
-            walreceiver::launch_wal_receiver(&self.conf, timelineid, &connstr, tenantid.to_owned());
+            walreceiver::launch_wal_receiver(self.conf, timelineid, &connstr, tenantid.to_owned());
 
             pgb.write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
         } else if query_string.starts_with("branch_create ") {
@@ -495,7 +495,7 @@ impl postgres_backend::Handler for PageServerHandler {
             // TOOD: escaping, to allow branch names with spaces
             let re = Regex::new(r"^branch_create ([[:xdigit:]]+) (\S+) ([^\r\n\s;]+)[\r\n\s;]*;?$")
                 .unwrap();
-            let caps = re.captures(&query_string).ok_or_else(err)?;
+            let caps = re.captures(query_string).ok_or_else(err)?;
 
             let tenantid = ZTenantId::from_str(caps.get(1).unwrap().as_str())?;
             let branchname = caps.get(2).ok_or_else(err)?.as_str().to_owned();
@@ -504,7 +504,7 @@ impl postgres_backend::Handler for PageServerHandler {
             self.check_permission(Some(tenantid))?;
 
             let branch =
-                branches::create_branch(&self.conf, &branchname, &startpoint_str, &tenantid)?;
+                branches::create_branch(self.conf, &branchname, &startpoint_str, &tenantid)?;
             let branch = serde_json::to_vec(&branch)?;
 
             pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?
@@ -519,14 +519,14 @@ impl postgres_backend::Handler for PageServerHandler {
 
             let tenantid = ZTenantId::from_str(caps.get(1).unwrap().as_str())?;
 
-            let branches = crate::branches::get_branches(&self.conf, &tenantid)?;
+            let branches = crate::branches::get_branches(self.conf, &tenantid)?;
             let branches_buf = serde_json::to_vec(&branches)?;
 
             pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?
                 .write_message_noflush(&BeMessage::DataRow(&[Some(&branches_buf)]))?
                 .write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
         } else if query_string.starts_with("tenant_list") {
-            let tenants = crate::branches::get_tenants(&self.conf)?;
+            let tenants = crate::branches::get_tenants(self.conf)?;
             let tenants_buf = serde_json::to_vec(&tenants)?;
 
             pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?
@@ -537,13 +537,13 @@ impl postgres_backend::Handler for PageServerHandler {
 
             // tenant_create <tenantid>
             let re = Regex::new(r"^tenant_create ([[:xdigit:]]+)$").unwrap();
-            let caps = re.captures(&query_string).ok_or_else(err)?;
+            let caps = re.captures(query_string).ok_or_else(err)?;
 
             self.check_permission(None)?;
 
             let tenantid = ZTenantId::from_str(caps.get(1).unwrap().as_str())?;
 
-            tenant_mgr::create_repository_for_tenant(&self.conf, tenantid)?;
+            tenant_mgr::create_repository_for_tenant(self.conf, tenantid)?;
 
             pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?
                 .write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
@@ -597,39 +597,39 @@ impl postgres_backend::Handler for PageServerHandler {
                 RowDescriptor::int8_col(b"elapsed"),
             ]))?
             .write_message_noflush(&BeMessage::DataRow(&[
-                Some(&result.ondisk_relfiles_total.to_string().as_bytes()),
+                Some(result.ondisk_relfiles_total.to_string().as_bytes()),
                 Some(
-                    &result
+                    result
                         .ondisk_relfiles_needed_by_cutoff
                         .to_string()
                         .as_bytes(),
                 ),
                 Some(
-                    &result
+                    result
                         .ondisk_relfiles_needed_by_branches
                         .to_string()
                         .as_bytes(),
                 ),
-                Some(&result.ondisk_relfiles_not_updated.to_string().as_bytes()),
-                Some(&result.ondisk_relfiles_removed.to_string().as_bytes()),
-                Some(&result.ondisk_relfiles_dropped.to_string().as_bytes()),
-                Some(&result.ondisk_nonrelfiles_total.to_string().as_bytes()),
+                Some(result.ondisk_relfiles_not_updated.to_string().as_bytes()),
+                Some(result.ondisk_relfiles_removed.to_string().as_bytes()),
+                Some(result.ondisk_relfiles_dropped.to_string().as_bytes()),
+                Some(result.ondisk_nonrelfiles_total.to_string().as_bytes()),
                 Some(
-                    &result
+                    result
                         .ondisk_nonrelfiles_needed_by_cutoff
                         .to_string()
                         .as_bytes(),
                 ),
                 Some(
-                    &result
+                    result
                         .ondisk_nonrelfiles_needed_by_branches
                         .to_string()
                         .as_bytes(),
                 ),
-                Some(&result.ondisk_nonrelfiles_not_updated.to_string().as_bytes()),
-                Some(&result.ondisk_nonrelfiles_removed.to_string().as_bytes()),
-                Some(&result.ondisk_nonrelfiles_dropped.to_string().as_bytes()),
-                Some(&result.elapsed.as_millis().to_string().as_bytes()),
+                Some(result.ondisk_nonrelfiles_not_updated.to_string().as_bytes()),
+                Some(result.ondisk_nonrelfiles_removed.to_string().as_bytes()),
+                Some(result.ondisk_nonrelfiles_dropped.to_string().as_bytes()),
+                Some(result.elapsed.as_millis().to_string().as_bytes()),
             ]))?
             .write_message(&BeMessage::CommandComplete(b"SELECT 1"))?;
         } else {

--- a/pageserver/src/relish.rs
+++ b/pageserver/src/relish.rs
@@ -125,11 +125,7 @@ impl RelishTag {
 
     // convenience function to check if this relish is a normal relation.
     pub const fn is_relation(&self) -> bool {
-        if let RelishTag::Relation(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, RelishTag::Relation(_))
     }
 }
 

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -113,7 +113,7 @@ pub trait Timeline: Send + Sync {
     fn list_rels(&self, spcnode: u32, dbnode: u32, lsn: Lsn) -> Result<HashSet<RelTag>>;
 
     /// Get a list of non-relational objects
-    fn list_nonrels<'a>(&'a self, lsn: Lsn) -> Result<HashSet<RelishTag>>;
+    fn list_nonrels(&self, lsn: Lsn) -> Result<HashSet<RelishTag>>;
 
     //------------------------------------------------------------------------------
     // Public PUT functions, to update the repository with new page versions.
@@ -201,6 +201,7 @@ impl WALRecord {
 ///
 /// Tests that should work the same with any Repository/Timeline implementation.
 ///
+#[allow(clippy::bool_assert_comparison)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pageserver/src/waldecoder.rs
+++ b/pageserver/src/waldecoder.rs
@@ -197,6 +197,7 @@ impl WalStreamDecoder {
 }
 
 #[allow(dead_code)]
+#[derive(Default)]
 pub struct DecodedBkpBlock {
     /* Is this block ref in use? */
     //in_use: bool,
@@ -229,25 +230,7 @@ pub struct DecodedBkpBlock {
 
 impl DecodedBkpBlock {
     pub fn new() -> DecodedBkpBlock {
-        DecodedBkpBlock {
-            rnode_spcnode: 0,
-            rnode_dbnode: 0,
-            rnode_relnode: 0,
-            forknum: 0,
-            blkno: 0,
-
-            flags: 0,
-            has_image: false,
-            apply_image: false,
-            will_init: false,
-            hole_offset: 0,
-            hole_length: 0,
-            bimg_len: 0,
-            bimg_info: 0,
-
-            has_data: false,
-            data_len: 0,
-        }
+        Default::default()
     }
 }
 

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -457,7 +457,7 @@ fn write_wal_file(
                 {
                     Ok(mut file) => {
                         for _ in 0..(wal_seg_size / XLOG_BLCKSZ) {
-                            file.write_all(&ZERO_BLOCK)?;
+                            file.write_all(ZERO_BLOCK)?;
                         }
                         wal_file = file;
                     }

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -209,7 +209,7 @@ impl WalRedoManager for PostgresRedoManager {
             let process = (*process_guard).as_ref().unwrap();
 
             self.runtime
-                .block_on(self.handle_apply_request(&process, &request))
+                .block_on(self.handle_apply_request(process, &request))
         };
         end_time = Instant::now();
 
@@ -453,7 +453,7 @@ impl PostgresRedoProcess {
         // FIXME: We need a dummy Postgres cluster to run the process in. Currently, we
         // just create one with constant name. That fails if you try to launch more than
         // one WAL redo manager concurrently.
-        let datadir = conf.tenant_path(&tenantid).join("wal-redo-datadir");
+        let datadir = conf.tenant_path(tenantid).join("wal-redo-datadir");
 
         // Create empty data directory for wal-redo postgres, deleting old one first.
         if datadir.exists() {

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -189,11 +189,11 @@ pub const XLOG_CHECKPOINT_SHUTDOWN: u8 = 0x00;
 pub const XLOG_CHECKPOINT_ONLINE: u8 = 0x10;
 pub const XLP_LONG_HEADER: u16 = 0x0002;
 
-pub const PG_MAJORVERSION: &'static str = "14";
+pub const PG_MAJORVERSION: &str = "14";
 
 // List of subdirectories inside pgdata.
 // Copied from src/bin/initdb/initdb.c
-pub const PGDATA_SUBDIRS: [&'static str; 22] = [
+pub const PGDATA_SUBDIRS: [&str; 22] = [
     "global",
     "pg_wal/archive_status",
     "pg_commit_ts",
@@ -218,11 +218,11 @@ pub const PGDATA_SUBDIRS: [&'static str; 22] = [
     "pg_logical/mappings",
 ];
 
-pub const PGDATA_SPECIAL_FILES: [&'static str; 4] = [
+pub const PGDATA_SPECIAL_FILES: [&str; 4] = [
     "pg_hba.conf",
     "pg_ident.conf",
     "postgresql.conf",
     "postgresql.auto.conf",
 ];
 
-pub static PG_HBA: &'static str = include_str!("../samples/pg_hba.conf");
+pub static PG_HBA: &str = include_str!("../samples/pg_hba.conf");

--- a/postgres_ffi/src/xlog_utils.rs
+++ b/postgres_ffi/src/xlog_utils.rs
@@ -37,6 +37,7 @@ pub const MAX_SEND_SIZE: usize = XLOG_BLCKSZ * 16;
 pub const XLOG_SIZE_OF_XLOG_SHORT_PHD: usize = std::mem::size_of::<XLogPageHeaderData>();
 pub const XLOG_SIZE_OF_XLOG_LONG_PHD: usize = std::mem::size_of::<XLogLongPageHeaderData>();
 pub const XLOG_SIZE_OF_XLOG_RECORD: usize = std::mem::size_of::<XLogRecord>();
+#[allow(clippy::identity_op)]
 pub const SIZE_OF_XLOG_RECORD_DATA_HEADER_SHORT: usize = 1 * 2;
 
 pub type XLogRecPtr = u64;
@@ -173,12 +174,11 @@ fn find_end_of_wal_segment(
                 let crc_offs = page_offs - rec_offs + XLOG_RECORD_CRC_OFFS;
                 wal_crc = LittleEndian::read_u32(&buf[crc_offs..crc_offs + 4]);
                 crc = crc32c_append(0, &buf[crc_offs + 4..page_offs + n]);
-                crc = !crc;
             } else {
                 crc ^= 0xFFFFFFFFu32;
                 crc = crc32c_append(crc, &buf[page_offs..page_offs + n]);
-                crc = !crc;
             }
+            crc = !crc;
             rec_offs += n;
             offs += n;
             contlen -= n;
@@ -465,7 +465,7 @@ mod tests {
         let waldump_output = std::str::from_utf8(&waldump_output.stderr).unwrap();
         println!("waldump_output = '{}'", &waldump_output);
         let re = Regex::new(r"invalid record length at (.+):").unwrap();
-        let caps = re.captures(&waldump_output).unwrap();
+        let caps = re.captures(waldump_output).unwrap();
         let waldump_wal_end = Lsn::from_str(caps.get(1).unwrap().as_str()).unwrap();
 
         // 5. Rename file to partial to actually find last valid lsn

--- a/proxy/src/cplane_api.rs
+++ b/proxy/src/cplane_api.rs
@@ -56,7 +56,7 @@ impl CPlaneApi {
             md5::compute([stored_hash.as_bytes(), salt].concat())
         );
 
-        let received_hash = std::str::from_utf8(&md5_response)?;
+        let received_hash = std::str::from_utf8(md5_response)?;
 
         println!(
             "auth: {} rh={} sh={} ssh={} {:?}",

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -143,10 +143,10 @@ fn main() -> anyhow::Result<()> {
         // for each connection.
         thread::Builder::new()
             .name("Proxy thread".into())
-            .spawn(move || proxy::thread_main(&state, pageserver_listener))?,
+            .spawn(move || proxy::thread_main(state, pageserver_listener))?,
         thread::Builder::new()
             .name("Mgmt thread".into())
-            .spawn(move || mgmt::thread_main(&state, mgmt_listener))?,
+            .spawn(move || mgmt::thread_main(state, mgmt_listener))?,
     ];
 
     for t in threads.into_iter() {

--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -148,7 +148,7 @@ impl ReplicationConn {
             }
         });
 
-        let (mut start_pos, mut stop_pos) = Self::parse_start_stop(&cmd)?;
+        let (mut start_pos, mut stop_pos) = Self::parse_start_stop(cmd)?;
 
         let mut wal_seg_size: usize;
         loop {

--- a/walkeeper/src/timeline.rs
+++ b/walkeeper/src/timeline.rs
@@ -127,7 +127,7 @@ impl SharedState {
                     if let CreateControlFile::False = create {
                         bail!("control file is empty");
                     }
-                    return Ok((file, SafeKeeperState::new()));
+                    Ok((file, SafeKeeperState::new()))
                 } else {
                     match SafeKeeperState::des_from(&mut file) {
                         Err(e) => {
@@ -144,7 +144,7 @@ impl SharedState {
                                     SK_FORMAT_VERSION
                                 );
                             }
-                            return Ok((file, s));
+                            Ok((file, s))
                         }
                     }
                 }
@@ -220,11 +220,8 @@ impl Timeline {
             commit_lsn = min(shared_state.sk.flush_lsn, shared_state.sk.s.commit_lsn);
 
             // if this is AppendResponse, fill in proper hot standby feedback
-            match rmsg {
-                AcceptorProposerMessage::AppendResponse(ref mut resp) => {
-                    resp.hs_feedback = shared_state.hs_feedback.clone();
-                }
-                _ => (),
+            if let AcceptorProposerMessage::AppendResponse(ref mut resp) = rmsg {
+                resp.hs_feedback = shared_state.hs_feedback.clone();
             }
         }
         // Ping wal sender that new data might be available.
@@ -401,7 +398,7 @@ impl Storage for FileStorage {
                     {
                         Ok(mut file) => {
                             for _ in 0..(wal_seg_size / XLOG_BLCKSZ) {
-                                file.write_all(&ZERO_BLOCK)?;
+                                file.write_all(ZERO_BLOCK)?;
                             }
                             wal_file = file;
                         }

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -359,7 +359,7 @@ fn get_branch_infos(
 }
 
 fn handle_tenant(tenant_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
-    let pageserver = PageServerNode::from_env(&env);
+    let pageserver = PageServerNode::from_env(env);
     match tenant_match.subcommand() {
         ("list", Some(_)) => {
             for tenant in pageserver.tenant_list()? {
@@ -381,12 +381,12 @@ fn handle_tenant(tenant_match: &ArgMatches, env: &local_env::LocalEnv) -> Result
 }
 
 fn handle_branch(branch_match: &ArgMatches, env: &local_env::LocalEnv) -> Result<()> {
-    let pageserver = PageServerNode::from_env(&env);
+    let pageserver = PageServerNode::from_env(env);
 
     if let Some(branchname) = branch_match.value_of("branchname") {
         let startpoint_str = branch_match
             .value_of("start-point")
-            .ok_or(anyhow!("Missing start-point"))?;
+            .ok_or_else(|| anyhow!("Missing start-point"))?;
         let tenantid: ZTenantId = branch_match
             .value_of("tenantid")
             .map_or(Ok(env.tenantid), |value| value.parse())?;

--- a/zenith_metrics/src/lib.rs
+++ b/zenith_metrics/src/lib.rs
@@ -42,6 +42,7 @@ lazy_static! {
 // performed by the process.
 // We know the the size of the block, so we can determine the I/O bytes out of it.
 // The value might be not 100% exact, but should be fine for Prometheus metrics in this case.
+#[allow(clippy::unnecessary_cast)]
 fn update_io_metrics() {
     let mut usage = rusage {
         ru_utime: timeval {

--- a/zenith_utils/src/http/endpoint.rs
+++ b/zenith_utils/src/http/endpoint.rs
@@ -95,13 +95,13 @@ pub fn attach_openapi_ui(
 
 fn parse_token(header_value: &str) -> Result<&str, ApiError> {
     // header must be in form Bearer <token>
-    let (prefix, token) = header_value.split_once(' ').ok_or(ApiError::Unauthorized(
-        "malformed authorization header".to_string(),
-    ))?;
+    let (prefix, token) = header_value
+        .split_once(' ')
+        .ok_or_else(|| ApiError::Unauthorized("malformed authorization header".to_string()))?;
     if prefix != "Bearer" {
-        Err(ApiError::Unauthorized(
+        return Err(ApiError::Unauthorized(
             "malformed authorization header".to_string(),
-        ))?
+        ));
     }
     Ok(token)
 }
@@ -123,9 +123,11 @@ pub fn auth_middleware<B: hyper::body::HttpBody + Send + Sync + 'static>(
                         .map_err(|_| ApiError::Unauthorized("malformed jwt token".to_string()))?;
                     req.set_context(data.claims);
                 }
-                None => Err(ApiError::Unauthorized(
-                    "missing authorization header".to_string(),
-                ))?,
+                None => {
+                    return Err(ApiError::Unauthorized(
+                        "missing authorization header".to_string(),
+                    ))
+                }
             }
         }
         Ok(req)

--- a/zenith_utils/src/lib.rs
+++ b/zenith_utils/src/lib.rs
@@ -1,6 +1,8 @@
 //! zenith_utils is intended to be a place to put code that is shared
 //! between other crates in this repository.
 
+#![allow(clippy::manual_range_contains)]
+
 /// `Lsn` type implements common tasks on Log Sequence Numbers
 pub mod lsn;
 /// SeqWait allows waiting for a future sequence number to arrive


### PR DESCRIPTION
I've fixed all clippy warnings for our code base according to clippy's default configuration. Most of the changes are pretty mechanical. If something doesnt look right to you lets figure out which lints we should ignore and where to put #[allow] marks :)

This is a starting point to running clippy in the CI and adding it as a pre commit check similar to rustfmt

Command to run clippy: `cargo clippy --all-targets --all-features --all --tests -- -D warnings`