### PR TITLE
Safekeeper metrics tests

### DIFF
--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -80,7 +80,7 @@ def test_many_timelines(zenith_env_builder: ZenithEnvBuilder):
         branch_metrics = []
         with env.pageserver.http_client() as pageserver_http:
             for branch_detail in branch_details:
-                timeline_id = branch_detail["timeline_id"]
+                timeline_id: str = branch_detail["timeline_id"]
 
                 m = BranchMetrics(
                     name=branch_detail["name"],

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -90,6 +90,11 @@ def test_many_timelines(zenith_env_builder: ZenithEnvBuilder):
                     m.flush_lsns.append(sk_m.flush_lsn_inexact[timeline_id])
                     m.commit_lsns.append(sk_m.commit_lsn_inexact[timeline_id])
 
+                # We only call collect_metrics() after a transaction is confirmed by
+                # the compute node, which only happens after a consensus of safekeepers
+                # has confirmed the transaction. In local tests it's quite often
+                # that all safekeepers has confirmed the transaction, so we ensure that
+                # until it's flaky.
                 for lsn in m.flush_lsns:
                     assert m.latest_valid_lsn <= lsn
                 for lsn in m.commit_lsns:
@@ -98,7 +103,8 @@ def test_many_timelines(zenith_env_builder: ZenithEnvBuilder):
         log.info(f"{message}: {branch_metrics}")
         return branch_metrics
 
-    collect_metrics("before CREATE TABLE")
+    # TODO: https://github.com/zenithdb/zenith/issues/809
+    # collect_metrics("before CREATE TABLE")
 
     # Do everything in different loops to have actions on different timelines
     # interleaved.

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -87,8 +87,8 @@ def test_many_timelines(zenith_env_builder: ZenithEnvBuilder):
                     latest_valid_lsn=branch_detail["latest_valid_lsn"],
                 )
                 for sk_m in sk_metrics:
-                    m.flush_lsns.append(sk_m.timeline_flush_lsn_inexact[timeline_id])
-                    m.commit_lsns.append(sk_m.timeline_commit_lsn_inexact[timeline_id])
+                    m.flush_lsns.append(sk_m.flush_lsn_inexact[timeline_id])
+                    m.commit_lsns.append(sk_m.commit_lsn_inexact[timeline_id])
 
                 for lsn in m.flush_lsns:
                     assert m.latest_valid_lsn <= lsn

--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -6,10 +6,12 @@ import subprocess
 import uuid
 
 from contextlib import closing
+from dataclasses import dataclass, field
 from multiprocessing import Process, Value
 from fixtures.zenith_fixtures import PgBin, ZenithEnv, ZenithEnvBuilder
 from fixtures.utils import lsn_to_hex, mkdir_if_needed
 from fixtures.log_helper import log
+from typing import List
 
 pytest_plugins = ("fixtures.zenith_fixtures")
 
@@ -34,13 +36,21 @@ def test_normal_work(zenith_env_builder: ZenithEnvBuilder):
             assert cur.fetchone() == (5000050000, )
 
 
+@dataclass
+class BranchMetrics:
+    name: str
+    latest_valid_lsn: int
+    flush_lsns: List[int] = field(default_factory=list)
+    commit_lsns: List[int] = field(default_factory=list)
+
+
 # Run page server and multiple acceptors, and multiple compute nodes running
 # against different timelines.
 def test_many_timelines(zenith_env_builder: ZenithEnvBuilder):
     zenith_env_builder.num_safekeepers = 3
     env = zenith_env_builder.init()
 
-    n_timelines = 2
+    n_timelines = 3
 
     branches = ["test_wal_acceptors_many_timelines_{}".format(tlin) for tlin in range(n_timelines)]
 
@@ -50,20 +60,73 @@ def test_many_timelines(zenith_env_builder: ZenithEnvBuilder):
         env.zenith_cli(["branch", branch, "main"])
         pgs.append(env.postgres.create_start(branch))
 
+    tenant_id = uuid.UUID(env.initial_tenant)
+
+    def collect_metrics(message: str) -> List[BranchMetrics]:
+        with env.pageserver.http_client() as pageserver_http:
+            branch_details = [
+                pageserver_http.branch_detail(tenant_id=tenant_id, name=branch)
+                for branch in branches
+            ]
+        # All changes visible to pageserver (latest_valid_lsn) should be
+        # confirmed by safekeepers first. As we cannot atomically get
+        # state of both pageserver and safekeepers, we should start with
+        # pageserver. Looking at outdated data from pageserver is ok.
+        # Asking safekeepers first is not ok because new commits may arrive
+        # to both safekeepers and pageserver after we've already obtained
+        # safekeepers' state, it will look contradictory.
+        sk_metrics = [sk.http_client().get_metrics() for sk in env.safekeepers]
+
+        branch_metrics = []
+        with env.pageserver.http_client() as pageserver_http:
+            for branch_detail in branch_details:
+                timeline_id = branch_detail["timeline_id"]
+
+                m = BranchMetrics(
+                    name=branch_detail["name"],
+                    latest_valid_lsn=branch_detail["latest_valid_lsn"],
+                )
+                for sk_m in sk_metrics:
+                    m.flush_lsns.append(sk_m.timeline_flush_lsn_inexact[timeline_id])
+                    m.commit_lsns.append(sk_m.timeline_commit_lsn_inexact[timeline_id])
+
+                for lsn in m.flush_lsns:
+                    assert m.latest_valid_lsn <= lsn
+                for lsn in m.commit_lsns:
+                    assert m.latest_valid_lsn <= lsn
+                branch_metrics.append(m)
+        log.info(f"{message}: {branch_metrics}")
+        return branch_metrics
+
+    collect_metrics("before CREATE TABLE")
+
     # Do everything in different loops to have actions on different timelines
     # interleaved.
     # create schema
     for pg in pgs:
         pg.safe_psql("CREATE TABLE t(key int primary key, value text)")
+    init_m = collect_metrics("after CREATE TABLE")
 
-    # Populate data
-    for pg in pgs:
+    # Populate data for 2/3 branches
+    for pg in pgs[:-1]:
         pg.safe_psql("INSERT INTO t SELECT generate_series(1,100000), 'payload'")
+    collect_metrics("after INSERT INTO")
 
-    # Check data
-    for pg in pgs:
+    # Check data for 2/3 branches
+    for pg in pgs[:-1]:
         res = pg.safe_psql("SELECT sum(key) FROM t")
         assert res[0] == (5000050000, )
+
+    final_m = collect_metrics("after SELECT")
+    # Assume that LSNs (a) behave similarly in all branches; and (b) INSERT INTO alters LSN significantly.
+    # Also assume that safekeepers will not be significantly out of sync in this test.
+    middle_lsn = (init_m[0].latest_valid_lsn + final_m[0].latest_valid_lsn) // 2
+    assert max(init_m[0].flush_lsns) < middle_lsn < min(final_m[0].flush_lsns)
+    assert max(init_m[0].commit_lsns) < middle_lsn < min(final_m[0].commit_lsns)
+    assert max(init_m[1].flush_lsns) < middle_lsn < min(final_m[1].flush_lsns)
+    assert max(init_m[1].commit_lsns) < middle_lsn < min(final_m[1].commit_lsns)
+    assert max(init_m[2].flush_lsns) <= min(final_m[2].flush_lsns) < middle_lsn
+    assert max(init_m[2].commit_lsns) <= min(final_m[2].commit_lsns) < middle_lsn
 
 
 # Check that dead minority doesn't prevent the commits: execute insert n_inserts

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1059,8 +1059,10 @@ class SafekeeperTimelineStatus:
 
 @dataclass
 class SafekeeperMetrics:
-    timeline_flush_lsn_inexact: Dict[str, int] = field(default_factory=dict)
-    timeline_commit_lsn_inexact: Dict[str, int] = field(default_factory=dict)
+    # These are metrics from Prometheus which uses float64 internally.
+    # As a consequence, values may differ from real original int64s.
+    flush_lsn_inexact: Dict[str, int] = field(default_factory=dict)
+    commit_lsn_inexact: Dict[str, int] = field(default_factory=dict)
 
 
 class SafekeeperHttpClient(requests.Session):
@@ -1087,11 +1089,11 @@ class SafekeeperHttpClient(requests.Session):
         for match in re.finditer(r'^safekeeper_flush_lsn{ztli="([0-9a-f]+)"} (\S+)$',
                                  all_metrics_text,
                                  re.MULTILINE):
-            metrics.timeline_flush_lsn_inexact[match.group(1)] = int(match.group(2))
+            metrics.flush_lsn_inexact[match.group(1)] = int(match.group(2))
         for match in re.finditer(r'^safekeeper_commit_lsn{ztli="([0-9a-f]+)"} (\S+)$',
                                  all_metrics_text,
                                  re.MULTILINE):
-            metrics.timeline_commit_lsn_inexact[match.group(1)] = int(match.group(2))
+            metrics.commit_lsn_inexact[match.group(1)] = int(match.group(2))
         return metrics
 
 

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -642,7 +642,7 @@ class ZenithPageserver(PgProtocol):
     def __exit__(self, exc_type, exc, tb):
         self.stop(True)
 
-    def http_client(self, auth_token: Optional[str] = None):
+    def http_client(self, auth_token: Optional[str] = None) -> ZenithPageserverHttpClient:
         return ZenithPageserverHttpClient(
             port=self.service_port.http,
             auth_token=auth_token,
@@ -1047,7 +1047,7 @@ class Safekeeper:
                 assert isinstance(res, dict)
                 return res
 
-    def http_client(self):
+    def http_client(self) -> SafekeeperHttpClient:
         return SafekeeperHttpClient(port=self.port.http)
 
 


### PR DESCRIPTION
This PR ensures that LSN guages in Safekeeper are reported and satisfy some basic requirements. Part of #541

WIP:

* [x] Take a look through #742 for better data retrieval from the Compute Node and stuff
* [x] Resolve conflicts with #742 
* [x] Understand what is the relation between `flush_lsn`, `commit_lsn` and `last_valid_lsn`: https://discord.com/channels/869525774699462656/869526396878323733/897550905090637855
* [x] Add actual assertions instead of debug output