### PR TITLE
Fix gc of dropped rels

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -470,7 +470,6 @@ impl LayeredRepository {
                 }
             }
 
-            // cutoff is
             if let Some(cutoff) = timeline.get_last_record_lsn().checked_sub(horizon) {
                 let branchpoints: Vec<Lsn> = all_branchpoints
                     .range((
@@ -1438,12 +1437,14 @@ impl LayeredTimeline {
 
         let mut layers_to_remove: Vec<Arc<dyn Layer>> = Vec::new();
 
-        // Scan all layer files in the directory. For each file, if a newer file
-        // exists, we can remove the old one.
+        // Scan all on-disk layers in the timeline.
         //
-        // Determine for each file if it needs to be retained
-        // FIXME: also scan open in-memory layers. Normally we cannot remove the
-        // latest layer of any seg, but if it was dropped it's possible
+        // Garbage collect the layer if all conditions are satisfied:
+        // 1. it is older than cutoff LSN;
+        // 2. it doesn't need to be retained for 'retain_lsns';
+        // 3. newer on-disk layer exists (only for non-dropped segments);
+        // 4. this layer doesn't serve as a tombstone for some older layer;
+        //
         let mut layers = self.layers.lock().unwrap();
         'outer: for l in layers.iter_historic_layers() {
             let seg = l.get_seg_tag();
@@ -1454,7 +1455,7 @@ impl LayeredTimeline {
                 result.ondisk_nonrelfiles_total += 1;
             }
 
-            // Is it newer than cutoff point?
+            // 1. Is it newer than cutoff point?
             if l.get_end_lsn() > cutoff {
                 info!(
                     "keeping {} {}-{} because it's newer than cutoff {}",
@@ -1471,7 +1472,7 @@ impl LayeredTimeline {
                 continue 'outer;
             }
 
-            // 2. Is it needed by any child branch?
+            // 2. Is it needed by a child branch?
             for retain_lsn in &retain_lsns {
                 // start_lsn is inclusive and end_lsn is exclusive
                 if l.get_start_lsn() <= *retain_lsn && *retain_lsn < l.get_end_lsn() {
@@ -1491,15 +1492,92 @@ impl LayeredTimeline {
                 }
             }
 
-            // Unless the relation was dropped, is there a later image file for this relation?
+            // 3. Is there a later on-disk layer for this relation?
             if !l.is_dropped() && !layers.newer_image_layer_exists(l.get_seg_tag(), l.get_end_lsn())
             {
+                info!(
+                    "keeping {} {}-{} because it is the latest layer",
+                    seg,
+                    l.get_start_lsn(),
+                    l.get_end_lsn()
+                );
                 if seg.rel.is_relation() {
                     result.ondisk_relfiles_not_updated += 1;
                 } else {
                     result.ondisk_nonrelfiles_not_updated += 1;
                 }
                 continue 'outer;
+            }
+
+            // 4. Does this layer serve as a tombstome for some older layer?
+            if l.is_dropped() {
+                let prior_lsn = l.get_start_lsn().checked_sub(1u64).unwrap();
+
+                // Check if this layer serves as a tombstone for this timeline
+                // We have to do this separately from timeline check below,
+                // because LayerMap of this timeline is already locked.
+                let mut is_tombstone = layers.layer_exists_at_lsn(l.get_seg_tag(), prior_lsn);
+                if is_tombstone {
+                    info!(
+                        "earlier layer exists at {} in {}",
+                        prior_lsn, self.timelineid
+                    );
+                }
+                // Now check ancestor timelines, if any
+                else if let Some(ancestor) = &self.ancestor_timeline {
+                    let prior_lsn = ancestor.get_last_record_lsn();
+                    if seg.rel.is_blocky() {
+                        info!(
+                            "check blocky relish size {} at {} in {} for layer {}-{}",
+                            seg,
+                            prior_lsn,
+                            ancestor.timelineid,
+                            l.get_start_lsn(),
+                            l.get_end_lsn()
+                        );
+                        match ancestor.get_relish_size(seg.rel, prior_lsn).unwrap() {
+                            Some(size) => {
+                                let last_live_seg = SegmentTag::from_blknum(seg.rel, size - 1);
+                                info!(
+                                    "blocky rel size is {} last_live_seg.segno {} seg.segno {}",
+                                    size, last_live_seg.segno, seg.segno
+                                );
+                                if last_live_seg.segno >= seg.segno {
+                                    is_tombstone = true;
+                                }
+                            }
+                            _ => {
+                                info!("blocky rel doesn't exist");
+                            }
+                        }
+                    } else {
+                        info!(
+                            "check non-blocky relish existence {} at {} in {} for layer {}-{}",
+                            seg,
+                            prior_lsn,
+                            ancestor.timelineid,
+                            l.get_start_lsn(),
+                            l.get_end_lsn()
+                        );
+                        is_tombstone = ancestor.get_rel_exists(seg.rel, prior_lsn).unwrap_or(false);
+                    }
+                }
+
+                if is_tombstone {
+                    info!(
+                        "keeping {} {}-{} because this layer servers as a tombstome for older layer",
+                        seg,
+                        l.get_start_lsn(),
+                        l.get_end_lsn()
+                    );
+
+                    if seg.rel.is_relation() {
+                        result.ondisk_relfiles_needed_as_tombstone += 1;
+                    } else {
+                        result.ondisk_nonrelfiles_needed_as_tombstone += 1;
+                    }
+                    continue 'outer;
+                }
             }
 
             // We didn't find any reason to keep this file, so remove it.

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -191,12 +191,12 @@ impl Repository for LayeredRepository {
         &self,
         target_timelineid: Option<ZTimelineId>,
         horizon: u64,
-        compact: bool,
+        checkpoint_before_gc: bool,
     ) -> Result<GcResult> {
         STORAGE_TIME
             .with_label_values(&["gc"])
             .observe_closure_duration(|| {
-                self.gc_iteration_internal(target_timelineid, horizon, compact)
+                self.gc_iteration_internal(target_timelineid, horizon, checkpoint_before_gc)
             })
     }
 }
@@ -401,14 +401,14 @@ impl LayeredRepository {
     //    don't cover any branch point LSNs.
     //
     // TODO:
-    // - if a relation has been modified on a child branch, then we
+    // - if a relation has a non-incremental persistent layer on a child branch, then we
     //   don't need to keep that in the parent anymore. But currently
     //   we do.
     fn gc_iteration_internal(
         &self,
         target_timelineid: Option<ZTimelineId>,
         horizon: u64,
-        compact: bool,
+        checkpoint_before_gc: bool,
     ) -> Result<GcResult> {
         let mut totals: GcResult = Default::default();
         let now = Instant::now();
@@ -420,63 +420,72 @@ impl LayeredRepository {
         // Scan all timelines. For each timeline, remember the timeline ID and
         // the branch point where it was created.
         //
+        let mut timelineids: Vec<ZTimelineId> = Vec::new();
+
         // We scan the directory, not the in-memory hash table, because the hash
         // table only contains entries for timelines that have been accessed. We
         // need to take all timelines into account, not only the active ones.
-        let mut timelineids: Vec<ZTimelineId> = Vec::new();
-        let mut all_branchpoints: BTreeSet<(ZTimelineId, Lsn)> = BTreeSet::new();
         let timelines_path = self.conf.timelines_path(&self.tenantid);
+
         for direntry in fs::read_dir(timelines_path)? {
             let direntry = direntry?;
             if let Some(fname) = direntry.file_name().to_str() {
                 if let Ok(timelineid) = fname.parse::<ZTimelineId>() {
                     timelineids.push(timelineid);
-
-                    // Read the metadata of this timeline to get its parent timeline.
-                    //
-                    // We read the ancestor information directly from the file, instead
-                    // of calling get_timeline(). We don't want to load the timeline
-                    // into memory just for GC.
-                    //
-                    // FIXME: we open the timeline in the loop below with
-                    // get_timeline_locked() anyway, so maybe we should just do it
-                    // here, too.
-                    let metadata = Self::load_metadata(self.conf, timelineid, self.tenantid)?;
-                    if let Some(ancestor_timeline) = metadata.ancestor_timeline {
-                        all_branchpoints.insert((ancestor_timeline, metadata.ancestor_lsn));
-                    }
                 }
             }
         }
 
-        // Ok, we now know all the branch points. Iterate through them.
+        //Now collect info about branchpoints
+        let mut all_branchpoints: BTreeSet<(ZTimelineId, Lsn)> = BTreeSet::new();
+        for timelineid in &timelineids {
+            let timeline = self.get_timeline_locked(*timelineid, &mut *timelines)?;
+
+            if let Some(ancestor_timeline) = &timeline.ancestor_timeline {
+                // If target_timeline is specified, we only need to know branchpoints of its childs
+                if let Some(timelineid) = target_timelineid {
+                    if ancestor_timeline.timelineid == timelineid {
+                        all_branchpoints
+                            .insert((ancestor_timeline.timelineid, timeline.ancestor_lsn));
+                    }
+                }
+                // Collect branchpoints for all timelines
+                else {
+                    all_branchpoints.insert((ancestor_timeline.timelineid, timeline.ancestor_lsn));
+                }
+            }
+        }
+
+        // Ok, we now know all the branch points.
+        // Perform GC for each timeline.
         for timelineid in timelineids {
-            // If a target timeline was specified, leave the other timelines alone.
-            // This is a bit inefficient, because we still collect the information for
-            // all the timelines above.
-            if let Some(x) = target_timelineid {
-                if x != timelineid {
+            // We have already loaded all timelines above
+            // so this operation is just a quick map lookup.
+            let timeline = self.get_timeline_locked(timelineid, &mut *timelines)?;
+
+            // If target_timeline is specified, only GC it
+            if let Some(target_timelineid) = target_timelineid {
+                if timelineid != target_timelineid {
                     continue;
                 }
             }
 
-            let branchpoints: Vec<Lsn> = all_branchpoints
-                .range((
-                    Included((timelineid, Lsn(0))),
-                    Included((timelineid, Lsn(u64::MAX))),
-                ))
-                .map(|&x| x.1)
-                .collect();
+            // cutoff is
+            if let Some(cutoff) = timeline.get_last_record_lsn().checked_sub(horizon) {
+                let branchpoints: Vec<Lsn> = all_branchpoints
+                    .range((
+                        Included((timelineid, Lsn(0))),
+                        Included((timelineid, Lsn(u64::MAX))),
+                    ))
+                    .map(|&x| x.1)
+                    .collect();
 
-            let timeline = self.get_timeline_locked(timelineid, &mut *timelines)?;
-            let last_lsn = timeline.get_last_record_lsn();
-
-            if let Some(cutoff) = last_lsn.checked_sub(horizon) {
-                // If GC was explicitly requested by the admin, force flush all in-memory
-                // layers to disk first, so that they too can be garbage collected. That's
+                // If requested, force flush all in-memory layers to disk first,
+                // so that they too can be garbage collected. That's
                 // used in tests, so we want as deterministic results as possible.
-                if compact {
+                if checkpoint_before_gc {
                     timeline.checkpoint()?;
+                    info!("timeline {} checkpoint_before_gc done", timelineid);
                 }
 
                 let result = timeline.gc_timeline(branchpoints, cutoff)?;
@@ -1425,6 +1434,7 @@ impl LayeredTimeline {
             "running GC on timeline {}, cutoff {}",
             self.timelineid, cutoff
         );
+        info!("retain_lsns:  {:?}", retain_lsns);
 
         let mut layers_to_remove: Vec<Arc<dyn Layer>> = Vec::new();
 
@@ -1461,10 +1471,10 @@ impl LayeredTimeline {
                 continue 'outer;
             }
 
-            // Is it needed by a child branch?
+            // 2. Is it needed by any child branch?
             for retain_lsn in &retain_lsns {
-                // FIXME: are the bounds inclusive or exclusive?
-                if l.get_start_lsn() <= *retain_lsn && *retain_lsn <= l.get_end_lsn() {
+                // start_lsn is inclusive and end_lsn is exclusive
+                if l.get_start_lsn() <= *retain_lsn && *retain_lsn < l.get_end_lsn() {
                     info!(
                         "keeping {} {}-{} because it's needed by branch point {}",
                         seg,

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -183,6 +183,20 @@ impl LayerMap {
         }
     }
 
+    /// Is there any layer for given segment that is alive at the lsn?
+    ///
+    /// This is a public wrapper for SegEntry fucntion,
+    /// used for garbage collection, to determine if some alive layer
+    /// exists at the lsn. If so, we shouldn't delete a newer dropped layer
+    /// to avoid incorrectly making it visible.
+    pub fn layer_exists_at_lsn(&self, seg: SegmentTag, lsn: Lsn) -> bool {
+        if let Some(segentry) = self.segs.get(&seg) {
+            segentry.exists_at_lsn(lsn).unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
     /// Return the oldest in-memory layer, along with its generation number.
     pub fn peek_oldest_open(&self) -> Option<(Arc<InMemoryLayer>, u64)> {
         self.open_layers

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -654,12 +654,14 @@ impl postgres_backend::Handler for PageServerHandler {
                 RowDescriptor::int8_col(b"layer_relfiles_needed_by_cutoff"),
                 RowDescriptor::int8_col(b"layer_relfiles_needed_by_branches"),
                 RowDescriptor::int8_col(b"layer_relfiles_not_updated"),
+                RowDescriptor::int8_col(b"layer_relfiles_needed_as_tombstone"),
                 RowDescriptor::int8_col(b"layer_relfiles_removed"),
                 RowDescriptor::int8_col(b"layer_relfiles_dropped"),
                 RowDescriptor::int8_col(b"layer_nonrelfiles_total"),
                 RowDescriptor::int8_col(b"layer_nonrelfiles_needed_by_cutoff"),
                 RowDescriptor::int8_col(b"layer_nonrelfiles_needed_by_branches"),
                 RowDescriptor::int8_col(b"layer_nonrelfiles_not_updated"),
+                RowDescriptor::int8_col(b"layer_nonrelfiles_needed_as_tombstone"),
                 RowDescriptor::int8_col(b"layer_nonrelfiles_removed"),
                 RowDescriptor::int8_col(b"layer_nonrelfiles_dropped"),
                 RowDescriptor::int8_col(b"elapsed"),
@@ -679,6 +681,12 @@ impl postgres_backend::Handler for PageServerHandler {
                         .as_bytes(),
                 ),
                 Some(result.ondisk_relfiles_not_updated.to_string().as_bytes()),
+                Some(
+                    result
+                        .ondisk_relfiles_needed_as_tombstone
+                        .to_string()
+                        .as_bytes(),
+                ),
                 Some(result.ondisk_relfiles_removed.to_string().as_bytes()),
                 Some(result.ondisk_relfiles_dropped.to_string().as_bytes()),
                 Some(result.ondisk_nonrelfiles_total.to_string().as_bytes()),
@@ -695,6 +703,12 @@ impl postgres_backend::Handler for PageServerHandler {
                         .as_bytes(),
                 ),
                 Some(result.ondisk_nonrelfiles_not_updated.to_string().as_bytes()),
+                Some(
+                    result
+                        .ondisk_nonrelfiles_needed_as_tombstone
+                        .to_string()
+                        .as_bytes(),
+                ),
                 Some(result.ondisk_nonrelfiles_removed.to_string().as_bytes()),
                 Some(result.ondisk_nonrelfiles_dropped.to_string().as_bytes()),
                 Some(result.elapsed.as_millis().to_string().as_bytes()),

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -28,18 +28,14 @@ pub trait Repository: Send + Sync {
     ///
     /// 'timelineid' specifies the timeline to GC, or None for all.
     /// `horizon` specifies delta from last lsn to preserve all object versions (pitr interval).
-    /// `compact` parameter is used to force compaction of storage.
-    /// some storage implementation are based on lsm tree and require periodic merge (compaction).
-    /// usually storage implementation determines itself when compaction should be performed.
-    /// but for gc tests it way be useful to force compaction just after completion of gc iteration
-    /// to make sure that all detected garbage is removed.
-    /// so right now `compact` is set to true when gc explicitly requested through page srver api,
-    /// and is st to false in gc threads which infinitely repeats gc iterations in loop.
+    /// `checkpoint_before_gc` parameter is used to force compaction of storage before CG
+    /// to make tests more deterministic.
+    /// TODO Do we still need it or we can call checkpoint explicitly in tests where needed?
     fn gc_iteration(
         &self,
         timelineid: Option<ZTimelineId>,
         horizon: u64,
-        compact: bool,
+        checkpoint_before_gc: bool,
     ) -> Result<GcResult>;
 }
 

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -457,9 +457,6 @@ mod tests {
     /// Test list_rels() function, with branches and dropped relations
     ///
     #[test]
-    // FIXME: The last assertion in this test is currently failing, see
-    // https://github.com/zenithdb/zenith/issues/502. Ignore the failure until that's fixed.
-    #[ignore]
     fn test_list_rels_drop() -> Result<()> {
         let repo = get_test_repo("test_list_rels_drop")?;
         let timelineid = ZTimelineId::from_str("11223344556677881122334455667788").unwrap();
@@ -505,7 +502,6 @@ mod tests {
         newtline.checkpoint()?;
         repo.gc_iteration(Some(newtimelineid), 0, true)?;
 
-        // FIXME: this is currently failing
         assert!(!newtline
             .list_rels(0, TESTDB, Lsn(0x40))?
             .contains(&TESTREL_A));

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -48,6 +48,7 @@ pub struct GcResult {
     pub ondisk_relfiles_needed_by_cutoff: u64,
     pub ondisk_relfiles_needed_by_branches: u64,
     pub ondisk_relfiles_not_updated: u64,
+    pub ondisk_relfiles_needed_as_tombstone: u64,
     pub ondisk_relfiles_removed: u64, // # of layer files removed because they have been made obsolete by newer ondisk files.
     pub ondisk_relfiles_dropped: u64, // # of layer files removed because the relation was dropped
 
@@ -55,6 +56,7 @@ pub struct GcResult {
     pub ondisk_nonrelfiles_needed_by_cutoff: u64,
     pub ondisk_nonrelfiles_needed_by_branches: u64,
     pub ondisk_nonrelfiles_not_updated: u64,
+    pub ondisk_nonrelfiles_needed_as_tombstone: u64,
     pub ondisk_nonrelfiles_removed: u64, // # of layer files removed because they have been made obsolete by newer ondisk files.
     pub ondisk_nonrelfiles_dropped: u64, // # of layer files removed because the relation was dropped
 
@@ -67,6 +69,7 @@ impl AddAssign for GcResult {
         self.ondisk_relfiles_needed_by_cutoff += other.ondisk_relfiles_needed_by_cutoff;
         self.ondisk_relfiles_needed_by_branches += other.ondisk_relfiles_needed_by_branches;
         self.ondisk_relfiles_not_updated += other.ondisk_relfiles_not_updated;
+        self.ondisk_relfiles_needed_as_tombstone += other.ondisk_relfiles_needed_as_tombstone;
         self.ondisk_relfiles_removed += other.ondisk_relfiles_removed;
         self.ondisk_relfiles_dropped += other.ondisk_relfiles_dropped;
 
@@ -74,6 +77,7 @@ impl AddAssign for GcResult {
         self.ondisk_nonrelfiles_needed_by_cutoff += other.ondisk_nonrelfiles_needed_by_cutoff;
         self.ondisk_nonrelfiles_needed_by_branches += other.ondisk_nonrelfiles_needed_by_branches;
         self.ondisk_nonrelfiles_not_updated += other.ondisk_nonrelfiles_not_updated;
+        self.ondisk_nonrelfiles_needed_as_tombstone += other.ondisk_nonrelfiles_needed_as_tombstone;
         self.ondisk_nonrelfiles_removed += other.ondisk_nonrelfiles_removed;
         self.ondisk_nonrelfiles_dropped += other.ondisk_nonrelfiles_dropped;
 


### PR DESCRIPTION
Some dropped layers serve as tombstones for earlier layers and thus cannot be garbage collected.
Check if such layers are present in `gc_internal()`.
In passing, also refactor the `gc_iteration_internal()`.

TODO:
- [ ] update `test_snapfiles_gc.py` test to cover the case when dropped layers are garbage collected.
- [ ] write more unit tests to cover different GC scenarios for rels and non-rels, with and without branching
- [ ] code cleanup