### PR TITLE
Prohibit branch creation at lsn that was already garbage collected.

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -146,7 +146,7 @@ impl Repository for LayeredRepository {
         // Create the timeline directory, and write initial metadata to file.
         crashsafe_dir::create_dir_all(self.conf.timeline_path(&timelineid, &self.tenantid))?;
 
-        let metadata = TimelineMetadata::new(Lsn(0), None, None, Lsn(0));
+        let metadata = TimelineMetadata::new(Lsn(0), None, None, Lsn(0), Lsn(0));
         Self::save_metadata(self.conf, timelineid, self.tenantid, &metadata, true)?;
 
         let timeline = LayeredTimeline::new(
@@ -168,7 +168,19 @@ impl Repository for LayeredRepository {
 
     /// Branch a timeline
     fn branch_timeline(&self, src: ZTimelineId, dst: ZTimelineId, start_lsn: Lsn) -> Result<()> {
-        let src_timeline = self.get_timeline(src)?;
+        // We need to hold this lock to prevent GC from starting at the same time. GC scans the directory to learn
+        // about timelines, so otherwise a race condition is possible, where we create new timeline and GC
+        // concurrently removes data that is needed by the new timeline.
+        let mut timelines = self.timelines.lock().unwrap();
+        let src_timeline = self.get_timeline_locked(src, &mut timelines)?;
+
+        let latest_gc_cutoff = src_timeline.latest_gc_cutoff.load();
+        ensure!(
+            start_lsn >= latest_gc_cutoff,
+            "Branch start LSN {} is earlier than latest GC horizon {} (we might've already garbage collected needed data)",
+            start_lsn,
+            latest_gc_cutoff,
+        );
 
         let RecordLsn {
             last: src_last,
@@ -185,11 +197,20 @@ impl Repository for LayeredRepository {
         // Create the metadata file, noting the ancestor of the new timeline.
         // There is initially no data in it, but all the read-calls know to look
         // into the ancestor.
-        let metadata = TimelineMetadata::new(start_lsn, dst_prev, Some(src), start_lsn);
+        let metadata = TimelineMetadata::new(
+            start_lsn,
+            dst_prev,
+            Some(src),
+            start_lsn,
+            src_timeline.latest_gc_cutoff.load(),
+        );
         crashsafe_dir::create_dir_all(self.conf.timeline_path(&dst, &self.tenantid))?;
         Self::save_metadata(self.conf, dst, self.tenantid, &metadata, true)?;
 
-        info!("branched timeline {} from {} at {}", dst, src, start_lsn);
+        info!(
+            "branched timeline {} from {} at {} latest_gc_cutoff {}",
+            dst, src, start_lsn, latest_gc_cutoff
+        );
 
         Ok(())
     }
@@ -552,6 +573,9 @@ pub struct LayeredTimeline {
     /// Must always be acquired before the layer map/individual layer lock
     /// to avoid deadlock.
     write_lock: Mutex<()>,
+
+    // Needed to ensure that we can't create a branch at a point that was already garbage collected
+    latest_gc_cutoff: AtomicLsn,
 }
 
 /// Public interface functions
@@ -591,6 +615,13 @@ impl Timeline for LayeredTimeline {
             );
         }
         debug_assert!(lsn <= self.get_last_record_lsn());
+        let latest_gc_cutoff = self.latest_gc_cutoff.load();
+        // error instead of assert to simplify testing
+        ensure!(
+            lsn >= latest_gc_cutoff,
+            "tried to request a page version that was garbage collected. requested at {} gc cutoff {}",
+            lsn, latest_gc_cutoff
+        );
 
         let seg = SegmentTag::from_blknum(rel, blknum);
 
@@ -857,6 +888,8 @@ impl LayeredTimeline {
             upload_relishes,
 
             write_lock: Mutex::new(()),
+
+            latest_gc_cutoff: AtomicLsn::from(metadata.latest_gc_cutoff()),
         };
         Ok(timeline)
     }
@@ -1237,6 +1270,7 @@ impl LayeredTimeline {
                 ondisk_prev_record_lsn,
                 ancestor_timelineid,
                 self.ancestor_lsn,
+                self.latest_gc_cutoff.load(),
             );
 
             LayeredRepository::save_metadata(
@@ -1333,6 +1367,10 @@ impl LayeredTimeline {
         let mut result: GcResult = Default::default();
 
         let _enter = info_span!("garbage collection", timeline = %self.timelineid, tenant = %self.tenantid, cutoff = %cutoff).entered();
+
+        // We need to ensure that no one branches at a point before latest_gc_cutoff.
+        // See branch_timeline() for details.
+        self.latest_gc_cutoff.store(cutoff);
 
         info!("GC starting");
 
@@ -1485,11 +1523,12 @@ impl LayeredTimeline {
 
             // We didn't find any reason to keep this file, so remove it.
             info!(
-                "garbage collecting {} {}-{} {}",
+                "garbage collecting {} {}-{} is_dropped: {} is_incremental: {}",
                 l.get_seg_tag(),
                 l.get_start_lsn(),
                 l.get_end_lsn(),
-                l.is_dropped()
+                l.is_dropped(),
+                l.is_incremental(),
             );
             layers_to_remove.push(Arc::clone(&l));
         }
@@ -1572,12 +1611,19 @@ impl LayeredTimeline {
         let mut layer_ref = layer;
         let mut curr_lsn = lsn;
         loop {
-            match layer_ref.get_page_reconstruct_data(
-                blknum,
-                curr_lsn,
-                cached_lsn_opt,
-                &mut data,
-            )? {
+            let result = layer_ref
+                .get_page_reconstruct_data(blknum, curr_lsn, cached_lsn_opt, &mut data)
+                .with_context(|| {
+                    format!(
+                        "Failed to get reconstruct data {} {:?} {} {} {:?}",
+                        layer_ref.get_seg_tag(),
+                        layer_ref.filename(),
+                        blknum,
+                        curr_lsn,
+                        cached_lsn_opt,
+                    )
+                })?;
+            match result {
                 PageReconstructResult::Complete => break,
                 PageReconstructResult::Continue(cont_lsn) => {
                     // Fetch base image / more WAL from the returned predecessor layer

--- a/pageserver/src/layered_repository/metadata.rs
+++ b/pageserver/src/layered_repository/metadata.rs
@@ -42,6 +42,7 @@ pub struct TimelineMetadata {
     prev_record_lsn: Option<Lsn>,
     ancestor_timeline: Option<ZTimelineId>,
     ancestor_lsn: Lsn,
+    latest_gc_cutoff: Lsn,
 }
 
 /// Points to a place in pageserver's local directory,
@@ -61,12 +62,14 @@ impl TimelineMetadata {
         prev_record_lsn: Option<Lsn>,
         ancestor_timeline: Option<ZTimelineId>,
         ancestor_lsn: Lsn,
+        latest_gc_cutoff: Lsn,
     ) -> Self {
         Self {
             disk_consistent_lsn,
             prev_record_lsn,
             ancestor_timeline,
             ancestor_lsn,
+            latest_gc_cutoff,
         }
     }
 
@@ -121,6 +124,10 @@ impl TimelineMetadata {
     pub fn ancestor_lsn(&self) -> Lsn {
         self.ancestor_lsn
     }
+
+    pub fn latest_gc_cutoff(&self) -> Lsn {
+        self.latest_gc_cutoff
+    }
 }
 
 /// This module is for direct conversion of metadata to bytes and back.
@@ -139,6 +146,7 @@ mod serialize {
         prev_record_lsn: &'a Option<Lsn>,
         ancestor_timeline: &'a Option<ZTimelineId>,
         ancestor_lsn: &'a Lsn,
+        latest_gc_cutoff: &'a Lsn,
     }
 
     impl<'a> From<&'a TimelineMetadata> for SeTimelineMetadata<'a> {
@@ -148,6 +156,7 @@ mod serialize {
                 prev_record_lsn: &other.prev_record_lsn,
                 ancestor_timeline: &other.ancestor_timeline,
                 ancestor_lsn: &other.ancestor_lsn,
+                latest_gc_cutoff: &other.latest_gc_cutoff,
             }
         }
     }
@@ -158,6 +167,7 @@ mod serialize {
         prev_record_lsn: Option<Lsn>,
         ancestor_timeline: Option<ZTimelineId>,
         ancestor_lsn: Lsn,
+        latest_gc_cutoff: Lsn,
     }
 
     impl From<DeTimelineMetadata> for TimelineMetadata {
@@ -167,6 +177,7 @@ mod serialize {
                 prev_record_lsn: other.prev_record_lsn,
                 ancestor_timeline: other.ancestor_timeline,
                 ancestor_lsn: other.ancestor_lsn,
+                latest_gc_cutoff: other.latest_gc_cutoff,
             }
         }
     }
@@ -185,6 +196,7 @@ mod tests {
             prev_record_lsn: Some(Lsn(0x100)),
             ancestor_timeline: Some(TIMELINE_ID),
             ancestor_lsn: Lsn(0),
+            latest_gc_cutoff: Lsn(0),
         };
 
         let metadata_bytes = original_metadata

--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -1562,6 +1562,6 @@ mod tests {
     }
 
     fn dummy_metadata(disk_consistent_lsn: Lsn) -> TimelineMetadata {
-        TimelineMetadata::new(disk_consistent_lsn, None, None, Lsn(0))
+        TimelineMetadata::new(disk_consistent_lsn, None, None, Lsn(0), Lsn(0))
     }
 }

--- a/test_runner/batch_others/test_snapfiles_gc.py
+++ b/test_runner/batch_others/test_snapfiles_gc.py
@@ -1,20 +1,11 @@
 from contextlib import closing
 import psycopg2.extras
 import time
+from fixtures.utils import print_gc_result
 from fixtures.zenith_fixtures import ZenithEnv
 from fixtures.log_helper import log
 
 pytest_plugins = ("fixtures.zenith_fixtures")
-
-
-def print_gc_result(row):
-    log.info("GC duration {elapsed} ms".format_map(row))
-    log.info(
-        "  REL    total: {layer_relfiles_total}, needed_by_cutoff {layer_relfiles_needed_by_cutoff}, needed_by_branches: {layer_relfiles_needed_by_branches}, not_updated: {layer_relfiles_not_updated}, needed_as_tombstone {layer_relfiles_needed_as_tombstone}, removed: {layer_relfiles_removed}, dropped: {layer_relfiles_dropped}"
-        .format_map(row))
-    log.info(
-        "  NONREL total: {layer_nonrelfiles_total}, needed_by_cutoff {layer_nonrelfiles_needed_by_cutoff}, needed_by_branches: {layer_nonrelfiles_needed_by_branches}, not_updated: {layer_nonrelfiles_not_updated}, needed_as_tombstone {layer_nonrelfiles_needed_as_tombstone}, removed: {layer_nonrelfiles_removed}, dropped: {layer_nonrelfiles_dropped}"
-        .format_map(row))
 
 
 #

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -69,3 +69,13 @@ def lsn_from_hex(lsn_hex: str) -> int:
     """ Convert lsn from hex notation to int. """
     l, r = lsn_hex.split('/')
     return (int(l, 16) << 32) + int(r, 16)
+
+
+def print_gc_result(row):
+    log.info("GC duration {elapsed} ms".format_map(row))
+    log.info(
+        "  REL    total: {layer_relfiles_total}, needed_by_cutoff {layer_relfiles_needed_by_cutoff}, needed_by_branches: {layer_relfiles_needed_by_branches}, not_updated: {layer_relfiles_not_updated}, needed_as_tombstone {layer_relfiles_needed_as_tombstone}, removed: {layer_relfiles_removed}, dropped: {layer_relfiles_dropped}"
+        .format_map(row))
+    log.info(
+        "  NONREL total: {layer_nonrelfiles_total}, needed_by_cutoff {layer_nonrelfiles_needed_by_cutoff}, needed_by_branches: {layer_nonrelfiles_needed_by_branches}, not_updated: {layer_nonrelfiles_not_updated}, needed_as_tombstone {layer_nonrelfiles_needed_as_tombstone}, removed: {layer_nonrelfiles_removed}, dropped: {layer_nonrelfiles_dropped}"
+        .format_map(row))

--- a/zenith_utils/src/lsn.rs
+++ b/zenith_utils/src/lsn.rs
@@ -203,6 +203,12 @@ impl AtomicLsn {
     }
 }
 
+impl From<Lsn> for AtomicLsn {
+    fn from(lsn: Lsn) -> Self {
+        Self::new(lsn.0)
+    }
+}
+
 /// Pair of LSN's pointing to the end of the last valid record and previous one
 #[derive(Debug, Clone, Copy)]
 pub struct RecordLsn {


### PR DESCRIPTION
This introduces new timeline field latest_gc_horizon. It is updated
before each gc iteration. New check is added to branch_timelines to
prevent branch creation with start point less than latest_gc_horizon.

This is split from #863.

~~Should this count as a fix for #95? This error shouldn't appear with this patch.~~
Resolves #95 