### PR TITLE
Allow downloading remote file range

### DIFF
--- a/pageserver/src/remote_storage.rs
+++ b/pageserver/src/remote_storage.rs
@@ -147,6 +147,15 @@ trait RemoteStorage: Send + Sync {
         to: &mut (impl io::AsyncWrite + Unpin + Send + Sync),
     ) -> anyhow::Result<()>;
 
+    /// Streams a given byte range of the remote storage entry contents into the buffered writer given, returns the filled writer.
+    async fn download_range(
+        &self,
+        from: &Self::StoragePath,
+        start_inclusive: u64,
+        end_exclusive: Option<u64>,
+        to: &mut (impl io::AsyncWrite + Unpin + Send + Sync),
+    ) -> anyhow::Result<()>;
+
     async fn delete(&self, path: &Self::StoragePath) -> anyhow::Result<()>;
 }
 


### PR DESCRIPTION
Another small step to prepare for S3 archives, helps when a part of remote archive such as metadata (as in proposed timeline compression design) or a particular file (in case any other archivation approach is picked and the offsets are known).