### PR TITLE
In wal_proposer_recovery, don't wait outcoming WAL to be committed.

### DIFF
--- a/walkeeper/src/replication.rs
+++ b/walkeeper/src/replication.rs
@@ -259,7 +259,7 @@ impl ReplicationConn {
 
             start_pos += send_size as u64;
 
-            debug!("sent WAL up to {}", end_pos);
+            debug!("sent WAL up to {}", start_pos);
 
             // Decide whether to reuse this file. If we don't set wal_file here
             // a new file will be opened next time.


### PR DESCRIPTION
Otherwise we're deadlocking ourselves. Oversight of 33007cc0bb.