### PR TITLE
Show underlying pageserver error details

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -24,7 +24,7 @@ use zenith_utils::connstring::connection_address;
 
 #[derive(Error, Debug)]
 pub enum PageserverHttpError {
-    #[error("Reqwest error")]
+    #[error("Reqwest error: {0}")]
     Transport(#[from] reqwest::Error),
 
     #[error("Error: {0}")]


### PR DESCRIPTION
Currently, something breaks for me in pageserver and I'm investigating the reason.
I found this change to be a bit more useful to see in test output.

Before:
```
E           Exception:             Run failed: Command '['/Users/someonetoignore/Work/zenith/zenith/target/debug/zenith', 'branch', 'empty', 'main']' returned non-zero exit status 1.
E                         stdout:
E                         stderr: branch command failed: Reqwest error

test_runner/fixtures/zenith_fixtures.py:197: Exception
```

After:
```
E           Exception:             Run failed: Command '['/Users/someonetoignore/Work/zenith/zenith/target/debug/zenith', 'branch', 'empty', 'main']' returned non-zero exit status 1.
E                         stdout:
E                         stderr: branch command failed: Reqwest error: error sending request for url (http://localhost:55001/v1/branch): error trying to connect: tcp connect error: Connection refused (os error 61)

test_runner/fixtures/zenith_fixtures.py:197: Exception
```