### PR TITLE
Disconnect walreceiver when no new WAL arrives

### DIFF
--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -11,6 +11,7 @@ use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 use zenith_utils::postgres_backend;
 use zenith_utils::postgres_backend::PostgresBackend;
 use zenith_utils::pq_proto::{BeMessage, FeStartupMessage, RowDescriptor, INT4_OID, TEXT_OID};
@@ -81,6 +82,10 @@ impl postgres_backend::Handler for SendWalHandler {
             bail!("Unexpected command {:?}", query_string);
         }
         Ok(())
+    }
+
+    fn idle_session_timeout(&self) -> Option<Duration> {
+        Some(Duration::from_secs(30))
     }
 }
 

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -23,7 +23,7 @@ pub fn thread_main(conf: SafeKeeperConf, listener: TcpListener) -> Result<()> {
                     .name("WAL service thread".into())
                     .spawn(move || {
                         if let Err(err) = handle_socket(socket, conf) {
-                            error!("connection handler exited: {}", err);
+                            error!("connection {} handler exited: {}", peer_addr, err);
                         }
                     })
                     .unwrap();
@@ -39,7 +39,7 @@ fn handle_socket(socket: TcpStream, conf: SafeKeeperConf) -> Result<()> {
     socket.set_nodelay(true)?;
 
     let mut conn_handler = SendWalHandler::new(conf);
-    let pgbackend = PostgresBackend::new(socket, AuthType::Trust, None, false)?;
+    let pgbackend = PostgresBackend::new(socket, AuthType::Trust, None, true)?;
     // libpq replication protocol between safekeeper and replicas/pagers
     pgbackend.run(&mut conn_handler)?;
 


### PR DESCRIPTION
 to turn tenant into Idle state.

Compute-node <--> WAL service connection changes:

Cancel SendWalHandler that has stopped receiving WAL after idle_session_timeout.
Now this is hardcoded as 30 seconds. Maybe worth turning into config parameter.

WAL service <--> Pageserver connection changes:

Change request_callback behavior: only request callback when receiver has some new WAL to stream,
shutdown request_callback thread together at ReceiveWalConn exit

If pageserver is caught up, disconnect ReplicationConn from WAL service to pageserver after some timeout.
Note that caught up here means that pageserver received the latest WAL. We don't have to wait for it to be durably stored, because it is already stored in WAL service and can be retreived later from safekeepers in case of pageserver restart.

Pageserver changes:
If walreceiver exited because of timeout, don't try to reconnect. Rely on WAL service request_callback to initiate this connection again, when new WAL arrives.