### PR TITLE
Frozen InMemoryLayers & checkpointing without holding lock

### DIFF
--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -701,8 +701,8 @@ impl InMemoryLayer {
         Ok(frozen_layers)
     }
 
-    pub fn update_predecessor(&self, predecessor: Arc<dyn Layer>) {
+    pub fn update_predecessor(&self, predecessor: Arc<dyn Layer>) -> Option<Arc<dyn Layer>> {
         let mut inner = self.inner.lock().unwrap();
-        inner.predecessor = Some(predecessor);
+        inner.predecessor.replace(predecessor)
     }
 }

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -130,6 +130,10 @@ impl Layer for InMemoryLayer {
     }
 
     fn get_end_lsn(&self) -> Lsn {
+        if let Some(end_lsn) = self.end_lsn {
+            return Lsn(end_lsn.0 + 1);
+        }
+
         let inner = self.inner.lock().unwrap();
 
         if let Some(drop_lsn) = inner.drop_lsn {


### PR DESCRIPTION
I've taken the advice from #572 and avoided creating FrozenLayer.

I ran some benchmarks on my system and noticed that I was still seeing some downward TPS spikes every 5 seconds, so maybe this isn't quite solved yet. I'll have to dig in more there, but my first guess that we're copying lots of data or logging a ton.

Haven't figured out how to have multiple frozen layers for the drop solution mentioned by @lubennikovaav, but we should think more about that now