### PR TITLE
More nightly clippy fixes (2021-09-29)

### DIFF
--- a/control_plane/src/compute.rs
+++ b/control_plane/src/compute.rs
@@ -452,9 +452,7 @@ impl PostgresNode {
             .output()
             .expect("failed to execute whoami");
 
-        if !output.status.success() {
-            panic!("whoami failed");
-        }
+        assert!(output.status.success(), "whoami failed");
 
         String::from_utf8(output.stdout).unwrap().trim().to_string()
     }

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1184,13 +1184,12 @@ impl LayeredTimeline {
         assert!(lsn.is_aligned());
 
         let last_record_lsn = self.get_last_record_lsn();
-        if lsn <= last_record_lsn {
-            panic!(
-                "cannot modify relation after advancing last_record_lsn (incoming_lsn={}, last_record_lsn={})",
-                lsn,
-                last_record_lsn
-            );
-        }
+        assert!(
+            lsn > last_record_lsn,
+            "cannot modify relation after advancing last_record_lsn (incoming_lsn={}, last_record_lsn={})",
+            lsn,
+            last_record_lsn,
+        );
 
         // Do we have a layer open for writing already?
         let layer;

--- a/pageserver/src/layered_repository/interval_tree.rs
+++ b/pageserver/src/layered_repository/interval_tree.rs
@@ -283,6 +283,7 @@ mod tests {
             write!(f, "{}", self.val)
         }
     }
+    #[rustfmt::skip]
     fn assert_search(
         tree: &IntervalTree<MockItem>,
         key: u32,
@@ -291,24 +292,20 @@ mod tests {
         if let Some(v) = tree.search(key) {
             let vstr = v.to_string();
 
-            if expected.is_empty() {
-                panic!("search with {} returned {}, expected None", key, v);
-            }
+            assert!(!expected.is_empty(), "search with {} returned {}, expected None", key, v);
+            assert!(
+                expected.contains(&vstr.as_str()),
+                "search with {} returned {}, expected one of: {:?}",
+                key, v, expected,
+            );
 
-            if !expected.contains(&vstr.as_str()) {
-                panic!(
-                    "search with {} returned {}, expected one of: {:?}",
-                    key, v, expected
-                );
-            }
             Some(v)
         } else {
-            if !expected.is_empty() {
-                panic!(
-                    "search with {} returned None, expected one of {:?}",
-                    key, expected
-                );
-            }
+            assert!(
+                expected.is_empty(),
+                "search with {} returned None, expected one of {:?}",
+                key, expected
+            );
             None
         }
     }

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -70,7 +70,7 @@ pub fn insert_repository_for_tenant(tenantid: ZTenantId, repo: Arc<dyn Repositor
 pub fn get_repository_for_tenant(tenantid: ZTenantId) -> Result<Arc<dyn Repository>> {
     let o = &REPOSITORY.lock().unwrap();
     o.get(&tenantid)
-        .map(|repo| Arc::clone(repo))
+        .map(Arc::clone)
         .ok_or_else(|| anyhow!("repository not found for tenant name {}", tenantid))
 }
 

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -298,9 +298,11 @@ impl PostgresRedoManager {
                     // Transaction manager stuff
                     let rec_segno = match rel {
                         RelishTag::Slru { slru, segno } => {
-                            if slru != SlruKind::Clog {
-                                panic!("Not valid XACT relish tag {:?}", rel);
-                            }
+                            assert!(
+                                slru == SlruKind::Clog,
+                                "Not valid XACT relish tag {:?}",
+                                rel
+                            );
                             segno
                         }
                         _ => panic!("Not valid XACT relish tag {:?}", rel),

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -192,9 +192,7 @@ impl AtomicLsn {
     /// This operation will panic on overflow.
     pub fn fetch_add(&self, val: u64) -> Lsn {
         let prev = self.inner.fetch_add(val, Ordering::AcqRel);
-        if prev.checked_add(val).is_none() {
-            panic!("AtomicLsn overflow");
-        }
+        assert!(prev.checked_add(val).is_some(), "AtomicLsn overflow");
         Lsn(prev)
     }
 


### PR DESCRIPTION
Most of the changes are for the new `if-then-panic` lint added in https://github.com/rust-lang/rust-clippy/pull/7669. The error messages look like:
```
error: only a `panic!` in `if`-then statement
   --> zenith_utils/src/lsn.rs:195:9
    |
195 | /         if prev.checked_add(val).is_none() {
196 | |             panic!("AtomicLsn overflow");
197 | |         }
    | |_________^ help: try: `assert!(!prev.checked_add(val).is_none(), "AtomicLsn overflow");`
    |
    = note: `-D clippy::if-then-panic` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_then_panic
```
At first I thought it generally made things less readable, but it actually surprised me - being able to see the `assert!` at the start of the line makes it abundantly clear what the purpose is.