### PR TITLE
WIP investigate gc issues

### DIFF
--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -199,6 +199,21 @@ impl LayerMap {
         }
     }
 
+    pub fn print_segment_layers(&self, seg: SegmentTag) {
+        let segentry = self.segs.get(&seg).unwrap();
+        println!("dbg layers seg: {}", seg);
+        for l in segentry.historic.iter() {
+            println!(
+                "{} {}-{} is_dropped: {} is_incremental: {}",
+                l.get_seg_tag(),
+                l.get_start_lsn(),
+                l.get_end_lsn(),
+                l.is_dropped(),
+                l.is_incremental(),
+            );
+        }
+    }
+
     /// Is there any layer for given segment that is alive at the lsn?
     ///
     /// This is a public wrapper for SegEntry fucntion,

--- a/pageserver/src/layered_repository/metadata.rs
+++ b/pageserver/src/layered_repository/metadata.rs
@@ -42,6 +42,7 @@ pub struct TimelineMetadata {
     prev_record_lsn: Option<Lsn>,
     ancestor_timeline: Option<ZTimelineId>,
     ancestor_lsn: Lsn,
+    latest_gc_horizon: Lsn,
 }
 
 /// Points to a place in pageserver's local directory,
@@ -61,12 +62,14 @@ impl TimelineMetadata {
         prev_record_lsn: Option<Lsn>,
         ancestor_timeline: Option<ZTimelineId>,
         ancestor_lsn: Lsn,
+        gc_horizon: Lsn,
     ) -> Self {
         Self {
             disk_consistent_lsn,
             prev_record_lsn,
             ancestor_timeline,
             ancestor_lsn,
+            latest_gc_horizon: gc_horizon,
         }
     }
 
@@ -121,6 +124,10 @@ impl TimelineMetadata {
     pub fn ancestor_lsn(&self) -> Lsn {
         self.ancestor_lsn
     }
+
+    pub fn latest_gc_horizon(&self) -> Lsn {
+        self.latest_gc_horizon
+    }
 }
 
 /// This module is for direct conversion of metadata to bytes and back.
@@ -139,6 +146,7 @@ mod serialize {
         prev_record_lsn: &'a Option<Lsn>,
         ancestor_timeline: &'a Option<ZTimelineId>,
         ancestor_lsn: &'a Lsn,
+        latest_gc_horizon: &'a Lsn,
     }
 
     impl<'a> From<&'a TimelineMetadata> for SeTimelineMetadata<'a> {
@@ -148,6 +156,7 @@ mod serialize {
                 prev_record_lsn: &other.prev_record_lsn,
                 ancestor_timeline: &other.ancestor_timeline,
                 ancestor_lsn: &other.ancestor_lsn,
+                latest_gc_horizon: &other.latest_gc_horizon,
             }
         }
     }
@@ -158,6 +167,7 @@ mod serialize {
         prev_record_lsn: Option<Lsn>,
         ancestor_timeline: Option<ZTimelineId>,
         ancestor_lsn: Lsn,
+        latest_gc_horizon: Lsn,
     }
 
     impl From<DeTimelineMetadata> for TimelineMetadata {
@@ -167,6 +177,7 @@ mod serialize {
                 prev_record_lsn: other.prev_record_lsn,
                 ancestor_timeline: other.ancestor_timeline,
                 ancestor_lsn: other.ancestor_lsn,
+                latest_gc_horizon: other.latest_gc_horizon,
             }
         }
     }
@@ -185,6 +196,7 @@ mod tests {
             prev_record_lsn: Some(Lsn(0x100)),
             ancestor_timeline: Some(TIMELINE_ID),
             ancestor_lsn: Lsn(0),
+            latest_gc_horizon: Lsn(0),
         };
 
         let metadata_bytes = original_metadata

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -35,11 +35,14 @@ pub mod defaults {
     // FIXME: This current value is very low. I would imagine something like 1 GB or 10 GB
     // would be more appropriate. But a low value forces the code to be exercised more,
     // which is good for now to trigger bugs.
-    pub const DEFAULT_CHECKPOINT_DISTANCE: u64 = 256 * 1024 * 1024;
+    // pub const DEFAULT_CHECKPOINT_DISTANCE: u64 = 256 * 1024 * 1024;
+    pub const DEFAULT_CHECKPOINT_DISTANCE: u64 = 1024 * 1024;
     pub const DEFAULT_CHECKPOINT_PERIOD: Duration = Duration::from_secs(1);
 
-    pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
-    pub const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(100);
+    // pub const DEFAULT_GC_HORIZON: u64 = 64 * 1024 * 1024;
+    // pub const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(100);
+    pub const DEFAULT_GC_HORIZON: u64 = 1024 * 1024;
+    pub const DEFAULT_GC_PERIOD: Duration = Duration::from_secs(1);
 
     pub const DEFAULT_SUPERUSER: &str = "zenith_admin";
     pub const DEFAULT_REMOTE_STORAGE_MAX_CONCURRENT_SYNC_LIMITS: usize = 100;

--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -1562,6 +1562,6 @@ mod tests {
     }
 
     fn dummy_metadata(disk_consistent_lsn: Lsn) -> TimelineMetadata {
-        TimelineMetadata::new(disk_consistent_lsn, None, None, Lsn(0))
+        TimelineMetadata::new(disk_consistent_lsn, None, None, Lsn(0), Lsn(0))
     }
 }

--- a/test_runner/batch_others/test_branch_behind.py
+++ b/test_runner/batch_others/test_branch_behind.py
@@ -30,6 +30,9 @@ def test_branch_behind(zenith_simple_env: ZenithEnv):
     lsn_a = main_cur.fetchone()[0]
     log.info(f'LSN after 100 rows: {lsn_a}')
 
+    # Branch at the point where only 100 rows were inserted
+    env.zenith_cli(["branch", "test_branch_behind_hundred", "test_branch_behind@" + lsn_a])
+
     # Insert some more rows. (This generates enough WAL to fill a few segments.)
     main_cur.execute('''
         INSERT INTO foo
@@ -39,9 +42,11 @@ def test_branch_behind(zenith_simple_env: ZenithEnv):
     main_cur.execute('SELECT pg_current_wal_insert_lsn()')
     lsn_b = main_cur.fetchone()[0]
     log.info(f'LSN after 200100 rows: {lsn_b}')
+    # Branch at the point where only 200100 rows were inserted
+    env.zenith_cli(["branch", "test_branch_behind_more", "test_branch_behind@" + lsn_b])
 
-    # Branch at the point where only 100 rows were inserted
-    env.zenith_cli(["branch", "test_branch_behind_hundred", "test_branch_behind@" + lsn_a])
+    # # Branch at the point where only 100 rows were inserted
+    # env.zenith_cli(["branch", "test_branch_behind_hundred", "test_branch_behind@" + lsn_a])
 
     # Insert many more rows. This generates enough WAL to fill a few segments.
     main_cur.execute('''
@@ -54,9 +59,11 @@ def test_branch_behind(zenith_simple_env: ZenithEnv):
     main_cur.execute('SELECT pg_current_wal_insert_lsn()')
     lsn_c = main_cur.fetchone()[0]
     log.info(f'LSN after 400100 rows: {lsn_c}')
+    main_cur.execute("SELECT pg_relation_filepath('foo');")
+    log.warn("pg_relation_filepath('foo') %s", main_cur.fetchone())
 
-    # Branch at the point where only 200100 rows were inserted
-    env.zenith_cli(["branch", "test_branch_behind_more", "test_branch_behind@" + lsn_b])
+    # # Branch at the point where only 200100 rows were inserted
+    # env.zenith_cli(["branch", "test_branch_behind_more", "test_branch_behind@" + lsn_b])
 
     pg_hundred = env.postgres.create_start("test_branch_behind_hundred")
     pg_more = env.postgres.create_start("test_branch_behind_more")
@@ -64,6 +71,11 @@ def test_branch_behind(zenith_simple_env: ZenithEnv):
     # On the 'hundred' branch, we should see only 100 rows
     hundred_pg_conn = pg_hundred.connect()
     hundred_cur = hundred_pg_conn.cursor()
+    # All the rows are visible on the main branch
+    main_cur.execute('SELECT count(*) FROM foo')
+    assert main_cur.fetchone() == (400100, )
+
+    # psycopg2.errors.UndefinedTable: relation "foo" does not exist
     hundred_cur.execute('SELECT count(*) FROM foo')
     assert hundred_cur.fetchone() == (100, )
 
@@ -79,18 +91,18 @@ def test_branch_behind(zenith_simple_env: ZenithEnv):
 
     # Check bad lsn's for branching
 
-    # branch at segment boundary
-    env.zenith_cli(["branch", "test_branch_segment_boundary", "test_branch_behind@0/3000000"])
-    pg = env.postgres.create_start("test_branch_segment_boundary")
-    cur = pg.connect().cursor()
-    cur.execute('SELECT 1')
-    assert cur.fetchone() == (1, )
+    # # branch at segment boundary
+    # env.zenith_cli(["branch", "test_branch_segment_boundary", "test_branch_behind@0/3000000"])
+    # pg = env.postgres.create_start("test_branch_segment_boundary")
+    # cur = pg.connect().cursor()
+    # cur.execute('SELECT 1')
+    # assert cur.fetchone() == (1, )
 
-    # branch at pre-initdb lsn
-    #
-    # FIXME: This works currently, but probably shouldn't be allowed
-    try:
-        env.zenith_cli(["branch", "test_branch_preinitdb", "test_branch_behind@0/42"])
-        # FIXME: assert false, "branch with invalid LSN should have failed"
-    except subprocess.CalledProcessError:
-        log.info("Branch creation with pre-initdb LSN failed (as expected)")
+    # # branch at pre-initdb lsn
+    # #
+    # # FIXME: This works currently, but probably shouldn't be allowed
+    # try:
+    #     env.zenith_cli(["branch", "test_branch_preinitdb", "test_branch_behind@0/42"])
+    #     # FIXME: assert false, "branch with invalid LSN should have failed"
+    # except subprocess.CalledProcessError:
+    #     log.info("Branch creation with pre-initdb LSN failed (as expected)")

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -203,6 +203,12 @@ impl AtomicLsn {
     }
 }
 
+impl From<Lsn> for AtomicLsn {
+    fn from(lsn: Lsn) -> Self {
+        Self::new(lsn.0)
+    }
+}
+
 /// Pair of LSN's pointing to the end of the last valid record and previous one
 #[derive(Debug, Clone, Copy)]
 pub struct RecordLsn {


### PR DESCRIPTION
Investigation is based on errors from #707 but I think I found different problems.
1. The first problem is that we do not prohibit creation of a branch at a point that was already garbage collected. This is solved by introducing a `latest_gc_horizon`. The other way is to directly calculate it when we want to create a branch, but this might be vulnerable to race conditions and if we change gc strategy so gc horizon becomes not constant this would also break. latest_gc_horizon is updated before actual gc actions are performed on a timeline.
2. Second problem is that we do not track which layers are needed by child branch. So it is possible to garbage collect layers in parent branch and then fail to retrieve data in child branch. Currently this is half fixed in this pr, because here gc just ignores layers which might be referenced from child branches, but it wont delete them when they are no longer needed by the child branch. I'll try to implement gc strategy when child timeline can remove obsolete layers from the parent. 
 
Also I do not clearly understand yet how these problems interfere with layers stored in s3.

This is a draft PR with some debugging code left in place. But I will be glad to hear some feedback about the approach.