### PR TITLE
React on sigint

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -552,7 +552,7 @@ fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
                 info!("Got SIGQUIT. Terminate pageserver in immediate shutdown mode");
                 exit(111);
             }
-            SIGTERM => {
+            SIGINT | SIGTERM => {
                 info!("Got SIGINT/SIGTERM. Terminate gracefully in fast shutdown mode");
                 // Terminate postgres backends
                 postgres_backend::set_pgbackend_shutdown_requested();
@@ -577,8 +577,8 @@ fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
                 info!("Pageserver shut down successfully completed");
                 exit(0);
             }
-            _ => {
-                debug!("Unknown signal.");
+            unknown_signal => {
+                debug!("Unknown signal {}", unknown_signal);
             }
         }
     }


### PR DESCRIPTION
Just realized, that on my machine (mac), Ctrl + C does nothing to pageserver.
When I turned on the debug logging, I've noted "Unknown signal." log.

This PR now also logs the unknown signal code and actually treats SIGINT (2) as stop, since that's what was commented in the code.