### PR TITLE
Use crc32c checksums in DeltaLayer

### DIFF
--- a/pageserver/src/layered_repository/blob.rs
+++ b/pageserver/src/layered_repository/blob.rs
@@ -1,18 +1,21 @@
 use std::{fs::File, io::Write};
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use bookfile::{BookWriter, BoundedReader, ChapterId, ChapterWriter};
+use crc32c::crc32c;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct BlobRange {
     offset: u64,
     size: usize,
+    cksum: u32,
 }
 
 pub fn read_blob(reader: &BoundedReader<&'_ File>, range: &BlobRange) -> Result<Vec<u8>> {
     let mut buf = vec![0u8; range.size];
     reader.read_exact_at(&mut buf, range.offset)?;
+    ensure!(range.cksum == crc32c(&buf));
     Ok(buf)
 }
 
@@ -31,9 +34,12 @@ impl BlobWriter {
     pub fn write_blob(&mut self, blob: &[u8]) -> Result<BlobRange> {
         self.writer.write_all(blob)?;
 
+        let cksum = crc32c(blob);
+
         let range = BlobRange {
             offset: self.offset,
             size: blob.len(),
+            cksum,
         };
         self.offset += blob.len() as u64;
         Ok(range)


### PR DESCRIPTION
Add a summary chapter to DeltaLayer files. This chapter includes
checksums for both the metas chapter (blob ranes) and relsizes chapter.
Both of these checksums are verified in `load()`. The blob range
metadata also have checksums for the bytes they refer to. These
checksums are verified as the blobs are read, not on layer load.

#427 #519