### PR TITLE
Forbid adding WAL to the repository after advancing last record LSN.

### DIFF
--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -221,11 +221,13 @@ fn bootstrap_timeline(
 
     info!("bootstrap_timeline {:?} at lsn {}", pgdata_path, lsn);
 
-    let timeline = repo.create_empty_timeline(tli, lsn)?;
+    // Import the contents of the data directory at the initial checkpoint
+    // LSN, and any WAL after that.
+    let timeline = repo.create_empty_timeline(tli)?;
     restore_local_repo::import_timeline_from_postgres_datadir(&pgdata_path, &*timeline, lsn)?;
 
     let wal_dir = pgdata_path.join("pg_wal");
-    restore_local_repo::import_timeline_wal(&wal_dir, &*timeline, timeline.get_last_record_lsn())?;
+    restore_local_repo::import_timeline_wal(&wal_dir, &*timeline, lsn)?;
 
     println!(
         "created initial timeline {} timeline.lsn {}",

--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -229,6 +229,8 @@ fn bootstrap_timeline(
     let wal_dir = pgdata_path.join("pg_wal");
     restore_local_repo::import_timeline_wal(&wal_dir, &*timeline, lsn)?;
 
+    timeline.checkpoint()?;
+
     println!(
         "created initial timeline {} timeline.lsn {}",
         tli,

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -863,11 +863,7 @@ impl Timeline for LayeredTimeline {
     fn advance_last_record_lsn(&self, new_lsn: Lsn) {
         assert!(new_lsn.is_aligned());
 
-        let old_lsn = self.last_record_lsn.advance(new_lsn);
-
-        // since we are align incoming LSN's we can't have delta less
-        // then 0x8
-        assert!(old_lsn == new_lsn || (new_lsn.0 - old_lsn.0 >= 0x8));
+        self.last_record_lsn.advance(new_lsn);
     }
 
     fn get_last_record_lsn(&self) -> Lsn {
@@ -1108,7 +1104,7 @@ impl LayeredTimeline {
         assert!(lsn.is_aligned());
 
         let last_record_lsn = self.get_last_record_lsn();
-        if lsn < last_record_lsn {
+        if lsn <= last_record_lsn {
             panic!(
                 "cannot modify relation after advancing last_record_lsn (incoming_lsn={}, last_record_lsn={})",
                 lsn,

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -124,23 +124,17 @@ impl Repository for LayeredRepository {
         Ok(self.get_timeline_locked(timelineid, &mut timelines)?)
     }
 
-    fn create_empty_timeline(
-        &self,
-        timelineid: ZTimelineId,
-        start_lsn: Lsn,
-    ) -> Result<Arc<dyn Timeline>> {
+    fn create_empty_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<dyn Timeline>> {
         let mut timelines = self.timelines.lock().unwrap();
-
-        assert!(start_lsn.is_aligned());
 
         // Create the timeline directory, and write initial metadata to file.
         std::fs::create_dir_all(self.conf.timeline_path(&timelineid, &self.tenantid))?;
 
         let metadata = TimelineMetadata {
-            disk_consistent_lsn: start_lsn,
+            disk_consistent_lsn: Lsn(0),
             prev_record_lsn: None,
             ancestor_timeline: None,
-            ancestor_lsn: start_lsn,
+            ancestor_lsn: Lsn(0),
         };
         Self::save_metadata(self.conf, timelineid, self.tenantid, &metadata)?;
 

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -17,11 +17,7 @@ pub trait Repository: Send + Sync {
     fn get_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<dyn Timeline>>;
 
     /// Create a new, empty timeline. The caller is responsible for loading data into it
-    fn create_empty_timeline(
-        &self,
-        timelineid: ZTimelineId,
-        start_lsn: Lsn,
-    ) -> Result<Arc<dyn Timeline>>;
+    fn create_empty_timeline(&self, timelineid: ZTimelineId) -> Result<Arc<dyn Timeline>>;
 
     /// Branch a timeline
     fn branch_timeline(&self, src: ZTimelineId, dst: ZTimelineId, start_lsn: Lsn) -> Result<()>;
@@ -300,7 +296,7 @@ mod tests {
 
         // Create timeline to work on
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
-        let tline = repo.create_empty_timeline(timelineid, Lsn(0x00))?;
+        let tline = repo.create_empty_timeline(timelineid)?;
 
         tline.put_page_image(TESTREL_A, 0, Lsn(0x20), TEST_IMG("foo blk 0 at 2"))?;
         tline.put_page_image(TESTREL_A, 0, Lsn(0x20), TEST_IMG("foo blk 0 at 2"))?;
@@ -416,7 +412,7 @@ mod tests {
     fn test_large_rel() -> Result<()> {
         let repo = get_test_repo("test_large_rel")?;
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
-        let tline = repo.create_empty_timeline(timelineid, Lsn(0x00))?;
+        let tline = repo.create_empty_timeline(timelineid)?;
 
         let mut lsn = 0x10;
         for blknum in 0..pg_constants::RELSEG_SIZE + 1 {
@@ -482,7 +478,7 @@ mod tests {
     fn test_list_rels_drop() -> Result<()> {
         let repo = get_test_repo("test_list_rels_drop")?;
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
-        let tline = repo.create_empty_timeline(timelineid, Lsn(0x00))?;
+        let tline = repo.create_empty_timeline(timelineid)?;
         const TESTDB: u32 = 111;
 
         // Import initial dummy checkpoint record, otherwise the get_timeline() call
@@ -539,7 +535,7 @@ mod tests {
     fn test_branch() -> Result<()> {
         let repo = get_test_repo("test_branch")?;
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
-        let tline = repo.create_empty_timeline(timelineid, Lsn(0x00))?;
+        let tline = repo.create_empty_timeline(timelineid)?;
 
         // Import initial dummy checkpoint record, otherwise the get_timeline() call
         // after branching fails below

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -373,9 +373,9 @@ mod tests {
         );
 
         // Truncate to zero length
-        tline.put_truncation(TESTREL_A, Lsn(0x60), 0)?;
-        tline.advance_last_record_lsn(Lsn(0x60));
-        assert_eq!(tline.get_relish_size(TESTREL_A, Lsn(0x60))?.unwrap(), 0);
+        tline.put_truncation(TESTREL_A, Lsn(0x68), 0)?;
+        tline.advance_last_record_lsn(Lsn(0x68));
+        assert_eq!(tline.get_relish_size(TESTREL_A, Lsn(0x68))?.unwrap(), 0);
 
         // Extend from 0 to 2 blocks, leaving a gap
         tline.put_page_image(TESTREL_A, 1, Lsn(0x70), TEST_IMG("foo blk 1"))?;

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -223,7 +223,6 @@ fn walreceiver_main(
                         recdata,
                         lsn,
                     )?;
-                    last_rec_lsn = lsn;
 
                     let new_checkpoint_bytes = checkpoint.encode();
                     // Check if checkpoint data was updated by save_decoded_record
@@ -235,6 +234,11 @@ fn walreceiver_main(
                             new_checkpoint_bytes,
                         )?;
                     }
+
+                    // Now that this record has been fully handled, including updating the
+                    // checkpoint data, let the repository know that it is up-to-date to this LSN
+                    timeline.advance_last_record_lsn(lsn);
+                    last_rec_lsn = lsn;
                 }
 
                 // Somewhat arbitrarily, if we have at least 10 complete wal segments (16 MB each),


### PR DESCRIPTION
When you advance last record LSN, *all* changes up to that LSN should be
imported into repository. We have been a bit sloppy about that when it
comes to the checkpoint information that we also store in the repository.
In WAL receiver, for example, we would receive a WAL record, advance
last record LSN, and only then update the checkpoint relish at the same
LSN. Reorder that so that you advance the last record LSN only after
updating the checkpoint relish. It hasn't apparently caused any problems
so far, but let's be tidy.

Tighten the check for that, so that it checks for 'lsn > last_record_lsn'
rather than 'lsn >= last_record_lsn'.
