### PR TITLE
Remove unused FE/BE ControlFile message.

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -254,14 +254,6 @@ impl PageServerHandler {
         }
     }
 
-    fn handle_controlfile(&self, pgb: &mut PostgresBackend) -> io::Result<()> {
-        pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?
-            .write_message_noflush(&BeMessage::ControlFile)?
-            .write_message(&BeMessage::CommandComplete(b"SELECT 1"))?;
-
-        Ok(())
-    }
-
     fn handle_pagerequests(
         &self,
         pgb: &mut PostgresBackend,
@@ -502,9 +494,7 @@ impl postgres_backend::Handler for PageServerHandler {
         }
         let query_string = std::str::from_utf8(&query_string)?;
 
-        if query_string.starts_with("controlfile") {
-            self.handle_controlfile(pgb)?;
-        } else if query_string.starts_with("pagestream ") {
+        if query_string.starts_with("pagestream ") {
             let (_, params_raw) = query_string.split_at("pagestream ".len());
             let params = params_raw.split(' ').collect::<Vec<_>>();
             ensure!(

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -337,7 +337,6 @@ pub enum BeMessage<'a> {
     AuthenticationCleartextPassword,
     BindComplete,
     CommandComplete(&'a [u8]),
-    ControlFile,
     CopyData(&'a [u8]),
     CopyDone,
     CopyFail,
@@ -528,11 +527,6 @@ impl<'a> BeMessage<'a> {
                     write_cstr(cmd, buf)?;
                     Ok::<_, io::Error>(())
                 })?;
-            }
-
-            BeMessage::ControlFile => {
-                // TODO pass checkpoint and xid info in this message
-                BeMessage::write(buf, &BeMessage::DataRow(&[Some(b"hello pg_control")]))?;
             }
 
             BeMessage::CopyData(data) => {


### PR DESCRIPTION
It's a remnant of some old tests in Zenith, but isn't used anymore. It
doesn't exist in PostgreSQL.