### PR TITLE
Don't print 'pg_controldata' output after every startup in tests.

### DIFF
--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -552,8 +552,6 @@ class Postgres(PgProtocol):
 
         print(f"stdout: {run_result.stdout}")
 
-        self.pg_bin.run(['pg_controldata', self.pg_data_dir_path()])
-
         return self
 
     def pg_data_dir_path(self) -> str:


### PR DESCRIPTION
It's not interesting for most tests, and clutters the output. If there
are individual tests where it is worthwhole, let's add pg_controldata calls
to those tests, but I don't think it's needed for now.