### PR TITLE
Suppress 'unknown deref_nullptr' warning for Rust 1.52.1

### DIFF
--- a/postgres_ffi/src/lib.rs
+++ b/postgres_ffi/src/lib.rs
@@ -3,7 +3,9 @@
 #![allow(non_snake_case)]
 // suppress warnings on rust 1.53 due to bindgen unit tests.
 // https://github.com/rust-lang/rust-bindgen/issues/1651
+#![allow(unknown_lints)] // TODO: CI uses rust 1.52.1, which does not know about deref_nullptr
 #![allow(deref_nullptr)]
+#![warn(unknown_lints)]
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Here is a typical output of my local build:

```
    Checking zenith_metrics v0.1.0 (/home/yeputons/job/zenith/zenith_metrics)
    Checking zenith_utils v0.1.0 (/home/yeputons/job/zenith/zenith_utils)
    Checking postgres_ffi v0.1.0 (/home/yeputons/job/zenith/postgres_ffi)
    Checking proxy v0.1.0 (/home/yeputons/job/zenith/proxy)
warning: unknown lint: `deref_nullptr`
 --> postgres_ffi/src/lib.rs:6:10
  |
6 | #![allow(deref_nullptr)]
  |          ^^^^^^^^^^^^^
  |
  = note: `#[warn(unknown_lints)]` on by default

warning: 1 warning emitted

    Checking pageserver v0.1.0 (/home/yeputons/job/zenith/pageserver)
    Checking walkeeper v0.1.0 (/home/yeputons/job/zenith/walkeeper)
    Checking control_plane v0.1.0 (/home/yeputons/job/zenith/control_plane)
    Checking zenith v0.1.0 (/home/yeputons/job/zenith/zenith)
    Finished dev [unoptimized + debuginfo] target(s) in 16.67s
```

It looks like `deref_nullptr` is only available since Rust 1.53.0: https://github.com/rust-lang/rust/pull/83948#event-4595775375

While 1.56 is already available and is probably used by some devs (hence #350), our CI only uses 1.52.1 (and I use the same for consistency).

It looks like there is no simple way to check for compiler version or if lint is known, so I decided to suppress the "unknown lint" lint altogether for a piece of code.

Note that treating all warnings as errors is still disabled because there are build with different versions for... Reasons?