### PR TITLE
Decouple GC and Checkpointer

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,6 +30,10 @@ writes out the changes from in-memory layers into new layer files[]. This proces
 is called "checkpointing". The page server only creates layer files for
 relations that have been modified since the last checkpoint. 
 
+Configuration parameter `checkpoint_distance` defines the distance
+from current LSN to perform checkpoint of in-memory layers.
+Default is `DEFAULT_CHECKPOINT_DISTANCE`.
+Set this parameter to `0` to force checkpoint of every layer.
 ### Compute node
 
 Stateless Postgres node that stores data in pageserver.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -34,6 +34,9 @@ Configuration parameter `checkpoint_distance` defines the distance
 from current LSN to perform checkpoint of in-memory layers.
 Default is `DEFAULT_CHECKPOINT_DISTANCE`.
 Set this parameter to `0` to force checkpoint of every layer.
+
+Configuration parameter `checkpoint_period` defines the interval between checkpoint iterations.
+Default is `DEFAULT_CHECKPOINT_PERIOD`.
 ### Compute node
 
 Stateless Postgres node that stores data in pageserver.

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -27,6 +27,7 @@ use zenith_utils::http::endpoint;
 struct CfgFileParams {
     listen_pg_addr: Option<String>,
     listen_http_addr: Option<String>,
+    checkpoint_distance: Option<String>,
     gc_horizon: Option<String>,
     gc_period: Option<String>,
     pg_distrib_dir: Option<String>,
@@ -44,6 +45,7 @@ impl CfgFileParams {
         Self {
             listen_pg_addr: get_arg("listen-pg"),
             listen_http_addr: get_arg("listen-http"),
+            checkpoint_distance: get_arg("checkpoint_distance"),
             gc_horizon: get_arg("gc_horizon"),
             gc_period: get_arg("gc_period"),
             pg_distrib_dir: get_arg("postgres-distrib"),
@@ -58,6 +60,7 @@ impl CfgFileParams {
         Self {
             listen_pg_addr: self.listen_pg_addr.or(other.listen_pg_addr),
             listen_http_addr: self.listen_http_addr.or(other.listen_http_addr),
+            checkpoint_distance: self.checkpoint_distance.or(other.checkpoint_distance),
             gc_horizon: self.gc_horizon.or(other.gc_horizon),
             gc_period: self.gc_period.or(other.gc_period),
             pg_distrib_dir: self.pg_distrib_dir.or(other.pg_distrib_dir),
@@ -80,6 +83,11 @@ impl CfgFileParams {
         let listen_http_addr = match self.listen_http_addr.as_ref() {
             Some(addr) => addr.clone(),
             None => DEFAULT_HTTP_LISTEN_ADDR.to_owned(),
+        };
+
+        let checkpoint_distance: i128 = match self.checkpoint_distance.as_ref() {
+            Some(checkpoint_distance_str) => checkpoint_distance_str.parse()?,
+            None => DEFAULT_CHECKPOINT_DISTANCE,
         };
 
         let gc_horizon: u64 = match self.gc_horizon.as_ref() {
@@ -129,6 +137,7 @@ impl CfgFileParams {
 
             listen_pg_addr,
             listen_http_addr,
+            checkpoint_distance,
             gc_horizon,
             gc_period,
 
@@ -174,6 +183,12 @@ fn main() -> Result<()> {
                 .long("init")
                 .takes_value(false)
                 .help("Initialize pageserver repo"),
+        )
+        .arg(
+            Arg::with_name("checkpoint_distance")
+                .long("checkpoint_distance")
+                .takes_value(true)
+                .help("Distance from current LSN to perform checkpoint of in-memory layers"),
         )
         .arg(
             Arg::with_name("gc_horizon")

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -88,7 +88,7 @@ impl CfgFileParams {
             None => DEFAULT_HTTP_LISTEN_ADDR.to_owned(),
         };
 
-        let checkpoint_distance: i128 = match self.checkpoint_distance.as_ref() {
+        let checkpoint_distance: u64 = match self.checkpoint_distance.as_ref() {
             Some(checkpoint_distance_str) => checkpoint_distance_str.parse()?,
             None => DEFAULT_CHECKPOINT_DISTANCE,
         };

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -28,6 +28,7 @@ struct CfgFileParams {
     listen_pg_addr: Option<String>,
     listen_http_addr: Option<String>,
     checkpoint_distance: Option<String>,
+    checkpoint_period: Option<String>,
     gc_horizon: Option<String>,
     gc_period: Option<String>,
     pg_distrib_dir: Option<String>,
@@ -46,6 +47,7 @@ impl CfgFileParams {
             listen_pg_addr: get_arg("listen-pg"),
             listen_http_addr: get_arg("listen-http"),
             checkpoint_distance: get_arg("checkpoint_distance"),
+            checkpoint_period: get_arg("checkpoint_period"),
             gc_horizon: get_arg("gc_horizon"),
             gc_period: get_arg("gc_period"),
             pg_distrib_dir: get_arg("postgres-distrib"),
@@ -61,6 +63,7 @@ impl CfgFileParams {
             listen_pg_addr: self.listen_pg_addr.or(other.listen_pg_addr),
             listen_http_addr: self.listen_http_addr.or(other.listen_http_addr),
             checkpoint_distance: self.checkpoint_distance.or(other.checkpoint_distance),
+            checkpoint_period: self.checkpoint_period.or(other.checkpoint_period),
             gc_horizon: self.gc_horizon.or(other.gc_horizon),
             gc_period: self.gc_period.or(other.gc_period),
             pg_distrib_dir: self.pg_distrib_dir.or(other.pg_distrib_dir),
@@ -88,6 +91,10 @@ impl CfgFileParams {
         let checkpoint_distance: i128 = match self.checkpoint_distance.as_ref() {
             Some(checkpoint_distance_str) => checkpoint_distance_str.parse()?,
             None => DEFAULT_CHECKPOINT_DISTANCE,
+        };
+        let checkpoint_period = match self.checkpoint_period.as_ref() {
+            Some(checkpoint_period_str) => humantime::parse_duration(checkpoint_period_str)?,
+            None => DEFAULT_CHECKPOINT_PERIOD,
         };
 
         let gc_horizon: u64 = match self.gc_horizon.as_ref() {
@@ -138,6 +145,7 @@ impl CfgFileParams {
             listen_pg_addr,
             listen_http_addr,
             checkpoint_distance,
+            checkpoint_period,
             gc_horizon,
             gc_period,
 
@@ -189,6 +197,12 @@ fn main() -> Result<()> {
                 .long("checkpoint_distance")
                 .takes_value(true)
                 .help("Distance from current LSN to perform checkpoint of in-memory layers"),
+        )
+        .arg(
+            Arg::with_name("checkpoint_period")
+                .long("checkpoint_period")
+                .takes_value(true)
+                .help("Interval between checkpoint iterations"),
         )
         .arg(
             Arg::with_name("gc_horizon")

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1232,7 +1232,7 @@ impl LayeredTimeline {
     /// Flush to disk all data that was written with the put_* functions
     ///
     /// NOTE: This has nothing to do with checkpoint in PostgreSQL.
-    fn checkpoint_internal(&self, checkpoint_distance: i128) -> Result<()> {
+    fn checkpoint_internal(&self, checkpoint_distance: u64) -> Result<()> {
         // Grab lock on the layer map.
         //
         // TODO: We hold it locked throughout the checkpoint operation. That's bad,
@@ -1280,7 +1280,7 @@ impl LayeredTimeline {
             // inserted ourselves.
             let distance = last_record_lsn.widening_sub(oldest_pending_lsn);
             if distance < 0
-                || distance < checkpoint_distance
+                || distance < checkpoint_distance.into()
                 || oldest_generation == current_generation
             {
                 info!(

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -32,6 +32,7 @@ pub mod defaults {
     // would be more appropriate. But a low value forces the code to be exercised more,
     // which is good for now to trigger bugs.
     pub const DEFAULT_CHECKPOINT_DISTANCE: i128 = 64 * 1024 * 1024;
+    pub const DEFAULT_CHECKPOINT_PERIOD: Duration = Duration::from_secs(100);
 
     pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
     pub const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(100);
@@ -59,6 +60,8 @@ pub struct PageServerConf {
     // This puts a backstop on how much WAL needs to be re-digested if the
     // page server crashes.
     pub checkpoint_distance: i128,
+    pub checkpoint_period: Duration,
+
     pub gc_horizon: u64,
     pub gc_period: Duration,
     pub superuser: String,
@@ -145,6 +148,7 @@ impl PageServerConf {
         PageServerConf {
             daemonize: false,
             checkpoint_distance: defaults::DEFAULT_CHECKPOINT_DISTANCE,
+            checkpoint_period: Duration::from_secs(10),
             gc_horizon: defaults::DEFAULT_GC_HORIZON,
             gc_period: Duration::from_secs(10),
             listen_pg_addr: "127.0.0.1:5430".to_string(),

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -28,6 +28,11 @@ pub mod defaults {
     pub const DEFAULT_HTTP_LISTEN_PORT: u16 = 9898;
     pub const DEFAULT_HTTP_LISTEN_ADDR: &str = "127.0.0.1:9898";
 
+    // FIXME: This current value is very low. I would imagine something like 1 GB or 10 GB
+    // would be more appropriate. But a low value forces the code to be exercised more,
+    // which is good for now to trigger bugs.
+    pub const DEFAULT_CHECKPOINT_DISTANCE: i128 = 64 * 1024 * 1024;
+
     pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
     pub const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(100);
 
@@ -50,6 +55,10 @@ pub struct PageServerConf {
     pub daemonize: bool,
     pub listen_pg_addr: String,
     pub listen_http_addr: String,
+    // Flush out an inmemory layer, if it's holding WAL older than this
+    // This puts a backstop on how much WAL needs to be re-digested if the
+    // page server crashes.
+    pub checkpoint_distance: i128,
     pub gc_horizon: u64,
     pub gc_period: Duration,
     pub superuser: String,
@@ -135,7 +144,8 @@ impl PageServerConf {
     fn dummy_conf(repo_dir: PathBuf) -> Self {
         PageServerConf {
             daemonize: false,
-            gc_horizon: 64 * 1024 * 1024,
+            checkpoint_distance: defaults::DEFAULT_CHECKPOINT_DISTANCE,
+            gc_horizon: defaults::DEFAULT_GC_HORIZON,
             gc_period: Duration::from_secs(10),
             listen_pg_addr: "127.0.0.1:5430".to_string(),
             listen_http_addr: "127.0.0.1:9898".to_string(),

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -31,7 +31,7 @@ pub mod defaults {
     // FIXME: This current value is very low. I would imagine something like 1 GB or 10 GB
     // would be more appropriate. But a low value forces the code to be exercised more,
     // which is good for now to trigger bugs.
-    pub const DEFAULT_CHECKPOINT_DISTANCE: i128 = 64 * 1024 * 1024;
+    pub const DEFAULT_CHECKPOINT_DISTANCE: u64 = 64 * 1024 * 1024;
     pub const DEFAULT_CHECKPOINT_PERIOD: Duration = Duration::from_secs(100);
 
     pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
@@ -59,7 +59,7 @@ pub struct PageServerConf {
     // Flush out an inmemory layer, if it's holding WAL older than this
     // This puts a backstop on how much WAL needs to be re-digested if the
     // page server crashes.
-    pub checkpoint_distance: i128,
+    pub checkpoint_distance: u64,
     pub checkpoint_period: Duration,
 
     pub gc_horizon: u64,

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -216,8 +216,6 @@ mod tests {
     use postgres_ffi::xlog_utils::SIZEOF_CHECKPOINT;
     use std::fs;
     use std::str::FromStr;
-    use std::time::Duration;
-    use zenith_utils::postgres_backend::AuthType;
     use zenith_utils::zid::ZTenantId;
 
     /// Arbitrary relation tag, for testing.
@@ -261,18 +259,8 @@ mod tests {
         fs::create_dir_all(&repo_dir)?;
         fs::create_dir_all(&repo_dir.join("timelines"))?;
 
-        let conf = PageServerConf {
-            daemonize: false,
-            gc_horizon: 64 * 1024 * 1024,
-            gc_period: Duration::from_secs(10),
-            listen_pg_addr: "127.0.0.1:5430".to_string(),
-            listen_http_addr: "127.0.0.1:9898".to_string(),
-            superuser: "zenith_admin".to_string(),
-            workdir: repo_dir,
-            pg_distrib_dir: "".into(),
-            auth_type: AuthType::Trust,
-            auth_validation_public_key_path: None,
-        };
+        let conf = PageServerConf::dummy_conf(repo_dir);
+
         // Make a static copy of the config. This can never be free'd, but that's
         // OK in a test.
         let conf: &'static PageServerConf = Box::leak(Box::new(conf));

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -37,6 +37,7 @@ pub fn init(conf: &'static PageServerConf) {
             tenantid,
         ));
         LayeredRepository::launch_checkpointer_thread(conf, repo.clone());
+        LayeredRepository::launch_gc_thread(conf, repo.clone());
 
         info!("initialized storage for tenant: {}", &tenantid);
         m.insert(tenantid, repo);


### PR DESCRIPTION
- Change hardcoded OLDEST_INMEM_DISTANCE value to pageserver config option checkpoint_distance.
- Get rid of 'force' flag in checkpoint_internal(). Use checkpoint_distance=0 instead.
- Run GC and checkpointer in separate threads.
- Add checkpoint_period configuration parameter