### PR TITLE
initialize tenant_mgr after daemonizing

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -294,9 +294,6 @@ fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
     );
     let pageserver_listener = TcpListener::bind(conf.listen_addr.clone())?;
 
-    // Initialize tenant manager.
-    tenant_mgr::init(conf);
-
     if conf.daemonize {
         info!("daemonizing...");
 
@@ -316,6 +313,9 @@ fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
             Err(e) => error!("Error, {}", e),
         }
     }
+
+    // Initialize tenant manager.
+    tenant_mgr::init(conf);
 
     // keep join handles for spawned threads
     let mut join_handles = vec![];


### PR DESCRIPTION
Ran into problems launching the WAL redo process on OS X after 4b73ad.
Launching the `initdb` process was met with "bad file descriptor" errors.
Using dtrace, I found shortly after calling `posix_spawn` for `initdb`,
`kevent` was returning this error.

I haven't dug super deep to see if the daemonization itself is the
problem, but this commit fixes it for me. My hunch is that some file
descriptors used when the Tokio runtime is initailzed become invalid
in the daemon process.