### PR TITLE
Fix high CPU usage in walproposer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,9 +239,11 @@ jobs:
       - run:
           name: Run pytest
           working_directory: test_runner
-          # pytest doesn't output test logs in real time, so CI job may fail
-          # with `Too long with no output` error, if a test is running for a long time.
-          no_output_timeout: 20m
+          # pytest doesn't output test logs in real time, so CI job may fail with
+          # `Too long with no output` error, if a test is running for a long time.
+          # In that case, ests should have internal timeouts that are less than 
+          # no_output_timeout, specified here.
+          no_output_timeout: 10m
           environment:
             - ZENITH_BIN: /tmp/zenith/bin
             - POSTGRES_DISTRIB_DIR: /tmp/zenith/pg_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
           working_directory: test_runner
           # pytest doesn't output test logs in real time, so CI job may fail with
           # `Too long with no output` error, if a test is running for a long time.
-          # In that case, ests should have internal timeouts that are less than 
+          # In that case, tests should have internal timeouts that are less than 
           # no_output_timeout, specified here.
           no_output_timeout: 10m
           environment:

--- a/test_runner/batch_others/test_wal_acceptor_async.py
+++ b/test_runner/batch_others/test_wal_acceptor_async.py
@@ -109,7 +109,7 @@ async def wait_for_lsn(safekeeper: Safekeeper,
                        timeline_id: str,
                        wait_lsn: str,
                        polling_interval=1,
-                       timeout=200):
+                       timeout=60):
     """
     Poll flush_lsn from safekeeper until it's greater or equal than
     provided wait_lsn. To do that, timeline_status is fetched from
@@ -147,9 +147,10 @@ async def run_restarts_under_load(pg: Postgres, acceptors: List[Safekeeper], n_w
     period_time = 10
     iterations = 6
 
-    # Set timeout for this test at 15 minutes. It should be enough for
-    # test to complete and less than CircleCI's no_output_timeout.
-    test_timeout_at = time.monotonic() + 15 * 60
+    # Set timeout for this test at 5 minutes. It should be enough for test to complete
+    # and less than CircleCI's no_output_timeout, taking into account that this timeout
+    # is checked only at the beginning of every iteration.
+    test_timeout_at = time.monotonic() + 5 * 60
 
     pg_conn = await pg.connect_async()
     tenant_id = await pg_conn.fetchval("show zenith.zenith_tenant")


### PR DESCRIPTION
Update postgres with https://github.com/zenithdb/postgres/pull/101, which fixes slow walproposer work. Also update timeouts for test_restarts_under_load, which were previously relaxed in https://github.com/zenithdb/zenith/pull/830. 

Fixes https://github.com/zenithdb/zenith/issues/780