### PR TITLE
Prever MiB and GiB when applicable

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -68,7 +68,7 @@ static TIMEOUT: Duration = Duration::from_secs(60);
 // This puts a backstop on how much WAL needs to be re-digested if the
 // page server crashes.
 //
-// FIXME: This current value is very low. I would imagine something like 1 GB or 10 GB
+// FIXME: This current value is very low. I would imagine something like 1 GiB or 10 GiB
 // would be more appropriate. But a low value forces the code to be exercised more,
 // which is good for now to trigger bugs.
 static OLDEST_INMEM_DISTANCE: i128 = 16 * 1024 * 1024;

--- a/pageserver/src/layered_repository/README.md
+++ b/pageserver/src/layered_repository/README.md
@@ -225,7 +225,7 @@ because disk space isn't infinite.
 What files are still needed? Currently, the page server supports PITR
 and branching from any branch at any LSN that is "recent enough" from
 the tip of the branch.  "Recent enough" is defined as an LSN horizon,
-which by default is 64 MB.  (See DEFAULT_GC_HORIZON). For this
+which by default is 64 MiB.  (See DEFAULT_GC_HORIZON). For this
 example, let's assume that the LSN horizon is 150 units.
 
 Let's look at the single branch scenario again. Imagine that the end
@@ -255,9 +255,9 @@ table:
 	main/orders_200_300   DELETE
 	main/orders_300       STILL NEEDED BY orders_300_400
 	main/orders_300_400   KEEP, NEWER THAN GC HORIZON
-	main/orders_400       .. 
-	main/orders_400_500   .. 
-	main/orders_500       .. 
+	main/orders_400       ..
+	main/orders_400_500   ..
+	main/orders_500       ..
 	main/customers_100      DELETE
 	main/customers_100_200  DELETE
 	main/customers_200      KEEP, NO NEWER VERSION

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -14,12 +14,12 @@ use std::sync::Arc;
 
 use zenith_utils::lsn::Lsn;
 
-// Size of one segment in pages (10 MB)
+// Size of one segment in pages (10 MiB)
 pub const RELISH_SEG_SIZE: u32 = 10 * 1024 * 1024 / 8192;
 
 ///
 /// Each relish stored in the repository is divided into fixed-sized "segments",
-/// with 10 MB of key-space, or 1280 8k pages each.
+/// with 10 MiB of key-space, or 1280 8k pages each.
 ///
 #[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Copy)]
 pub struct SegmentTag {

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -234,7 +234,7 @@ fn walreceiver_main(
                     }
                 }
 
-                // Somewhat arbitrarily, if we have at least 10 complete wal segments (16 MB each),
+                // Somewhat arbitrarily, if we have at least 10 complete wal segments (16 MiB each),
                 // "checkpoint" the repository to flush all the changes from WAL we've processed
                 // so far to disk. After this, we don't need the original WAL anymore, and it
                 // can be removed. This is probably too aggressive for production, but it's useful

--- a/postgres_ffi/src/relfile_utils.rs
+++ b/postgres_ffi/src/relfile_utils.rs
@@ -134,7 +134,7 @@ mod tests {
         assert_eq!(parse_relfilename("0"), Ok((0, 0, 0)));
 
         // PostgreSQL has a limit of 2^32-2 blocks in a table. With 8k block size and
-        // 1 GB segments, the max segment number is 32767. But we accept larger values
+        // 1 GiB segments, the max segment number is 32767. But we accept larger values
         // currently.
         assert_eq!(parse_relfilename("1.123456"), Ok((1, 0, 123456)));
     }

--- a/test_runner/fixtures/benchmark_fixture.py
+++ b/test_runner/fixtures/benchmark_fixture.py
@@ -42,7 +42,7 @@ def test_mybench(postgres: PostgresFactory, pageserver: ZenithPageserver, zenben
 
     # Initialize the test
     ...
-    
+
     # Run the test, timing how long it takes
     with zenbenchmark.record_duration('test_query'):
         cur.execute('SELECT test_query(...)')
@@ -110,10 +110,10 @@ class ZenithBenchmarker:
     def record_duration(self, metric_name):
         """
         Record a duration. Usage:
-        
+
         with zenbenchmark.record_duration('foobar_runtime'):
             foobar()   # measure this
-        
+
         """
         start = timeit.default_timer()
         yield
@@ -148,7 +148,7 @@ class ZenithBenchmarker:
         yield
         after = self.get_io_writes(pageserver)
 
-        self.results.record(self.request.node.name, metric_name, round((after - before) / (1024 * 1024)), 'MB')
+        self.results.record(self.request.node.name, metric_name, round((after - before) / (1024 * 1024)), 'MiB')
 
 @pytest.fixture(scope='function')
 def zenbenchmark(zenbenchmark_global, request) -> Iterator[ZenithBenchmarker]:
@@ -182,7 +182,7 @@ def pytest_terminal_summary(
 
         terminalreporter.write("{}.{}: ".format(func, metric_name))
 
-        if unit == 'MB':
+        if unit == 'MiB':
             terminalreporter.write("{0:,.0f}".format(metric_value), green=True)
         elif unit == 's':
             terminalreporter.write("{0:,.3f}".format(metric_value), green=True)

--- a/test_runner/performance/test_perf_pgbench.py
+++ b/test_runner/performance/test_perf_pgbench.py
@@ -65,4 +65,4 @@ def test_pgbench(postgres: PostgresFactory, pageserver: ZenithPageserver, pg_bin
 
     # Report disk space used by the repository
     timeline_size = get_timeline_size(repo_dir, pageserver.initial_tenant, timeline)
-    zenbenchmark.record('size', timeline_size / (1024*1024), 'MB')
+    zenbenchmark.record('size', timeline_size / (1024*1024), 'MiB')


### PR DESCRIPTION
Closes https://github.com/zenithdb/zenith/issues/531

Had left a couple stray GB and MB mentions that are not obvious from the context, but I think we've spent enough time on this already.

I've also noticed how many MB and GB mentions are there in `vendor/postgres` and now think that I've rushed with the message 🙂 
As an alternative, I propose to close the PR and issue and leave things as they are, for consistency.