### PR TITLE
Docker build now also uses BUILD_TYPE=release.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,7 @@ test_output
 .zenith
 integration_tests/.zenith
 .mypy_cache
+
+Dockerfile
+.dockerignore
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /zenith
 COPY ./vendor/postgres vendor/postgres
 COPY ./Makefile Makefile
 RUN make -j $(getconf _NPROCESSORS_ONLN) -s postgres
+ENV BUILD_TYPE release
 RUN rm -rf postgres_install/build
 
 #
@@ -24,6 +25,7 @@ WORKDIR /zenith
 COPY --from=pg-build /zenith/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
 
 COPY . .
+ENV BUILD_TYPE release
 RUN cargo build --release
 
 #


### PR DESCRIPTION
The dockerignore and dockerfile have also been excluded from being moved into
docker images, saving docker layer cache busts if only those are changed.

Fixes #683 