### PR TITLE
Add unit tests for drop_lsn and fix.

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1384,7 +1384,9 @@ impl LayeredTimeline {
             // Finally, replace the frozen in-memory layer with the new on-disk layers
             layers.remove_historic(frozen.as_ref());
 
-            //FIXME This needs a comment.
+            // If we created a successor InMemoryLayer, its predecessor is
+            // currently the frozen layer. We need to update the predecessor
+            // to be the latest on-disk layer.
             if let Some(last_historic) = new_historics.last() {
                 if let Some(new_open) = &maybe_new_open {
                     let maybe_old_predecessor =
@@ -1395,6 +1397,7 @@ impl LayeredTimeline {
                 }
             }
 
+            // Add the historics to the LayerMap
             for n in new_historics {
                 layers.insert_historic(n);
             }

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -403,7 +403,7 @@ mod tests {
 
         // Create timeline to work on
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
-        let tline = repo.create_empty_timeline(timelineid, Lsn(0x00))?;
+        let tline = repo.create_empty_timeline(timelineid)?;
 
         tline.put_page_image(TESTREL_A, 0, Lsn(0x20), TEST_IMG("foo blk 0 at 2"))?;
         tline.advance_last_record_lsn(Lsn(0x20));
@@ -440,7 +440,7 @@ mod tests {
 
         // Create timeline to work on
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
-        let tline = repo.create_empty_timeline(timelineid, Lsn(0x00))?;
+        let tline = repo.create_empty_timeline(timelineid)?;
 
         //from storage_layer.rs
         const RELISH_SEG_SIZE: u32 = 10 * 1024 * 1024 / 8192;


### PR DESCRIPTION
test_drop_extend and test_truncate_extend illustrate what happens if we dropped a segment and then created it again within the same layer.
Fix: if get_layer_for_write() finds an existing open layer that is dropped, just mark it as non-writeable and create a new open layer for write.

TODO:
- [x] handle non-writeable open layers in checkpointer.
- [x] remove code that handles dropped layers in freeze() function. It is not used anymore.