### PR TITLE
Add more details to the log, when an error happens in GetPage request.

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -293,7 +293,9 @@ impl PageServerHandler {
             };
 
             let response = response.unwrap_or_else(|e| {
-                error!("error reading relation or page version: {}", e);
+                // print the all details to the log with {:#}, but for the client the
+                // error message is enough
+                error!("error reading relation or page version: {:#}", e);
                 PagestreamBeMessage::Error(PagestreamErrorResponse {
                     message: e.to_string(),
                 })


### PR DESCRIPTION
I was trying to debug this test failure:

https://app.circleci.com/pipelines/github/zenithdb/zenith/2068/workflows/dcec5e1f-b833-48ba-b5f0-3cd1196aa9b4/jobs/14374/tests#failed-test-0

And was frustrated when the page server log contained lines like this:
 ```
Sep 24 17:29:09.345 ERRO error reading relation or page version: No such file or directory (os error 2)
```
Would've been nice to get more details...