### PR TITLE
removes protobuf dependency (brought by prometheus default features)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,15 +1395,8 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "protobuf",
  "thiserror",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
 
 [[package]]
 name = "proxy"

--- a/zenith_metrics/Cargo.toml
+++ b/zenith_metrics/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-prometheus = "0.12"
+prometheus = {version = "0.12", default_features=false} # removes protobuf dependency
 libc = "0.2"
 lazy_static = "1.4"


### PR DESCRIPTION
Before that in `cargo +nightly  build -Z timings` report:
![image](https://user-images.githubusercontent.com/19991702/132843645-e2a90fe4-5432-4bfa-9de4-1a653b60c898.png)
