### PR TITLE
Fix rustc & clippy warnings for nightly (2021-09-16)

### DIFF
--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -32,6 +32,7 @@ lazy_static! {
 ///
 /// LayerMap tracks what layers exist on a timeline.
 ///
+#[derive(Default)]
 pub struct LayerMap {
     /// All the layers keyed by segment tag
     segs: HashMap<SegmentTag, SegEntry>,
@@ -44,16 +45,6 @@ pub struct LayerMap {
     /// Generation number, used to distinguish newly inserted entries in the
     /// binary heap from older entries during checkpoint.
     current_generation: u64,
-}
-
-impl Default for LayerMap {
-    fn default() -> Self {
-        LayerMap {
-            segs: HashMap::new(),
-            open_layers: BinaryHeap::new(),
-            current_generation: 0,
-        }
-    }
 }
 
 impl LayerMap {
@@ -231,18 +222,10 @@ impl LayerMap {
 /// and is kept in a separate field, because there can be only one for
 /// each segment. The older layers, stored on disk, are kept in a
 /// BTreeMap keyed by the layer's start LSN.
+#[derive(Default)]
 struct SegEntry {
     pub open: Option<Arc<InMemoryLayer>>,
     pub historic: BTreeMap<Lsn, Arc<dyn Layer>>,
-}
-
-impl Default for SegEntry {
-    fn default() -> Self {
-        SegEntry {
-            open: None,
-            historic: BTreeMap::new(),
-        }
-    }
 }
 
 impl SegEntry {

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -360,6 +360,8 @@ fn find_wal_file_range(
 ///
 /// [postgres docs]: https://www.postgresql.org/docs/current/protocol-replication.html
 #[derive(Debug)]
+// As of nightly 2021-09-11, fields that are only read by the type's `Debug` impl still count as
+// unused. Relevant issue: https://github.com/rust-lang/rust/issues/88900
 #[allow(dead_code)]
 pub struct IdentifySystem {
     systemid: u64,

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -360,6 +360,7 @@ fn find_wal_file_range(
 ///
 /// [postgres docs]: https://www.postgresql.org/docs/current/protocol-replication.html
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct IdentifySystem {
     systemid: u64,
     timeline: u32,


### PR DESCRIPTION
Clippy/rustc commit rust-lang/rust@e4828d5b7

There's a few additional warnings that currently pop up on nightly (not sure exactly when they started), some from rustc itself and some from clippy.

Perhaps there's a better solution to handling the unused fields in `IdentifySystem`, but I'm not sure what it is right now. I think it does make sense for that struct to be left as-is, given that rust-postgres doesn't provide an `IDENTIFY_SYSTEM` interface.