### PR TITLE
Use non_blocking TcpListener in the Page Service thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,9 +886,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "libloading"
@@ -1179,6 +1179,7 @@ dependencies = [
  "humantime",
  "hyper",
  "lazy_static",
+ "libc",
  "log",
  "postgres",
  "postgres-protocol",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -37,6 +37,7 @@ async-trait = "0.1"
 const_format = "0.2.21"
 tracing = "0.1.27"
 signal-hook = {version = "0.3.10", features = ["extended-siginfo"] }
+libc = "0.2.104"
 
 postgres_ffi = { path = "../postgres_ffi" }
 zenith_metrics = { path = "../zenith_metrics" }


### PR DESCRIPTION
It fixes shutting down of pageserver that haven't accepted any connection yet
i.e.
```
zenith init
zenith start
kill -INT $(cat .zenith/pageserver.pid)
```