### PR TITLE
Use more robust way to persist safekeeper control file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "rust-s3",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "walkdir",

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -38,3 +38,6 @@ postgres_ffi = { path = "../postgres_ffi" }
 workspace_hack = { path = "../workspace_hack" }
 zenith_metrics = { path = "../zenith_metrics" }
 zenith_utils = { path = "../zenith_utils" }
+
+[dev-dependencies]
+tempfile = "3.2"

--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -6,7 +6,6 @@ use clap::{App, Arg};
 use const_format::formatcp;
 use daemonize::Daemonize;
 use log::*;
-use std::env;
 use std::path::{Path, PathBuf};
 use std::thread;
 use zenith_utils::http::endpoint;
@@ -78,20 +77,7 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
-    let mut conf = SafeKeeperConf {
-        // Always set to './'. We will chdir into the directory specified on the
-        // command line, so that when the server is running, all paths are relative
-        // to that.
-        workdir: PathBuf::from("./"),
-        daemonize: false,
-        no_sync: false,
-        pageserver_addr: None,
-        listen_pg_addr: DEFAULT_PG_LISTEN_ADDR.to_string(),
-        listen_http_addr: DEFAULT_HTTP_LISTEN_ADDR.to_string(),
-        ttl: None,
-        recall_period: None,
-        pageserver_auth_token: env::var("PAGESERVER_AUTH_TOKEN").ok(),
-    };
+    let mut conf: SafeKeeperConf = Default::default();
 
     if let Some(dir) = arg_matches.value_of("datadir") {
         // change into the data directory.

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -2,6 +2,9 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use std::env;
+use zenith_utils::zid::ZTimelineId;
+
 pub mod http;
 pub mod json_ctrl;
 pub mod receive_wal;
@@ -41,4 +44,29 @@ pub struct SafeKeeperConf {
     pub pageserver_auth_token: Option<String>,
     pub ttl: Option<Duration>,
     pub recall_period: Option<Duration>,
+}
+
+impl SafeKeeperConf {
+    pub fn timeline_dir(&self, timelineid: &ZTimelineId) -> PathBuf {
+        self.workdir.join(timelineid.to_string())
+    }
+}
+
+impl Default for SafeKeeperConf {
+    fn default() -> Self {
+        SafeKeeperConf {
+            // Always set to './'. We will chdir into the directory specified on the
+            // command line, so that when the server is running, all paths are relative
+            // to that.
+            workdir: PathBuf::from("./"),
+            daemonize: false,
+            no_sync: false,
+            pageserver_addr: None,
+            listen_pg_addr: defaults::DEFAULT_PG_LISTEN_ADDR.to_string(),
+            listen_http_addr: defaults::DEFAULT_PG_LISTEN_ADDR.to_string(),
+            ttl: None,
+            recall_period: None,
+            pageserver_auth_token: env::var("PAGESERVER_AUTH_TOKEN").ok(),
+        }
+    }
 }

--- a/walkeeper/src/receive_wal.rs
+++ b/walkeeper/src/receive_wal.rs
@@ -73,12 +73,12 @@ fn request_callback(conf: SafeKeeperConf, timelineid: ZTimelineId, tenantid: ZTe
 }
 
 impl<'pg> ReceiveWalConn<'pg> {
-    pub fn new(pg: &'pg mut PostgresBackend) -> Result<ReceiveWalConn<'pg>> {
+    pub fn new(pg: &'pg mut PostgresBackend) -> ReceiveWalConn<'pg> {
         let peer_addr = *pg.get_peer_addr();
-        Ok(ReceiveWalConn {
+        ReceiveWalConn {
             pg_backend: pg,
             peer_addr,
-        })
+        }
     }
 
     // Read and extract the bytes of a `CopyData` message from the postgres instance
@@ -142,7 +142,11 @@ impl<'pg> ReceiveWalConn<'pg> {
         }
 
         loop {
-            let reply = swh.timeline.get().process_msg(&msg)?;
+            let reply = swh
+                .timeline
+                .get()
+                .process_msg(&msg)
+                .with_context(|| "failed to process ProposerAcceptorMessage")?;
             self.write_msg(&reply)?;
             msg = self.read_msg()?;
         }

--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -228,8 +228,8 @@ impl ReplicationConn {
                     // Open a new file.
                     let segno = start_pos.segment_number(wal_seg_size);
                     let wal_file_name = XLogFileName(timeline, segno, wal_seg_size);
-                    let timeline_id = swh.timeline.get().timelineid.to_string();
-                    let wal_file_path = swh.conf.workdir.join(timeline_id).join(wal_file_name);
+                    let timeline_id = swh.timeline.get().timelineid;
+                    let wal_file_path = swh.conf.timeline_dir(&timeline_id).join(wal_file_name);
                     Self::open_wal_file(&wal_file_path)?
                 }
             };

--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -1,5 +1,6 @@
 //! Acceptor part of proposer-acceptor consensus algorithm.
 
+use anyhow::Context;
 use anyhow::{anyhow, bail, Result};
 use byteorder::LittleEndian;
 use byteorder::ReadBytesExt;
@@ -423,7 +424,9 @@ where
         self.s.server.ztli = msg.ztli;
         self.s.server.tli = msg.tli;
         self.s.server.wal_seg_size = msg.wal_seg_size;
-        self.storage.persist(&self.s, true)?;
+        self.storage
+            .persist(&self.s, true)
+            .with_context(|| "failed to persist shared state")?;
 
         self.metrics = SafeKeeperMetrics::new(self.s.server.ztli);
 


### PR DESCRIPTION
Now safekeeper control file updated in a following way:
1. Write data to temp file
2. Fsync the temporary file (if sync option is specified)
3. Rename temporary file to actual control file
4. Fsync containing directory (if sync option is specified)

Also because of the rename machinery switch to use dedicated lock file
to prevent running several safekeepers concurrently on the same data

I've also added a few `.with_context` calls for better error visibility

Resolves #678 