### PR TITLE
bin_ser: reject trailing bytes by default

### DIFF
--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -213,6 +213,7 @@ mod tests {
     use crate::walredo::{WalRedoError, WalRedoManager};
     use crate::PageServerConf;
     use postgres_ffi::pg_constants;
+    use postgres_ffi::xlog_utils::SIZEOF_CHECKPOINT;
     use std::fs;
     use std::str::FromStr;
     use std::time::Duration;
@@ -252,6 +253,7 @@ mod tests {
     }
 
     static ZERO_PAGE: Bytes = Bytes::from_static(&[0u8; 8192]);
+    static ZERO_CHECKPOINT: Bytes = Bytes::from_static(&[0u8; SIZEOF_CHECKPOINT]);
 
     fn get_test_repo(test_name: &str) -> Result<Box<dyn Repository>> {
         let repo_dir = PageServerConf::test_repo_dir(test_name);
@@ -483,7 +485,7 @@ mod tests {
 
         // Import initial dummy checkpoint record, otherwise the get_timeline() call
         // after branching fails below
-        tline.put_page_image(RelishTag::Checkpoint, 0, Lsn(0x10), ZERO_PAGE.clone())?;
+        tline.put_page_image(RelishTag::Checkpoint, 0, Lsn(0x10), ZERO_CHECKPOINT.clone())?;
 
         // Create a relation on the timeline
         tline.put_page_image(TESTREL_A, 0, Lsn(0x20), TEST_IMG("foo blk 0 at 2"))?;
@@ -539,7 +541,7 @@ mod tests {
 
         // Import initial dummy checkpoint record, otherwise the get_timeline() call
         // after branching fails below
-        tline.put_page_image(RelishTag::Checkpoint, 0, Lsn(0x10), ZERO_PAGE.clone())?;
+        tline.put_page_image(RelishTag::Checkpoint, 0, Lsn(0x10), ZERO_CHECKPOINT.clone())?;
 
         // Create a relation on the timeline
         tline.put_page_image(TESTREL_A, 0, Lsn(0x20), TEST_IMG("foo blk 0 at 2"))?;

--- a/postgres_ffi/src/controlfile_utils.rs
+++ b/postgres_ffi/src/controlfile_utils.rs
@@ -58,7 +58,7 @@ impl ControlFileData {
         let expectedcrc = crc32c::crc32c(&buf[0..OFFSETOF_CRC]);
 
         // Use serde to deserialize the input as a ControlFileData struct.
-        let controlfile = ControlFileData::des(buf)?;
+        let controlfile = ControlFileData::des_prefix(buf)?;
 
         // Check the CRC
         if expectedcrc != controlfile.crc {

--- a/postgres_ffi/src/xlog_utils.rs
+++ b/postgres_ffi/src/xlog_utils.rs
@@ -374,7 +374,7 @@ impl CheckPoint {
 
     pub fn decode(buf: &[u8]) -> Result<CheckPoint, anyhow::Error> {
         use zenith_utils::bin_ser::LeSer;
-        Ok(CheckPoint::des_prefix(buf)?)
+        Ok(CheckPoint::des(buf)?)
     }
 
     // Update next XID based on provided new_xid and stored epoch.

--- a/postgres_ffi/src/xlog_utils.rs
+++ b/postgres_ffi/src/xlog_utils.rs
@@ -374,7 +374,7 @@ impl CheckPoint {
 
     pub fn decode(buf: &[u8]) -> Result<CheckPoint, anyhow::Error> {
         use zenith_utils::bin_ser::LeSer;
-        Ok(CheckPoint::des(buf)?)
+        Ok(CheckPoint::des_prefix(buf)?)
     }
 
     // Update next XID based on provided new_xid and stored epoch.


### PR DESCRIPTION
Primarily changes `LeSer`/`BeSer` deserialization to now reject trailing bytes by default. Adds a new `des_prefix` function to retain the old behavior.

This also exposes #586, but that doesn't seem to cause CI to fail.

There's a couple places that seem to actually require `des_prefix`. I'm not sure if `xlog_utils::CheckPoint::decode` is (or should be) one of them, but I'm using it there for now. During `cargo test`, it gets called with more data than it needs but... disallowing trailing bytes didn't cause the rest of CI to fail.