### PR TITLE
Wait for safekeepers to catch up in test_restarts_under_load

### DIFF
--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -109,7 +109,7 @@ async def wait_for_lsn(safekeeper: WalAcceptor,
                        timeline_id: str,
                        wait_lsn: str,
                        polling_interval=1,
-                       timeout=120):
+                       timeout=600):
     """
     Poll flush_lsn from safekeeper until it's greater or equal than
     provided wait_lsn. To do that, timeline_status is fetched from

--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -1,9 +1,11 @@
 import asyncio
 import asyncpg
 import random
+import time
 
 from fixtures.zenith_fixtures import WalAcceptor, WalAcceptorFactory, ZenithPageserver, PostgresFactory, Postgres
 from fixtures.log_helper import getLogger
+from fixtures.utils import lsn_from_hex, lsn_to_hex
 from typing import List
 
 log = getLogger('root.wal_acceptor_async')
@@ -101,6 +103,27 @@ async def run_random_worker(stats: WorkerStats, pg: Postgres, worker_id, n_accou
 
     await pg_conn.close()
 
+async def wait_for_lsn(safekeeper: WalAcceptor, tenant_id: str, timeline_id: str, wait_lsn: str, polling_interval=1, timeout=120):
+    """
+    Poll flush_lsn from safekeeper until it's greater or equal than
+    provided wait_lsn. To do that, timeline_status is fetched from
+    safekeeper every polling_interval seconds.
+    """
+    
+    started_at = time.time()
+    client = safekeeper.http_client()
+
+    flush_lsn = client.timeline_status(tenant_id, timeline_id).flush_lsn
+    log.info(f'Safekeeper at port {safekeeper.port.pg} has flush_lsn {flush_lsn}, waiting for lsn {wait_lsn}')
+
+    while lsn_from_hex(wait_lsn) > lsn_from_hex(flush_lsn):
+        elapsed = time.time() - started_at
+        if elapsed > timeout:
+            raise RuntimeError(f"timed out waiting for safekeeper at port {safekeeper.port.pg} to reach {wait_lsn}, current lsn is {flush_lsn}")
+
+        await asyncio.sleep(polling_interval)
+        flush_lsn = client.timeline_status(tenant_id, timeline_id).flush_lsn
+        log.debug(f'safekeeper port={safekeeper.port.pg} flush_lsn={flush_lsn} wait_lsn={wait_lsn}')
 
 # This test will run several iterations and check progress in each of them.
 # On each iteration 1 acceptor is stopped, and 2 others should allow
@@ -114,6 +137,9 @@ async def run_restarts_under_load(pg: Postgres, acceptors: List[WalAcceptor], n_
     iterations = 6
 
     pg_conn = await pg.connect_async()
+    tenant_id = await pg_conn.fetchval("show zenith.zenith_tenant")
+    timeline_id = await pg_conn.fetchval("show zenith.zenith_timeline")
+
     bank = BankClient(pg_conn, n_accounts=n_accounts, init_amount=init_amount)
     # create tables and initial balances
     await bank.initdb()
@@ -125,14 +151,18 @@ async def run_restarts_under_load(pg: Postgres, acceptors: List[WalAcceptor], n_
         workers.append(asyncio.create_task(worker))
 
     for it in range(iterations):
-        victim = acceptors[it % len(acceptors)]
+        victim_idx = it % len(acceptors)
+        victim = acceptors[victim_idx]
         victim.stop()
 
-        # Wait till previous victim recovers so it is ready for the next
-        # iteration by making any writing xact.
-        conn = await pg.connect_async()
-        await conn.execute('UPDATE bank_accs SET amount = amount WHERE uid = 1', timeout=120)
-        await conn.close()
+        flush_lsn = await pg_conn.fetchval('SELECT pg_current_wal_flush_lsn()')
+        flush_lsn = lsn_to_hex(flush_lsn)
+        log.info(f'Postgres flush_lsn {flush_lsn}')
+
+        # Wait until alive safekeepers catch up with postgres
+        for idx, safekeeper in enumerate(acceptors):
+            if idx != victim_idx:
+                await wait_for_lsn(safekeeper, tenant_id, timeline_id, flush_lsn)
 
         stats.reset()
         await asyncio.sleep(period_time)

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -63,3 +63,8 @@ def global_counter() -> int:
 def lsn_to_hex(num: int) -> str:
     """ Convert lsn from int to standard hex notation. """
     return "{:X}/{:X}".format(num >> 32, num & 0xffffffff)
+
+def lsn_from_hex(lsn_hex: str) -> int:
+    """ Convert lsn from hex notation to int. """
+    l, r = lsn_hex.split('/')
+    return (int(l, 16) << 32) + int(r, 16)

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -64,6 +64,7 @@ def lsn_to_hex(num: int) -> str:
     """ Convert lsn from int to standard hex notation. """
     return "{:X}/{:X}".format(num >> 32, num & 0xffffffff)
 
+
 def lsn_from_hex(lsn_hex: str) -> int:
     """ Convert lsn from hex notation to int. """
     l, r = lsn_hex.split('/')

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1031,8 +1031,9 @@ def wa_factory(zenith_binpath: str,
 
 
 @dataclass
-class PageserverTimelineStatus:
+class SafekeeperTimelineStatus:
     acceptor_epoch: int
+    flush_lsn: str
 
 
 class WalAcceptorHttpClient(requests.Session):
@@ -1043,11 +1044,14 @@ class WalAcceptorHttpClient(requests.Session):
     def check_status(self):
         self.get(f"http://localhost:{self.port}/v1/status").raise_for_status()
 
-    def timeline_status(self, tenant_id: str, timeline_id: str) -> PageserverTimelineStatus:
+    def timeline_status(self, tenant_id: str, timeline_id: str) -> SafekeeperTimelineStatus:
         res = self.get(f"http://localhost:{self.port}/v1/timeline/{tenant_id}/{timeline_id}")
         res.raise_for_status()
         resj = res.json()
-        return PageserverTimelineStatus(acceptor_epoch=resj['acceptor_state']['epoch'])
+        return SafekeeperTimelineStatus(
+            acceptor_epoch=resj['acceptor_state']['epoch'],
+            flush_lsn=resj['flush_lsn']
+        )
 
 
 @zenfixture

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1048,10 +1048,8 @@ class WalAcceptorHttpClient(requests.Session):
         res = self.get(f"http://localhost:{self.port}/v1/timeline/{tenant_id}/{timeline_id}")
         res.raise_for_status()
         resj = res.json()
-        return SafekeeperTimelineStatus(
-            acceptor_epoch=resj['acceptor_state']['epoch'],
-            flush_lsn=resj['flush_lsn']
-        )
+        return SafekeeperTimelineStatus(acceptor_epoch=resj['acceptor_state']['epoch'],
+                                        flush_lsn=resj['flush_lsn'])
 
 
 @zenfixture

--- a/walkeeper/src/http/routes.rs
+++ b/walkeeper/src/http/routes.rs
@@ -49,6 +49,8 @@ struct TimelineStatus {
     commit_lsn: Lsn,
     #[serde(serialize_with = "display_serialize")]
     truncate_lsn: Lsn,
+    #[serde(serialize_with = "display_serialize")]
+    flush_lsn: Lsn,
 }
 
 /// Report info about timeline.
@@ -64,6 +66,7 @@ async fn timeline_status_handler(request: Request<Body>) -> Result<Response<Body
     )
     .map_err(ApiError::from_err)?;
     let sk_state = tli.get_info();
+    let (flush_lsn, _) = tli.get_end_of_wal();
 
     let status = TimelineStatus {
         tenant_id,
@@ -71,6 +74,7 @@ async fn timeline_status_handler(request: Request<Body>) -> Result<Response<Body
         acceptor_state: sk_state.acceptor_state,
         commit_lsn: sk_state.commit_lsn,
         truncate_lsn: sk_state.truncate_lsn,
+        flush_lsn: flush_lsn,
     };
     Ok(json_response(StatusCode::OK, status)?)
 }

--- a/walkeeper/src/http/routes.rs
+++ b/walkeeper/src/http/routes.rs
@@ -74,7 +74,7 @@ async fn timeline_status_handler(request: Request<Body>) -> Result<Response<Body
         acceptor_state: sk_state.acceptor_state,
         commit_lsn: sk_state.commit_lsn,
         truncate_lsn: sk_state.truncate_lsn,
-        flush_lsn: flush_lsn,
+        flush_lsn,
     };
     Ok(json_response(StatusCode::OK, status)?)
 }


### PR DESCRIPTION
There were a lot of failed runs for `test_restarts_under_load` recently in the CI, test fails with this error in pg.log:
```
 DETAIL:  page server returned error: Timed out while waiting for WAL record at LSN 0/2E53FD8 to arrive
```

I downloaded logs for failed tests in CI and searched for this error in pg.log. [Here is a link](https://gist.github.com/petuhovskiy/f30f428bb6c88adec2c4a677b2583652) with `grep -A 20 -B 20` on these logs.

It seems that many failed tests follow the same pattern, where safekeeper starts syncing after start but doesn't have time to download all messages from postgres in 1 minute. After that, a timeout occurs in the pageserver for reading a page, and the test crashes with the same error. Here is pg.log after starting safekeeper:
```
2021-10-19 17:24:17.564 GMT [4869] LOG:  connected with node localhost:15106
2021-10-19 17:24:17.565 GMT [4869] LOG:  got VoteResponse from acceptor localhost:15106, voteGiven=0, epoch=0, flushLsn=0/0, truncateLsn=0/0
2021-10-19 17:24:17.565 GMT [4869] LOG:  sending message len 1320 beginLsn=0/25E1C88 endLsn=0/25E21B0 commitLsn=0/2E535A8 truncateLsn=0/25E1C88 to localhost:15106

# sending messages to safekeeper here

2021-10-19 17:25:16.776 GMT [4869] LOG:  sending message len 0 beginLsn=0/2D8EF98 endLsn=0/2D8EF98 commitLsn=0/2E535A8 truncateLsn=0/25E21B0 to localhost:15106
2021-10-19 17:25:16.778 GMT [4869] LOG:  sending message len 352 beginLsn=0/2D8EF98 endLsn=0/2D8F0F8 commitLsn=0/2E535A8 truncateLsn=0/25E21B0 to localhost:15106
2021-10-19 17:25:16.778 GMT [5900] FATAL:  could not read block 0 in rel 1663/13974/2616.0 from page server at lsn 0/02E53FD8
2021-10-19 17:25:16.778 GMT [5900] DETAIL:  page server returned error: Timed out while waiting for WAL record at LSN 0/2E53FD8 to arrive
2021-10-19 17:25:16.779 GMT [6072] LOG:  [ZENITH_SMGR] libpqpagestore: connected to 'host=localhost port=15100 password='
2021-10-19 17:25:16.780 GMT [4869] LOG:  sending message len 0 beginLsn=0/2D8F0F8 endLsn=0/2D8F0F8 commitLsn=0/2E535A8 truncateLsn=0/25E21B0 to localhost:15106
2021-10-19 17:25:16.783 GMT [4869] LOG:  sending message len 192 beginLsn=0/2D8F0F8 endLsn=0/2D8F1B8 commitLsn=0/2E535A8 truncateLsn=0/25E21B0 to localhost:15106
2021-10-19 17:25:16.785 GMT [4925] WARNING:  canceling wait for synchronous replication due to user request
2021-10-19 17:25:16.785 GMT [4925] DETAIL:  The transaction has already committed locally, but might not have been replicated to the standby.
```

This issue is fixed by manually waiting for safekeepers lsn to match flush lsn from postgres, but it still seems that walproposer to safekeeper replication became very slow.