### PR TITLE
Do not garbage collect child referenced data in parent branch

### DIFF
--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -203,7 +203,7 @@ impl Layer for DeltaLayer {
             let page_version_reader = inner
                 .book
                 .as_ref()
-                .unwrap()
+                .expect("should be loaded in load call above")
                 .chapter_reader(PAGE_VERSIONS_CHAPTER)?;
 
             // Scan the metadata BTreeMap backwards, starting from the given entry.
@@ -530,7 +530,7 @@ impl DeltaLayer {
 
         *inner = DeltaLayerInner {
             loaded: true,
-            book: None,
+            book: Some(book),
             page_version_metas,
             relsizes,
         };

--- a/test_runner/batch_others/test_branch_behind.py
+++ b/test_runner/batch_others/test_branch_behind.py
@@ -119,3 +119,13 @@ def test_branch_behind(zenith_simple_env: ZenithEnv):
     with pytest.raises(Exception, match="(we might've already garbage collected needed data)"):
         # this gced_lsn is pretty random, so if gc is disabled this woudln't fail
         env.zenith_cli(["branch", "test_branch_create_fail", f"test_branch_behind@{gced_lsn}"])
+
+    # check that after gc everything is still there
+    hundred_cur.execute('SELECT count(*) FROM foo')
+    assert hundred_cur.fetchone() == (100, )
+
+    more_cur.execute('SELECT count(*) FROM foo')
+    assert more_cur.fetchone() == (200100, )
+
+    main_cur.execute('SELECT count(*) FROM foo')
+    assert main_cur.fetchone() == (400100, )


### PR DESCRIPTION
This is the second half of #863. This prevents gc to collect data that still might be referenced in child branches. This doesn't include fix for bloat that might happen when there is a long living child branch. In that case gc in parent branch cannot delete data for child branch even if it is no longer needed. (As discussed I'll create separate issue for that)

This is based on #877 so see second commit for actual changes.

Resolves #865 