### PR TITLE
Propagate git SHA to zenith binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
           name: Build and push Docker image
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
-            docker build -t zenithdb/zenith:latest . && docker push zenithdb/zenith:latest
+            docker build --build-arg GIT_VERSION=$CIRCLE_SHA1 -t zenithdb/zenith:latest . && docker push zenithdb/zenith:latest
 
   # Trigger a new remote CI job
   remote-ci-trigger:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-version"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2596,7 @@ dependencies = [
  "bincode",
  "byteorder",
  "bytes",
+ "git-version",
  "hex",
  "hex-literal",
  "hyper",

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,15 @@ RUN rm -rf postgres_install/build
 # net time waste in a lot of cases. Copying Cargo.lock with empty lib.rs should do the work.
 #
 FROM zenithdb/build:buster AS build
+
+ARG GIT_VERSION
+RUN if [ -z "$GIT_VERSION" ]; then echo "GIT_VERSION is reqired, use build_arg to pass it"; exit 1; fi
+
 WORKDIR /zenith
 COPY --from=pg-build /zenith/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
 
 COPY . .
-RUN cargo build --release
+RUN GIT_VERSION=$GIT_VERSION cargo build --release
 
 #
 # Copy binaries to resulting image.

--- a/pageserver/src/bin/dump_layerfile.rs
+++ b/pageserver/src/bin/dump_layerfile.rs
@@ -5,10 +5,12 @@ use anyhow::Result;
 use clap::{App, Arg};
 use pageserver::layered_repository::dump_layerfile_from_path;
 use std::path::PathBuf;
+use zenith_utils::GIT_VERSION;
 
 fn main() -> Result<()> {
     let arg_matches = App::new("Zenith dump_layerfile utility")
         .about("Dump contents of one layer file, for debugging")
+        .version(GIT_VERSION)
         .arg(
             Arg::with_name("path")
                 .help("Path to file to dump")

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -10,7 +10,7 @@ use std::{
     thread,
 };
 use tracing::*;
-use zenith_utils::{auth::JwtAuth, logging, postgres_backend::AuthType, tcp_listener};
+use zenith_utils::{auth::JwtAuth, logging, postgres_backend::AuthType, tcp_listener, GIT_VERSION};
 
 use anyhow::{bail, ensure, Context, Result};
 use signal_hook::consts::signal::*;
@@ -264,6 +264,7 @@ fn main() -> Result<()> {
     zenith_metrics::set_common_metrics_prefix("pageserver");
     let arg_matches = App::new("Zenith page server")
         .about("Materializes WAL stream to pages and serves them to the postgres")
+        .version(GIT_VERSION)
         .arg(
             Arg::with_name("listen-pg")
                 .short("l")
@@ -475,6 +476,8 @@ fn main() -> Result<()> {
 fn start_pageserver(conf: &'static PageServerConf) -> Result<()> {
     // Initialize logger
     let log_file = logging::init(LOG_FILE_NAME, conf.daemonize)?;
+
+    info!("version: {}", GIT_VERSION);
 
     let term_now = Arc::new(AtomicBool::new(false));
     for sig in TERM_SIGNALS {

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -17,7 +17,7 @@ use clap::{App, Arg, ArgMatches};
 
 use cplane_api::DatabaseInfo;
 use rustls::{internal::pemfile, NoClientAuth, ProtocolVersion, ServerConfig};
-use zenith_utils::tcp_listener;
+use zenith_utils::{tcp_listener, GIT_VERSION};
 
 mod cplane_api;
 mod mgmt;
@@ -78,6 +78,7 @@ fn configure_ssl(arg_matches: &ArgMatches) -> anyhow::Result<Option<Arc<ServerCo
 
 fn main() -> anyhow::Result<()> {
     let arg_matches = App::new("Zenith proxy/router")
+        .version(GIT_VERSION)
         .arg(
             Arg::with_name("proxy")
                 .short("p")
@@ -138,6 +139,8 @@ fn main() -> anyhow::Result<()> {
         waiters: Mutex::new(HashMap::new()),
     };
     let state: &'static ProxyState = Box::leak(Box::new(state));
+
+    println!("Version: {}", GIT_VERSION);
 
     // Check that we can bind to address before further initialization
     println!("Starting proxy on {}", state.conf.proxy_address);

--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -10,7 +10,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::thread;
 use zenith_utils::http::endpoint;
-use zenith_utils::{logging, tcp_listener};
+use zenith_utils::{logging, tcp_listener, GIT_VERSION};
 
 use walkeeper::defaults::{DEFAULT_HTTP_LISTEN_ADDR, DEFAULT_PG_LISTEN_ADDR};
 use walkeeper::http;
@@ -22,6 +22,7 @@ fn main() -> Result<()> {
     zenith_metrics::set_common_metrics_prefix("safekeeper");
     let arg_matches = App::new("Zenith safekeeper")
         .about("Store WAL stream to local file system and push it to WAL receivers")
+        .version(GIT_VERSION)
         .arg(
             Arg::with_name("datadir")
                 .short("D")
@@ -130,6 +131,8 @@ fn main() -> Result<()> {
 
 fn start_safekeeper(conf: SafeKeeperConf) -> Result<()> {
     let log_file = logging::init("safekeeper.log", conf.daemonize)?;
+
+    info!("version: {}", GIT_VERSION);
 
     let http_listener = tcp_listener::bind(conf.listen_http_addr.clone()).map_err(|e| {
         error!("failed to bind to address {}: {}", conf.listen_http_addr, e);

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -20,6 +20,7 @@ use walkeeper::defaults::{
 use zenith_utils::auth::{Claims, Scope};
 use zenith_utils::postgres_backend::AuthType;
 use zenith_utils::zid::{ZTenantId, ZTimelineId};
+use zenith_utils::GIT_VERSION;
 
 use pageserver::branches::BranchInfo;
 
@@ -103,6 +104,7 @@ fn main() -> Result<()> {
 
     let matches = App::new("Zenith CLI")
         .setting(AppSettings::ArgRequiredElseHelp)
+        .version(GIT_VERSION)
         .subcommand(
             SubCommand::with_name("init")
                 .about("Initialize a new Zenith repository")

--- a/zenith_utils/Cargo.toml
+++ b/zenith_utils/Cargo.toml
@@ -30,6 +30,8 @@ hex = { version = "0.4.3", features = ["serde"] }
 rustls = "0.19.1"
 rustls-split = "0.2.1"
 
+git-version = "0.3.5"
+
 [dev-dependencies]
 hex-literal = "0.3"
 bytes = "1.0"

--- a/zenith_utils/build.rs
+++ b/zenith_utils/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=GIT_VERSION");
+}


### PR DESCRIPTION
Git commit sha is displayed when --version flag is used and is written
to logs during service startup. Uses simple buildscript to extract the hash.