### PR TITLE
Adjust timeouts for test_restarts_under_load

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,9 @@ jobs:
       - run:
           name: Run pytest
           working_directory: test_runner
+          # pytest doesn't output test logs in real time, so CI job may fail
+          # with `Too long with no output` error, if a test is running for a long time.
+          no_output_timeout: 20m
           environment:
             - ZENITH_BIN: /tmp/zenith/bin
             - POSTGRES_DISTRIB_DIR: /tmp/zenith/pg_install

--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -109,7 +109,7 @@ async def wait_for_lsn(safekeeper: Safekeeper,
                        timeline_id: str,
                        wait_lsn: str,
                        polling_interval=1,
-                       timeout=600):
+                       timeout=200):
     """
     Poll flush_lsn from safekeeper until it's greater or equal than
     provided wait_lsn. To do that, timeline_status is fetched from

--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -147,8 +147,9 @@ async def run_restarts_under_load(pg: Postgres, acceptors: List[Safekeeper], n_w
     period_time = 10
     iterations = 6
 
-    test_timeout = 15 * 60  # 15 minutes
-    started_at = time.time()
+    # Set timeout for this test at 15 minutes. It should be enough for
+    # test to complete and less than CircleCI's no_output_timeout.
+    test_timeout_at = time.monotonic() + 15 * 60
 
     pg_conn = await pg.connect_async()
     tenant_id = await pg_conn.fetchval("show zenith.zenith_tenant")
@@ -165,8 +166,7 @@ async def run_restarts_under_load(pg: Postgres, acceptors: List[Safekeeper], n_w
         workers.append(asyncio.create_task(worker))
 
     for it in range(iterations):
-        if time.time() - started_at > test_timeout:
-            raise RuntimeError('test timed out')
+        assert time.monotonic() < test_timeout_at, 'test timed out'
 
         victim_idx = it % len(acceptors)
         victim = acceptors[victim_idx]


### PR DESCRIPTION
There were several `Too long with no output` errors in CircleCI jobs, for example:
- https://app.circleci.com/pipelines/github/zenithdb/zenith/3030/workflows/20e84844-3c0d-4745-a94d-750e4ee25e15/jobs/24290
- https://app.circleci.com/pipelines/github/zenithdb/zenith/3052/workflows/30525649-6b75-485f-9983-8576c427c9d2/jobs/24498

These timeouts happen because test_restarts_under_load takes a long time to complete, and pytest is not writing anything to output at that time. 

This PR changes timeouts to get timeout error from pytest rather than CircleCI.