### PR TITLE
WIP: Run pgbench with vanilla PostgreSQL for performance comparison.

### DIFF
--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -1,6 +1,7 @@
 from pprint import pprint
 
 import os
+import re
 import timeit
 import pathlib
 import uuid
@@ -119,6 +120,27 @@ class ZenithBenchmarker:
         end = timeit.default_timer()
 
         self.results.record(self.request.node.name, metric_name, end - start, 's')
+
+    def get_io_writes(self, pageserver) -> int:
+        """
+        Fetch the "cumulative # of bytes written" metric from the pageserver
+        """
+        # Fetch all the exposed prometheus metrics from page server
+        all_metrics = pageserver.http_client().get_metrics()
+        # Use a regular expression to extract the one we're interested in
+        writes = re.search(r"pageserver_disk_io_bytes{io_operation=\"write\"} (\d+)", all_metrics)
+        return int(writes.group(1))
+
+    @contextmanager
+    def record_pageserver_writes(self, pageserver, metric_name):
+        """
+        Record bytes written by the pageserver during a test.
+        """
+        before = self.get_io_writes(pageserver)
+        yield
+        after = self.get_io_writes(pageserver)
+
+        self.results.record(self.request.node.name, metric_name, round((after - before) / (1024 * 1024)), 'MB')
 
 @pytest.fixture(scope='function')
 def zenbenchmark(zenbenchmark_global, request) -> Iterator[ZenithBenchmarker]:

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -226,6 +226,11 @@ class ZenithPageserverHttpClient(requests.Session):
         res.raise_for_status()
         return res.json()
 
+    def get_metrics(self) -> str:
+        res = self.get(f"http://localhost:{self.port}/metrics")
+        res.raise_for_status()
+        return res.text
+
 
 @dataclass
 class AuthKeys:


### PR DESCRIPTION
This adds a test to the performance test suite that runs pgbench in a
similar configuration that we use for the zenith pgbench test. That's
the baseline that we should be comparing zenith with.

This is pretty crude, I wrote the code to initialize and run Postgres
without any fancy python fixtures, and the pgbench invocations are
just copy-pasted from the zenith test. It would be nice to have better
helpers for running the same tests against vanilla Postgres and
zenith.

The metrics collected from vanilla postgres aren't exactly the same as
with zenith: the WAL and data size are accounted for separately, and
we don't collect # of bytes written from Postgres. So some interpretation
is needed to compare them fairly.