### PR TITLE
[Cleanup] Add `get_timeline_for_tenant()` to `tenant_mgr`

### DIFF
--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -257,7 +257,7 @@ pub(crate) fn get_tenants(conf: &PageServerConf) -> Result<Vec<String>> {
 }
 
 pub(crate) fn get_branches(conf: &PageServerConf, tenantid: &ZTenantId) -> Result<Vec<BranchInfo>> {
-    let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
+    let repo = tenant_mgr::get_repository_for_tenant(*tenantid)?;
 
     // Each branch has a corresponding record (text file) in the refs/branches
     // with timeline_id.
@@ -282,7 +282,7 @@ pub(crate) fn create_branch(
     startpoint_str: &str,
     tenantid: &ZTenantId,
 ) -> Result<BranchInfo> {
-    let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
+    let repo = tenant_mgr::get_repository_for_tenant(*tenantid)?;
 
     if conf.branch_path(branchname, tenantid).exists() {
         anyhow::bail!("branch {} already exists", branchname);

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -133,7 +133,7 @@ async fn branch_detail_handler(request: Request<Body>) -> Result<Response<Body>,
     let path = conf.branch_path(&branch_name, &tenantid);
 
     let response_data = tokio::task::spawn_blocking(move || {
-        let repo = tenant_mgr::get_repository_for_tenant(&tenantid)?;
+        let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
         BranchInfo::from_path(path, conf, &tenantid, &repo)
     })
     .await

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -3,17 +3,17 @@
 
 use crate::branches;
 use crate::layered_repository::LayeredRepository;
-use crate::repository::Repository;
+use crate::repository::{Repository, Timeline};
 use crate::walredo::PostgresRedoManager;
 use crate::PageServerConf;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use lazy_static::lazy_static;
 use log::info;
 use std::collections::HashMap;
 use std::fs;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
-use zenith_utils::zid::ZTenantId;
+use zenith_utils::zid::{ZTenantId, ZTimelineId};
 
 lazy_static! {
     pub static ref REPOSITORY: Mutex<HashMap<ZTenantId, Arc<dyn Repository>>> =
@@ -66,9 +66,18 @@ pub fn insert_repository_for_tenant(tenantid: ZTenantId, repo: Arc<dyn Repositor
     o.insert(tenantid, repo);
 }
 
-pub fn get_repository_for_tenant(tenantid: &ZTenantId) -> Result<Arc<dyn Repository>> {
+pub fn get_repository_for_tenant(tenantid: ZTenantId) -> Result<Arc<dyn Repository>> {
     let o = &REPOSITORY.lock().unwrap();
-    o.get(tenantid)
+    o.get(&tenantid)
         .map(|repo| Arc::clone(repo))
         .ok_or_else(|| anyhow!("repository not found for tenant name {}", tenantid))
+}
+
+pub fn get_timeline_for_tenant(
+    tenantid: ZTenantId,
+    timelineid: ZTimelineId,
+) -> Result<Arc<dyn Timeline>> {
+    get_repository_for_tenant(tenantid)?
+        .get_timeline(timelineid)
+        .with_context(|| format!("cannot fetch timeline {}", timelineid))
 }


### PR DESCRIPTION
Most of the previous usages of `get_repository_for_tenant` were followed by immediately getting a timeline in that repository, without keeping it around for longer, so I've added a function to do that.