### PR TITLE
Drop tenant

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -289,6 +289,20 @@ impl PageServerNode {
             .json()?)
     }
 
+    pub fn tenant_drop(&self, tenantid: ZTenantId) -> Result<()> {
+        Ok(self
+            .http_request(
+                Method::DELETE,
+                format!("{}/{}", self.http_base_url, "tenant"),
+            )
+            .json(&TenantCreateRequest {
+                tenant_id: tenantid,
+            })
+            .send()?
+            .error_from_body()?
+            .json()?)
+    }
+
     pub fn branch_list(&self, tenantid: &ZTenantId) -> Result<Vec<BranchInfo>> {
         Ok(self
             .http_request(

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -560,7 +560,7 @@ fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
                 // Terminate postgres backends
                 postgres_backend::set_pgbackend_shutdown_requested();
                 // Stop all tenants and flush their data
-                tenant_mgr::shutdown_all_tenants()?;
+                tenant_mgr::shutdown_all_tenants(conf)?;
                 // Wait for pageservice thread to complete the job
                 page_service_thread
                     .join()

--- a/pageserver/src/http/openapi_spec.yml
+++ b/pageserver/src/http/openapi_spec.yml
@@ -235,6 +235,52 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    delete:
+      description: Drop tenant
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - "tenant_id"
+              properties:
+                tenant_id:
+                  type: string
+                  format: hex
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        "400":
+          description: Malformed tenant drop request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UnauthorizedError"
+        "403":
+          description: Forbidden Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenError"
+        "500":
+          description: Generic operation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
 components:
   securitySchemes:

--- a/pageserver/src/relish_storage/synced_storage.rs
+++ b/pageserver/src/relish_storage/synced_storage.rs
@@ -33,7 +33,7 @@ pub fn run_storage_sync_thread<
     let handle = thread::Builder::new()
         .name("Queue based relish storage sync".to_string())
         .spawn(move || {
-            while !tenant_mgr::shutdown_requested() {
+            while !tenant_mgr::pageserver_shutdown_requested() {
                 let mut queue_accessor = UPLOAD_QUEUE.lock().unwrap();
                 log::debug!("Upload queue length: {}", queue_accessor.len());
                 let next_task = queue_accessor.pop();

--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -39,6 +39,8 @@ pub trait Repository: Send + Sync {
         horizon: u64,
         checkpoint_before_gc: bool,
     ) -> Result<GcResult>;
+
+    fn list_timelineids(&self) -> Vec<ZTimelineId>;
 }
 
 ///
@@ -848,5 +850,7 @@ mod tests {
             println!("{}", s);
             Ok(TEST_IMG(&s))
         }
+
+        fn shutdown(&self) {}
     }
 }

--- a/test_runner/batch_others/test_tenant_drop.py
+++ b/test_runner/batch_others/test_tenant_drop.py
@@ -1,0 +1,80 @@
+from contextlib import closing
+
+import pytest
+import time
+
+from fixtures.zenith_fixtures import (
+    TenantFactory,
+    ZenithCli,
+    PostgresFactory,
+)
+
+from fixtures.zenith_fixtures import ZenithPageserver
+
+
+@pytest.mark.parametrize('with_wal_acceptors', [False, True])
+def test_tenant_drop(
+    zenith_cli: ZenithCli,
+    tenant_factory: TenantFactory,
+    postgres: PostgresFactory,
+    wa_factory,
+    with_wal_acceptors: bool,
+    pageserver: ZenithPageserver,
+):
+    """Tests tenant drop with and without wal acceptors"""
+    tenant_1 = tenant_factory.create()
+    tenant_2 = tenant_factory.create()
+
+    tenants = pageserver.http_client().tenant_list()
+    assert tenant_1 in {t['id'] for t in tenants if t['state'] == 'Active'}
+    assert tenant_2 in {t['id'] for t in tenants if t['state'] == 'Active'}
+
+    zenith_cli.run([
+        "branch",
+        f"test_tenant_drop_with_wal_acceptors{with_wal_acceptors}",
+        "main",
+        f"--tenantid={tenant_1}"
+    ])
+    zenith_cli.run([
+        "branch",
+        f"test_tenant_drop_with_wal_acceptors{with_wal_acceptors}",
+        "main",
+        f"--tenantid={tenant_2}"
+    ])
+    if with_wal_acceptors:
+        wa_factory.start_n_new(3)
+
+    pg_tenant1 = postgres.create_start(
+        f"test_tenant_drop_with_wal_acceptors{with_wal_acceptors}",
+        None,  # branch name, None means same as node name
+        tenant_1,
+        wal_acceptors=wa_factory.get_connstrs() if with_wal_acceptors else None,
+    )
+    pg_tenant2 = postgres.create_start(
+        f"test_tenant_drop_with_wal_acceptors{with_wal_acceptors}",
+        None,  # branch name, None means same as node name
+        tenant_2,
+        wal_acceptors=wa_factory.get_connstrs() if with_wal_acceptors else None,
+    )
+
+    for pg in [pg_tenant1, pg_tenant2]:
+        with closing(pg.connect()) as conn:
+            with conn.cursor() as cur:
+                # we rely upon autocommit after each statement
+                # as waiting for acceptors happens there
+                cur.execute("CREATE TABLE t(key int primary key, value text)")
+                cur.execute("INSERT INTO t SELECT generate_series(1,100), 'payload'")
+                cur.execute("SELECT sum(key) FROM t")
+                assert cur.fetchone() == (5050, )
+
+    tenant_2 = tenant_factory.drop(tenant_2)
+
+    tenants = pageserver.http_client().tenant_list()
+    assert tenant_1 in {t['id'] for t in tenants if t['state'] == 'Active'}
+    assert tenant_2 in {t['id'] for t in tenants if t['state'] == 'Stopping'}
+
+    time.sleep(5)
+
+    tenants = pageserver.http_client().tenant_list()
+    assert tenant_1 in {t['id'] for t in tenants if t['state'] == 'Active'}
+    assert tenant_2 in {t['id'] for t in tenants if t['state'] == 'CloudOnly'}

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1141,6 +1141,7 @@ class TenantFactory:
         res.check_returncode()
         return tenant_id
 
+
 @zenfixture
 def tenant_factory(zenith_cli: ZenithCli):
     return TenantFactory(zenith_cli)

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1136,6 +1136,10 @@ class TenantFactory:
         res.check_returncode()
         return tenant_id
 
+    def drop(self, tenant_id: str):
+        res = self.cli.run(['tenant', 'drop', tenant_id])
+        res.check_returncode()
+        return tenant_id
 
 @zenfixture
 def tenant_factory(zenith_cli: ZenithCli):

--- a/walkeeper/src/receive_wal.rs
+++ b/walkeeper/src/receive_wal.rs
@@ -59,6 +59,13 @@ fn request_callback(conf: WalAcceptorConf, timelineid: ZTimelineId, tenantid: ZT
             Ok(mut client) => {
                 if let Err(e) = client.simple_query(&callme) {
                     error!("Failed to send callme request to pageserver: {}", e);
+                    if e.to_string().contains("Repository is not valid for tenant")
+                        || e.to_string().contains("Tenant is not active")
+                        || e.to_string().contains("connection closed")
+                    {
+                        info!("Don't try to recall for non existing tenant");
+                        break;
+                    }
                 }
             }
             Err(e) => error!("Failed to connect to pageserver {}: {}", &ps_connstr, e),

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -89,6 +89,7 @@ fn main() -> Result<()> {
             .about("Manage tenants")
             .subcommand(SubCommand::with_name("list"))
             .subcommand(SubCommand::with_name("create").arg(Arg::with_name("tenantid").required(false).index(1)))
+            .subcommand(SubCommand::with_name("drop").arg(Arg::with_name("tenantid").required(true).index(1)))
         )
         .subcommand(SubCommand::with_name("status"))
         .subcommand(SubCommand::with_name("start").about("Start local pageserver"))
@@ -396,6 +397,15 @@ fn handle_tenant(tenant_match: &ArgMatches, env: &local_env::LocalEnv) -> Result
             println!("using tenant id {}", tenantid);
             pageserver.tenant_create(tenantid)?;
             println!("tenant successfully created on the pageserver");
+        }
+        ("drop", Some(drop_match)) => {
+            let tenantid_str = drop_match
+                .value_of("tenantid")
+                .ok_or_else(|| anyhow!("Missing tenant-id"))?;
+            let tenantid = ZTenantId::from_str(tenantid_str)?;
+            println!("drop tenant with tenant id {}", tenantid);
+            pageserver.tenant_drop(tenantid)?;
+            println!("tenant successfully deleted from the pageserver");
         }
         _ => {}
     }


### PR DESCRIPTION
`zenith tenant drop`
New command that allows to gracefully shutdown one tenant in the pageserver and free its resources.

tenant drop consists of a few stages:

1. stop all threads
2. free memory occupied by a tenant layers
3. drop on-disk files. Now `tenant drop` does it by default. Do we need to expose some separate flag for that?
4. remove data  from S3 (This part is not implemented yet)
