### PR TITLE
Include layer metadata in layer summary chapters

### DIFF
--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -21,7 +21,7 @@ pub const RELISH_SEG_SIZE: u32 = 10 * 1024 * 1024 / 8192;
 /// Each relish stored in the repository is divided into fixed-sized "segments",
 /// with 10 MB of key-space, or 1280 8k pages each.
 ///
-#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Ord, Clone, Copy, Serialize, Deserialize)]
 pub struct SegmentTag {
     pub rel: RelishTag,
     pub segno: u32,


### PR DESCRIPTION
Include all data stored in layer filenames and the tenant+timeline IDs
inside a summary chapter. Use this chapter in the `dump_layerfile`
utility.

Ignore the checksum commits (#619 #620), will rebase on top of them after merged.

Appropriate filename:
```
pat@chi zenith % ./target/debug/dump_layerfile test_output/test_pgbench/repo/tenants/e981be79c75e725312783d9c42669d79/timelines/9e0f3b2c27588bf98e7733682491c884/rel_1663_14235_113_0_0_00000000016B90D8_00000000016B9150
----- delta layer for tli 9e0f3b2c27588bf98e7733682491c884 seg 1663/14235/113.0 0/16B90D8-0/16B9150 ----
--- relsizes ---
  0/16B90D8: 1
--- page versions ---
  blk 0 at 0/16B90D8:  img 8192 bytes
pat@chi zenith % ./target/debug/dump_layerfile test_output/test_pgbench/repo/tenants/e981be79c75e725312783d9c42669d79/timelines/9e0f3b2c27588bf98e7733682491c884/rel_1663_14235_113_0_0_00000000016B9150
----- image layer for tli 9e0f3b2c27588bf98e7733682491c884 seg 1663/14235/113.0 at 0/16B9150 ----
(1) blocks
```

Invalid filename:
```
pat@chi zenith % cp test_output/test_pgbench/repo/tenants/e981be79c75e725312783d9c42669d79/timelines/9e0f3b2c27588bf98e7733682491c884/rel_1663_14235_113_0_0_00000000016B9150 image.bin
pat@chi zenith % ./target/debug/dump_layerfile image.bin
----- image layer for tli 9e0f3b2c27588bf98e7733682491c884 seg 1663/14235/113.0 at 0/16B9150 ----
note: 'image.bin' not a valid delta layer filename
(1) blocks
pat@chi zenith % cp test_output/test_pgbench/repo/tenants/e981be79c75e725312783d9c42669d79/timelines/9e0f3b2c27588bf98e7733682491c884/rel_1663_14235_113_0_0_00000000016B90D8_00000000016B9150 delta.bin
pat@chi zenith % ./target/debug/dump_layerfile delta.bin
----- delta layer for tli 9e0f3b2c27588bf98e7733682491c884 seg 1663/14235/113.0 0/16B90D8-0/16B9150 ----
note: 'delta.bin' not a valid delta layer filename
--- relsizes ---
  0/16B90D8: 1
--- page versions ---
  blk 0 at 0/16B90D8:  img 8192 bytes
```

Incorrect LSN filename:
```
pat@chi zenith % cp test_output/test_pgbench/repo/tenants/e981be79c75e725312783d9c42669d79/timelines/9e0f3b2c27588bf98e7733682491c884/rel_1663_14235_113_0_0_00000000016B90D8_00000000016B9150 rel_1663_14235_113_0_0_00000000016B90D8_00000000016B9151
pat@chi zenith % ./target/debug/dump_layerfile rel_1663_14235_113_0_0_00000000016B90D8_00000000016B9151
----- delta layer for tli 9e0f3b2c27588bf98e7733682491c884 seg 1663/14235/113.0 0/16B90D8-0/16B9150 ----
warning: detected a well-formed delta filename but it does not correspond to this file
actual: DeltaFileName { seg: SegmentTag { rel: Relation(RelTag { forknum: 0, spcnode: 1663, dbnode: 14235, relnode: 113 }), segno: 0 }, start_lsn: 0/16B90D8, end_lsn: 0/16B9151, dropped: false }
expected: DeltaFileName { seg: SegmentTag { rel: Relation(RelTag { forknum: 0, spcnode: 1663, dbnode: 14235, relnode: 113 }), segno: 0 }, start_lsn: 0/16B90D8, end_lsn: 0/16B9150, dropped: false }
--- relsizes ---
  0/16B90D8: 1
--- page versions ---
  blk 0 at 0/16B90D8:  img 8192 bytes
pat@chi zenith % cp test_output/test_pgbench/repo/tenants/e981be79c75e725312783d9c42669d79/timelines/9e0f3b2c27588bf98e7733682491c884/rel_1663_14235_113_0_0_00000000016B9150 rel_1663_14235_113_0_0_00000000016B9151
pat@chi zenith % ./target/debug/dump_layerfile rel_1663_14235_113_0_0_00000000016B9151
----- image layer for tli 9e0f3b2c27588bf98e7733682491c884 seg 1663/14235/113.0 at 0/16B9150 ----
warning: detected a well-formed image filename but it does not correspond to this file
actual: ImageFileName { seg: SegmentTag { rel: Relation(RelTag { forknum: 0, spcnode: 1663, dbnode: 14235, relnode: 113 }), segno: 0 }, lsn: 0/16B9151 }
expected: ImageFileName { seg: SegmentTag { rel: Relation(RelTag { forknum: 0, spcnode: 1663, dbnode: 14235, relnode: 113 }), segno: 0 }, lsn: 0/16B9150 }
(1) blocks
```