### PR TITLE
Fpi to page

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -54,6 +54,7 @@ use zenith_utils::seqwait::SeqWait;
 
 mod blob;
 mod delta_layer;
+mod ephemeral_file;
 mod filename;
 mod global_layer_map;
 mod image_layer;
@@ -73,6 +74,8 @@ use layer_map::LayerMap;
 use storage_layer::{
     Layer, PageReconstructData, PageReconstructResult, SegmentTag, RELISH_SEG_SIZE,
 };
+
+pub use crate::layered_repository::ephemeral_file::writeback as writeback_ephemeral_file;
 
 static ZERO_PAGE: Bytes = Bytes::from_static(&[0u8; 8192]);
 
@@ -1559,8 +1562,9 @@ impl LayeredTimeline {
     }
 
     fn lookup_cached_page(&self, seg: &SegmentTag, blknum: u32, lsn: Lsn) -> Option<(Lsn, Bytes)> {
+        let cache = page_cache::get();
         if let RelishTag::Relation(rel_tag) = &seg.rel {
-            let (lsn, read_guard) = page_cache::get().lookup_materialized_page(
+            let (lsn, read_guard) = cache.lookup_materialized_page(
                 self.tenantid,
                 self.timelineid,
                 *rel_tag,
@@ -1747,7 +1751,8 @@ impl LayeredTimeline {
                 )?;
 
                 if let RelishTag::Relation(rel_tag) = &rel {
-                    page_cache::get().memorize_materialized_page(
+                    let cache = page_cache::get();
+                    cache.memorize_materialized_page(
                         self.tenantid,
                         self.timelineid,
                         *rel_tag,

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -68,7 +68,7 @@ use delta_layer::DeltaLayer;
 use image_layer::ImageLayer;
 
 use global_layer_map::{LayerId, GLOBAL_LAYER_MAP};
-use inmemory_layer::InMemoryLayer;
+use inmemory_layer::OpenLayer;
 use layer_map::LayerMap;
 use storage_layer::{
     Layer, PageReconstructData, PageReconstructResult, SegmentTag, RELISH_SEG_SIZE,
@@ -1058,7 +1058,7 @@ impl LayeredTimeline {
     ///
     /// Get a handle to the latest layer for appending.
     ///
-    fn get_layer_for_write(&self, seg: SegmentTag, lsn: Lsn) -> Result<Arc<InMemoryLayer>> {
+    fn get_layer_for_write(&self, seg: SegmentTag, lsn: Lsn) -> Result<Arc<OpenLayer>> {
         let mut layers = self.layers.lock().unwrap();
 
         assert!(lsn.is_aligned());
@@ -1089,14 +1089,8 @@ impl LayeredTimeline {
                     lsn
                 );
 
-                layer = InMemoryLayer::create(
-                    self.conf,
-                    self.timelineid,
-                    self.tenantid,
-                    seg,
-                    lsn,
-                    lsn,
-                )?;
+                layer =
+                    OpenLayer::create(self.conf, self.timelineid, self.tenantid, seg, lsn, lsn)?;
             } else {
                 return Ok(open_layer);
             }
@@ -1132,7 +1126,7 @@ impl LayeredTimeline {
                 prev_layer.get_start_lsn(),
                 prev_layer.get_end_lsn()
             );
-            layer = InMemoryLayer::create_successor_layer(
+            layer = OpenLayer::create_successor_layer(
                 self.conf,
                 prev_layer,
                 self.timelineid,
@@ -1149,11 +1143,10 @@ impl LayeredTimeline {
                 lsn
             );
 
-            layer =
-                InMemoryLayer::create(self.conf, self.timelineid, self.tenantid, seg, lsn, lsn)?;
+            layer = OpenLayer::create(self.conf, self.timelineid, self.tenantid, seg, lsn, lsn)?;
         }
 
-        let layer_rc: Arc<InMemoryLayer> = Arc::new(layer);
+        let layer_rc: Arc<OpenLayer> = Arc::new(layer);
         layers.insert_open(Arc::clone(&layer_rc));
 
         Ok(layer_rc)
@@ -1830,7 +1823,7 @@ impl<'a> TimelineWriter for LayeredTimelineWriter<'a> {
 
         let seg = SegmentTag::from_blknum(rel, blknum);
         let layer = self.tl.get_layer_for_write(seg, lsn)?;
-        let delta_size = layer.put_wal_record(lsn, blknum, rec);
+        let delta_size = layer.put_wal_record(lsn, blknum, rec)?;
         self.tl
             .increase_current_logical_size(delta_size * BLCKSZ as u32);
         Ok(())
@@ -1849,7 +1842,7 @@ impl<'a> TimelineWriter for LayeredTimelineWriter<'a> {
         let seg = SegmentTag::from_blknum(rel, blknum);
 
         let layer = self.tl.get_layer_for_write(seg, lsn)?;
-        let delta_size = layer.put_page_image(blknum, lsn, img);
+        let delta_size = layer.put_page_image(blknum, lsn, img)?;
 
         self.tl
             .increase_current_logical_size(delta_size * BLCKSZ as u32);
@@ -1998,33 +1991,4 @@ fn rename_to_backup(path: PathBuf) -> anyhow::Result<()> {
         "couldn't find an unused backup number for {:?}",
         path
     ))
-}
-
-//----- Global layer management
-
-/// Check if too much memory is being used by open layers. If so, evict
-pub fn evict_layer_if_needed(conf: &PageServerConf) -> Result<()> {
-    // Keep evicting layers until we are below the memory threshold.
-    let mut global_layer_map = GLOBAL_LAYER_MAP.read().unwrap();
-    while let Some((layer_id, layer)) = global_layer_map.find_victim_if_needed(conf.open_mem_limit)
-    {
-        drop(global_layer_map);
-        let tenantid = layer.get_tenant_id();
-        let timelineid = layer.get_timeline_id();
-
-        let _entered =
-            info_span!("global evict", timeline = %timelineid, tenant = %tenantid).entered();
-        info!("evicting {}", layer.filename().display());
-        drop(layer);
-
-        let timeline = tenant_mgr::get_timeline_for_tenant(tenantid, timelineid)?;
-
-        timeline
-            .upgrade_to_layered_timeline()
-            .evict_layer(layer_id)?;
-
-        global_layer_map = GLOBAL_LAYER_MAP.read().unwrap();
-    }
-
-    Ok(())
 }

--- a/pageserver/src/layered_repository/blob.rs
+++ b/pageserver/src/layered_repository/blob.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::io::{Read, Write};
 use std::os::unix::prelude::FileExt;
 
 use anyhow::Result;
@@ -29,14 +29,14 @@ impl<W: Write> BlobWriter<W> {
         Self { writer, offset: 0 }
     }
 
-    pub fn write_blob(&mut self, blob: &[u8]) -> Result<BlobRange> {
-        self.writer.write_all(blob)?;
+    pub fn write_blob_from_reader(&mut self, r: &mut impl Read) -> Result<BlobRange> {
+        let len = std::io::copy(r, &mut self.writer)?;
 
         let range = BlobRange {
             offset: self.offset,
-            size: blob.len(),
+            size: len as usize,
         };
-        self.offset += blob.len() as u64;
+        self.offset += len as u64;
         Ok(range)
     }
 

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -39,6 +39,7 @@
 //!
 use crate::layered_repository::blob::BlobWriter;
 use crate::layered_repository::filename::{DeltaFileName, PathOrConf};
+use crate::layered_repository::page_versions::PageVersions;
 use crate::layered_repository::storage_layer::{
     Layer, PageReconstructData, PageReconstructResult, PageVersion, SegmentTag,
 };
@@ -377,14 +378,14 @@ impl DeltaLayer {
     }
 
     /// Create a new delta file, using the given page versions and relsizes.
-    /// The page versions are passed by an iterator; the iterator must return
-    /// page versions in blknum+lsn order.
+    /// The page versions are passed in a PageVersions struct. If 'cutoff' is
+    /// given, only page versions with LSN < cutoff are included.
     ///
-    /// This is used to write the in-memory layer to disk. The in-memory layer uses the same
-    /// data structure with two btreemaps as we do, so passing the btreemaps is currently
-    /// expedient.
+    /// This is used to write the in-memory layer to disk. The page_versions and
+    /// relsizes are thus passed in the same format as they are in the in-memory
+    /// layer, as that's expedient.
     #[allow(clippy::too_many_arguments)]
-    pub fn create<'a>(
+    pub fn create(
         conf: &'static PageServerConf,
         timelineid: ZTimelineId,
         tenantid: ZTenantId,
@@ -392,7 +393,8 @@ impl DeltaLayer {
         start_lsn: Lsn,
         end_lsn: Lsn,
         dropped: bool,
-        page_versions: impl Iterator<Item = (u32, Lsn, &'a PageVersion)>,
+        page_versions: &PageVersions,
+        cutoff: Option<Lsn>,
         relsizes: VecMap<Lsn, u32>,
     ) -> Result<DeltaLayer> {
         if seg.rel.is_blocky() {
@@ -431,9 +433,10 @@ impl DeltaLayer {
 
         let mut page_version_writer = BlobWriter::new(book, PAGE_VERSIONS_CHAPTER);
 
-        for (blknum, lsn, page_version) in page_versions {
-            let buf = PageVersion::ser(page_version)?;
-            let blob_range = page_version_writer.write_blob(&buf)?;
+        let page_versions_iter = page_versions.ordered_page_version_iter(cutoff);
+        for (blknum, lsn, pos) in page_versions_iter {
+            let blob_range =
+                page_version_writer.write_blob_from_reader(&mut page_versions.reader(pos)?)?;
 
             inner
                 .page_version_metas

--- a/pageserver/src/layered_repository/ephemeral_file.rs
+++ b/pageserver/src/layered_repository/ephemeral_file.rs
@@ -1,0 +1,295 @@
+use crate::page_cache;
+use crate::page_cache::PAGE_SZ;
+use crate::page_cache::{ReadBufResult, WriteBufResult};
+use crate::virtual_file::VirtualFile;
+use crate::PageServerConf;
+use lazy_static::lazy_static;
+use std::cmp::min;
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::{Error, ErrorKind, Seek, SeekFrom, Write};
+use std::ops::DerefMut;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use zenith_utils::zid::ZTenantId;
+use zenith_utils::zid::ZTimelineId;
+
+use std::os::unix::fs::FileExt;
+
+lazy_static! {
+    ///
+    /// This is the global cache of file descriptors (File objects).
+    ///
+    static ref EPHEMERAL_FILES: RwLock<EphemeralFiles> = RwLock::new(EphemeralFiles {
+        next_file_id: 1,
+        files: HashMap::new(),
+    });
+}
+
+pub struct EphemeralFiles {
+    next_file_id: u64,
+
+    files: HashMap<u64, Arc<VirtualFile>>,
+}
+
+pub struct EphemeralFile {
+    file_id: u64,
+    _tenantid: ZTenantId,
+    _timelineid: ZTimelineId,
+    file: Arc<VirtualFile>,
+
+    pos: u64,
+}
+
+impl EphemeralFile {
+    pub fn create(
+        conf: &PageServerConf,
+        tenantid: ZTenantId,
+        timelineid: ZTimelineId,
+    ) -> Result<EphemeralFile, std::io::Error> {
+        let mut l = EPHEMERAL_FILES.write().unwrap();
+        let file_id = l.next_file_id;
+        l.next_file_id += 1;
+
+        let filename = conf
+            .timeline_path(&timelineid, &tenantid)
+            .join(PathBuf::from(format!("ephemeral-{}", file_id)));
+
+        let file = VirtualFile::open_with_options(
+            &filename,
+            OpenOptions::new().read(true).write(true).create(true),
+        )?;
+        let file_rc = Arc::new(file);
+        l.files.insert(file_id, file_rc.clone());
+
+        Ok(EphemeralFile {
+            file_id,
+            _tenantid: tenantid,
+            _timelineid: timelineid,
+            file: file_rc,
+            pos: 0,
+        })
+    }
+
+    pub fn fill_buffer(&self, buf: &mut [u8], blkno: u32) -> Result<(), Error> {
+        let mut off = 0;
+        while off < PAGE_SZ {
+            let n = self
+                .file
+                .read_at(&mut buf[off..], blkno as u64 * PAGE_SZ as u64 + off as u64)?;
+
+            if n == 0 {
+                // Reached EOF. Fill the rest of the buffer with zeros.
+                const ZERO_BUF: [u8; PAGE_SZ] = [0u8; PAGE_SZ];
+
+                buf[off..].copy_from_slice(&ZERO_BUF[off..]);
+                break;
+            }
+
+            off += n as usize;
+        }
+        Ok(())
+    }
+}
+
+impl FileExt for EphemeralFile {
+    fn read_at(&self, dstbuf: &mut [u8], offset: u64) -> Result<usize, Error> {
+        // Look up the right page
+        let blkno = (offset / PAGE_SZ as u64) as u32;
+        let off = offset as usize % PAGE_SZ;
+        let len = min(PAGE_SZ - off, dstbuf.len());
+
+        let read_guard;
+        let mut write_guard;
+
+        let cache = page_cache::get();
+        let buf = match cache.read_ephemeral_buf(self.file_id, blkno) {
+            ReadBufResult::Found(guard) => {
+                read_guard = guard;
+                read_guard.as_ref()
+            }
+            ReadBufResult::NotFound(guard) => {
+                // Read the page from disk into the buffer
+                write_guard = guard;
+                self.fill_buffer(write_guard.deref_mut(), blkno)?;
+                write_guard.mark_valid();
+
+                // And then fall through to read the requested slice from the
+                // buffer.
+                write_guard.as_ref()
+            }
+        };
+
+        dstbuf[0..len].copy_from_slice(&buf[off..(off + len)]);
+        Ok(len)
+    }
+
+    fn write_at(&self, srcbuf: &[u8], offset: u64) -> Result<usize, Error> {
+        // Look up the right page
+        let blkno = (offset / PAGE_SZ as u64) as u32;
+        let off = offset as usize % PAGE_SZ;
+        let len = min(PAGE_SZ - off, srcbuf.len());
+
+        let mut write_guard;
+        let cache = page_cache::get();
+        let buf = match cache.write_ephemeral_buf(self.file_id, blkno) {
+            WriteBufResult::Found(guard) => {
+                write_guard = guard;
+                write_guard.deref_mut()
+            }
+            WriteBufResult::NotFound(guard) => {
+                // Read the page from disk into the buffer
+                // TODO: if we're overwriting the whole page, no need to read it in first
+                write_guard = guard;
+                self.fill_buffer(write_guard.deref_mut(), blkno)?;
+                write_guard.mark_valid();
+
+                // And then fall through to modify it.
+                write_guard.deref_mut()
+            }
+        };
+
+        buf[off..(off + len)].copy_from_slice(&srcbuf[0..len]);
+        write_guard.mark_dirty();
+        Ok(len)
+    }
+}
+
+impl Write for EphemeralFile {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        let n = self.write_at(buf, self.pos)?;
+        self.pos += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        todo!()
+    }
+}
+
+impl Seek for EphemeralFile {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Error> {
+        match pos {
+            SeekFrom::Start(offset) => {
+                self.pos = offset;
+            }
+            SeekFrom::End(_offset) => {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "SeekFrom::End not supported by EphemeralFile",
+                ));
+            }
+            SeekFrom::Current(offset) => {
+                let pos = self.pos as i128 + offset as i128;
+                if pos < 0 {
+                    return Err(Error::new(
+                        ErrorKind::InvalidInput,
+                        "offset would be negative",
+                    ));
+                }
+                if pos > u64::MAX as i128 {
+                    return Err(Error::new(ErrorKind::InvalidInput, "offset overflow"));
+                }
+                self.pos = pos as u64;
+            }
+        }
+        Ok(self.pos)
+    }
+}
+
+impl Drop for EphemeralFile {
+    fn drop(&mut self) {
+        // drop all pages from page cache
+        let cache = page_cache::get();
+        cache.drop_buffers_for_ephemeral(self.file_id);
+
+        // remove entry from the hash map
+        EPHEMERAL_FILES.write().unwrap().files.remove(&self.file_id);
+
+        // unlink file
+        // FIXME: print error
+        let _ = std::fs::remove_file(&self.file.path);
+    }
+}
+
+pub fn writeback(file_id: u64, blkno: u32, buf: &[u8]) -> Result<(), std::io::Error> {
+    if let Some(file) = EPHEMERAL_FILES.read().unwrap().files.get(&file_id) {
+        file.write_all_at(buf, blkno as u64 * PAGE_SZ as u64)?;
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            ErrorKind::Other,
+            "could not write back page, not found in ephemeral files hash",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::seq::SliceRandom;
+    use rand::thread_rng;
+    use std::fs;
+    use std::str::FromStr;
+
+    fn repo_harness(
+        test_name: &str,
+    ) -> Result<(&'static PageServerConf, ZTenantId, ZTimelineId), Error> {
+        let repo_dir = PageServerConf::test_repo_dir(test_name);
+        let _ = fs::remove_dir_all(&repo_dir);
+        let conf = PageServerConf::dummy_conf(repo_dir);
+        // Make a static copy of the config. This can never be free'd, but that's
+        // OK in a test.
+        let conf: &'static PageServerConf = Box::leak(Box::new(conf));
+
+        let tenantid = ZTenantId::from_str("11000000000000000000000000000000").unwrap();
+        let timelineid = ZTimelineId::from_str("22000000000000000000000000000000").unwrap();
+        fs::create_dir_all(conf.timeline_path(&timelineid, &tenantid))?;
+
+        Ok((conf, tenantid, timelineid))
+    }
+
+    // Helper function to slurp contents of a file, starting at the current position,
+    // into a string
+    fn read_string(efile: &EphemeralFile, offset: u64, len: usize) -> Result<String, Error> {
+        let mut buf = Vec::new();
+        buf.resize(len, 0u8);
+
+        efile.read_exact_at(&mut buf, offset)?;
+
+        Ok(String::from_utf8_lossy(&buf)
+            .trim_end_matches('\0')
+            .to_string())
+    }
+
+    #[test]
+    fn test_ephemeral_files() -> Result<(), Error> {
+        let (conf, tenantid, timelineid) = repo_harness("ephemeral_files")?;
+
+        let mut file_a = EphemeralFile::create(conf, tenantid, timelineid)?;
+
+        file_a.write_all(b"foo")?;
+        assert_eq!("foo", read_string(&file_a, 0, 20)?);
+
+        file_a.write_all(b"bar")?;
+        assert_eq!("foobar", read_string(&file_a, 0, 20)?);
+
+        // Open a lot of files, enough to cause some page evictions.
+        let mut efiles = Vec::new();
+        for fileno in 0..100 {
+            let mut efile = EphemeralFile::create(conf, tenantid, timelineid)?;
+            efile.write_all(format!("file {}", fileno).as_bytes())?;
+            assert_eq!(format!("file {}", fileno), read_string(&efile, 0, 10)?);
+            efiles.push((fileno, efile));
+        }
+
+        // Check that all the files can still be read from. Use them in random order for
+        // good measure.
+        efiles.as_mut_slice().shuffle(&mut thread_rng());
+        for (fileno, efile) in efiles.iter_mut() {
+            assert_eq!(format!("file {}", fileno), read_string(efile, 0, 10)?);
+        }
+
+        Ok(())
+    }
+}

--- a/pageserver/src/layered_repository/global_layer_map.rs
+++ b/pageserver/src/layered_repository/global_layer_map.rs
@@ -10,10 +10,10 @@
 //! The ID can be used to relocate the layer later, without having to hold locks.
 //!
 
-use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
 
-use super::inmemory_layer::InMemoryLayer;
+use super::inmemory_layer::OpenLayer;
 
 use lazy_static::lazy_static;
 
@@ -23,15 +23,6 @@ lazy_static! {
     pub static ref GLOBAL_LAYER_MAP: RwLock<OpenLayers> = RwLock::new(OpenLayers::default());
 }
 
-///
-/// How much memory is being used by all the open layers? This is used to trigger
-/// freezing and evicting an open layer to disk.
-///
-/// This is only a rough approximation, it leaves out a lot of things like malloc()
-/// overhead. But as long there is enough "slop" and it's not set too close to the RAM
-/// size on the system, it's good enough.
-pub static GLOBAL_OPEN_MEM_USAGE: AtomicUsize = AtomicUsize::new(0);
-
 // TODO these types can probably be smaller
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct LayerId {
@@ -40,7 +31,7 @@ pub struct LayerId {
 }
 
 enum SlotData {
-    Occupied(Arc<InMemoryLayer>),
+    Occupied(Arc<OpenLayer>),
     /// Vacant slots form a linked list, the value is the index
     /// of the next vacant slot in the list.
     Vacant(Option<usize>),
@@ -56,14 +47,13 @@ struct Slot {
 pub struct OpenLayers {
     slots: Vec<Slot>,
     num_occupied: usize,
-    next_victim: AtomicUsize,
 
     // Head of free-slot list.
     next_empty_slot_idx: Option<usize>,
 }
 
 impl OpenLayers {
-    pub fn insert(&mut self, layer: Arc<InMemoryLayer>) -> LayerId {
+    pub fn insert(&mut self, layer: Arc<OpenLayer>) -> LayerId {
         let slot_idx = match self.next_empty_slot_idx {
             Some(slot_idx) => slot_idx,
             None => {
@@ -101,7 +91,7 @@ impl OpenLayers {
         }
     }
 
-    pub fn get(&self, layer_id: &LayerId) -> Option<Arc<InMemoryLayer>> {
+    pub fn get(&self, layer_id: &LayerId) -> Option<Arc<OpenLayer>> {
         let slot = self.slots.get(layer_id.index)?; // TODO should out of bounds indexes just panic?
         if slot.tag != layer_id.tag {
             return None;
@@ -122,64 +112,6 @@ impl OpenLayers {
             Some(Arc::clone(layer))
         } else {
             None
-        }
-    }
-
-    /// Find a victim layer to evict, if the total memory usage of all open layers
-    /// is larger than 'limit'
-    pub fn find_victim_if_needed(&self, limit: usize) -> Option<(LayerId, Arc<InMemoryLayer>)> {
-        let mem_usage = GLOBAL_OPEN_MEM_USAGE.load(Ordering::Relaxed);
-
-        if mem_usage > limit {
-            self.find_victim()
-        } else {
-            None
-        }
-    }
-
-    pub fn find_victim(&self) -> Option<(LayerId, Arc<InMemoryLayer>)> {
-        if self.num_occupied == 0 {
-            return None;
-        }
-
-        // Run the clock algorithm.
-        //
-        // FIXME: It's theoretically possible that a constant stream of get() requests
-        // comes in faster than we advance the clock hand, so that this never finishes.
-        loop {
-            // FIXME: Because we interpret the clock hand variable modulo slots.len(), the
-            // hand effectively jumps to a more or less random place whenever the array is
-            // expanded. That's relatively harmless, it just leads to a non-optimal choice
-            // of victim. Also, in a server that runs for long enough, the array should reach
-            // a steady-state size and not grow anymore.
-            let next_victim = self.next_victim.fetch_add(1, Ordering::Relaxed) % self.slots.len();
-
-            let slot = &self.slots[next_victim];
-
-            if let SlotData::Occupied(data) = &slot.data {
-                fn update_fn(old_usage_count: u8) -> Option<u8> {
-                    if old_usage_count > 0 {
-                        Some(old_usage_count - 1)
-                    } else {
-                        None
-                    }
-                }
-
-                if slot
-                    .usage_count
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, update_fn)
-                    .is_err()
-                {
-                    // Found a slot with usage_count == 0. Return it.
-                    return Some((
-                        LayerId {
-                            index: next_victim,
-                            tag: slot.tag,
-                        },
-                        Arc::clone(data),
-                    ));
-                }
-            }
         }
     }
 

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -247,9 +247,13 @@ impl Layer for InMemoryLayer {
         assert!(lsn >= self.start_lsn);
 
         // Is the requested LSN after the segment was dropped?
-        if let Some(end_lsn) = inner.end_lsn {
-            if lsn >= end_lsn {
-                return Ok(false);
+        if inner.dropped {
+            if let Some(end_lsn) = inner.end_lsn {
+                if lsn >= end_lsn {
+                    return Ok(false);
+                }
+            } else {
+                panic!("dropped in-memory layer with no end LSN");
             }
         }
 

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -414,6 +414,13 @@ mod tests {
         forknum: 0,
     });
 
+    lazy_static! {
+        static ref DUMMY_TIMELINEID: ZTimelineId =
+            ZTimelineId::from_str("00000000000000000000000000000000").unwrap();
+        static ref DUMMY_TENANTID: ZTenantId =
+            ZTenantId::from_str("00000000000000000000000000000000").unwrap();
+    }
+
     /// Construct a dummy OpenLayer for testing
     fn dummy_open_layer(
         conf: &'static PageServerConf,
@@ -424,8 +431,8 @@ mod tests {
         Arc::new(
             OpenLayer::create(
                 conf,
-                ZTimelineId::from_str("00000000000000000000000000000000").unwrap(),
-                ZTenantId::from_str("00000000000000000000000000000000").unwrap(),
+                *DUMMY_TIMELINEID,
+                *DUMMY_TENANTID,
                 SegmentTag {
                     rel: TESTREL_A,
                     segno,
@@ -441,6 +448,7 @@ mod tests {
     fn test_open_layers() -> Result<()> {
         let conf = PageServerConf::dummy_conf(PageServerConf::test_repo_dir("dummy_open_layer"));
         let conf = Box::leak(Box::new(conf));
+        std::fs::create_dir_all(conf.timeline_path(&DUMMY_TIMELINEID, &DUMMY_TENANTID))?;
 
         let mut layers = LayerMap::default();
 

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -262,6 +262,7 @@ impl Drop for PageWriteGuard<'_> {
             let self_key = self.inner.key.as_ref().unwrap();
             PAGE_CACHE.get().unwrap().remove_mapping(self_key);
             self.inner.key = None;
+            self.inner.dirty = false;
         }
     }
 }
@@ -378,6 +379,7 @@ impl PageCache {
                         // remove mapping for old buffer
                         self.remove_mapping(key);
                         inner.key = None;
+                        inner.dirty = false;
                     }
                     _ => {}
                 }
@@ -479,6 +481,7 @@ impl PageCache {
             // Make the slot ready
             let slot = &self.slots[slot_idx];
             inner.key = Some(cache_key.clone());
+            inner.dirty = false;
             slot.usage_count.store(1, Ordering::Relaxed);
 
             return ReadBufResult::NotFound(PageWriteGuard {
@@ -539,6 +542,7 @@ impl PageCache {
             // Make the slot ready
             let slot = &self.slots[slot_idx];
             inner.key = Some(cache_key.clone());
+            inner.dirty = false;
             slot.usage_count.store(1, Ordering::Relaxed);
 
             return WriteBufResult::NotFound(PageWriteGuard {

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -46,11 +46,13 @@ use std::{
 };
 
 use once_cell::sync::OnceCell;
+use tracing::error;
 use zenith_utils::{
     lsn::Lsn,
     zid::{ZTenantId, ZTimelineId},
 };
 
+use crate::layered_repository::writeback_ephemeral_file;
 use crate::{relish::RelTag, PageServerConf};
 
 static PAGE_CACHE: OnceCell<PageCache> = OnceCell::new();
@@ -84,23 +86,25 @@ pub fn get() -> &'static PageCache {
     }
 }
 
-const PAGE_SZ: usize = postgres_ffi::pg_constants::BLCKSZ as usize;
+pub const PAGE_SZ: usize = postgres_ffi::pg_constants::BLCKSZ as usize;
 const MAX_USAGE_COUNT: u8 = 5;
 
 ///
 /// CacheKey uniquely identifies a "thing" to cache in the page cache.
 ///
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 enum CacheKey {
     MaterializedPage {
         hash_key: MaterializedPageHashKey,
         lsn: Lsn,
     },
-    // Currently, we only store materialized page versions in the page cache.
-    // To cache another kind of "thing", add enum variant here.
+    EphemeralPage {
+        file_id: u64,
+        blkno: u32,
+    },
 }
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 struct MaterializedPageHashKey {
     tenant_id: ZTenantId,
     timeline_id: ZTimelineId,
@@ -122,6 +126,7 @@ struct Slot {
 struct SlotInner {
     key: Option<CacheKey>,
     buf: &'static mut [u8; PAGE_SZ],
+    dirty: bool,
 }
 
 impl Slot {
@@ -169,6 +174,8 @@ pub struct PageCache {
     /// If you add support for caching different kinds of objects, each object kind
     /// can have a separate mapping map, next to this field.
     materialized_page_map: RwLock<HashMap<MaterializedPageHashKey, Vec<Version>>>,
+
+    ephemeral_page_map: RwLock<HashMap<(u64, u32), usize>>,
 
     /// The actual buffers with their metadata.
     slots: Box<[Slot]>,
@@ -232,6 +239,9 @@ impl PageWriteGuard<'_> {
         );
         self.valid = true;
     }
+    pub fn mark_dirty(&mut self) {
+        self.inner.dirty = true;
+    }
 }
 
 impl Drop for PageWriteGuard<'_> {
@@ -250,20 +260,20 @@ impl Drop for PageWriteGuard<'_> {
 }
 
 /// lock_for_read() return value
-enum ReadBufResult<'a> {
+pub enum ReadBufResult<'a> {
     Found(PageReadGuard<'a>),
     NotFound(PageWriteGuard<'a>),
 }
 
 /// lock_for_write() return value
-enum WriteBufResult<'a> {
+pub enum WriteBufResult<'a> {
     Found(PageWriteGuard<'a>),
     NotFound(PageWriteGuard<'a>),
 }
 
 impl PageCache {
     //
-    // Section 1: Public interface functions for looking up and memorizing materialized page
+    // Section 1.1: Public interface functions for looking up and memorizing materialized page
     // versions in the page cache
     //
 
@@ -291,8 +301,11 @@ impl PageCache {
         };
 
         if let Some(guard) = self.try_lock_for_read(&mut cache_key) {
-            let CacheKey::MaterializedPage { hash_key: _, lsn } = cache_key;
-            Some((lsn, guard))
+            if let CacheKey::MaterializedPage { hash_key: _, lsn } = cache_key {
+                Some((lsn, guard))
+            } else {
+                panic!("unexpected key type in slot");
+            }
         } else {
             None
         }
@@ -330,6 +343,37 @@ impl PageCache {
             WriteBufResult::NotFound(mut write_guard) => {
                 write_guard.copy_from_slice(img);
                 write_guard.mark_valid();
+            }
+        }
+    }
+
+    pub fn read_ephemeral_buf(&self, file_id: u64, blkno: u32) -> ReadBufResult {
+        let mut cache_key = CacheKey::EphemeralPage { file_id, blkno };
+
+        self.lock_for_read(&mut cache_key)
+    }
+
+    pub fn write_ephemeral_buf(&self, file_id: u64, blkno: u32) -> WriteBufResult {
+        let cache_key = CacheKey::EphemeralPage { file_id, blkno };
+
+        self.lock_for_write(&cache_key)
+    }
+
+    /// Immediately drop all buffers belonging to given file, without writeback
+    pub fn drop_buffers_for_ephemeral(&self, drop_file_id: u64) {
+        for slot_idx in 0..self.slots.len() {
+            let slot = &self.slots[slot_idx];
+
+            let mut inner = slot.inner.write().unwrap();
+            if let Some(key) = &inner.key {
+                match key {
+                    CacheKey::EphemeralPage { file_id, blkno: _ } if *file_id == drop_file_id => {
+                        // remove mapping for old buffer
+                        self.remove_mapping(key);
+                        inner.key = None;
+                    }
+                    _ => {}
+                }
             }
         }
     }
@@ -400,7 +444,6 @@ impl PageCache {
     /// }
     /// ```
     ///
-    #[allow(unused)] // this is currently unused
     fn lock_for_read(&self, cache_key: &mut CacheKey) -> ReadBufResult {
         loop {
             // First check if the key already exists in the cache.
@@ -527,6 +570,10 @@ impl PageCache {
                 *lsn = version.lsn;
                 Some(version.slot_idx)
             }
+            CacheKey::EphemeralPage { file_id, blkno } => {
+                let map = self.ephemeral_page_map.read().unwrap();
+                Some(*map.get(&(*file_id, *blkno))?)
+            }
         }
     }
 
@@ -545,6 +592,10 @@ impl PageCache {
                 } else {
                     None
                 }
+            }
+            CacheKey::EphemeralPage { file_id, blkno } => {
+                let map = self.ephemeral_page_map.read().unwrap();
+                Some(*map.get(&(*file_id, *blkno))?)
             }
         }
     }
@@ -569,8 +620,13 @@ impl PageCache {
                         }
                     }
                 } else {
-                    panic!()
+                    panic!("could not find old key in mapping")
                 }
+            }
+            CacheKey::EphemeralPage { file_id, blkno } => {
+                let mut map = self.ephemeral_page_map.write().unwrap();
+                map.remove(&(*file_id, *blkno))
+                    .expect("could not find old key in mapping");
             }
         }
     }
@@ -602,6 +658,16 @@ impl PageCache {
                     }
                 }
             }
+            CacheKey::EphemeralPage { file_id, blkno } => {
+                let mut map = self.ephemeral_page_map.write().unwrap();
+                match map.entry((*file_id, *blkno)) {
+                    Entry::Occupied(entry) => Some(*entry.get()),
+                    Entry::Vacant(entry) => {
+                        entry.insert(slot_idx);
+                        None
+                    }
+                }
+            }
         }
     }
 
@@ -624,17 +690,45 @@ impl PageCache {
                 let mut inner = slot.inner.write().unwrap();
 
                 if let Some(old_key) = &inner.key {
-                    // TODO: if we supported storing dirty pages, this is where
-                    // we'd need to write it disk
+                    if inner.dirty {
+                        if let Err(err) = Self::writeback(old_key, inner.buf) {
+                            // Writing the page to disk failed.
+                            //
+                            // FIXME: What to do here, when? We could propagate the error to the
+                            // caller, but victim buffer is generally unrelated to the original
+                            // call. It can even belong to a different tenant. Currently, we
+                            // report the error to the log and continue the clock sweep to find
+                            // a different victim. But if the problem persists, the page cache
+                            // could fill up with dirty pages that we cannot evict, and we will
+                            // loop retrying the writebacks indefinitely.
+                            error!("writeback of buffer {:?} failed: {}", old_key, err);
+                            continue;
+                        }
+                    }
 
                     // remove mapping for old buffer
                     self.remove_mapping(old_key);
+                    inner.dirty = false;
                     inner.key = None;
                 }
                 return (slot_idx, inner);
             }
 
             iters += 1;
+        }
+    }
+
+    fn writeback(cache_key: &CacheKey, buf: &[u8]) -> Result<(), std::io::Error> {
+        match cache_key {
+            CacheKey::MaterializedPage {
+                hash_key: _,
+                lsn: _,
+            } => {
+                panic!("unexpected dirty materialize page");
+            }
+            CacheKey::EphemeralPage { file_id, blkno } => {
+                writeback_ephemeral_file(*file_id, *blkno, buf)
+            }
         }
     }
 
@@ -652,7 +746,11 @@ impl PageCache {
                 let buf: &mut [u8; PAGE_SZ] = chunk.try_into().unwrap();
 
                 Slot {
-                    inner: RwLock::new(SlotInner { key: None, buf }),
+                    inner: RwLock::new(SlotInner {
+                        key: None,
+                        buf,
+                        dirty: false,
+                    }),
                     usage_count: AtomicU8::new(0),
                 }
             })
@@ -660,6 +758,7 @@ impl PageCache {
 
         Self {
             materialized_page_map: Default::default(),
+            ephemeral_page_map: Default::default(),
             slots,
             next_evict_slot: AtomicUsize::new(0),
         }

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -445,6 +445,8 @@ pub fn save_decoded_record(
                 image.resize(image.len() + blk.hole_length as usize, 0u8);
                 image.unsplit(tail);
             }
+            image[0..4].copy_from_slice(&((lsn.0 >> 32) as u32).to_le_bytes());
+            image[4..8].copy_from_slice(&(lsn.0 as u32).to_le_bytes());
             assert_eq!(image.len(), pg_constants::BLCKSZ as usize);
             timeline.put_page_image(tag, blk.blkno, lsn, image.freeze())?;
         } else {

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -425,7 +425,6 @@ pub fn save_decoded_record(
             relnode: blk.rnode_relnode,
             forknum: blk.forknum as u8,
         });
-	/*
         if blk.apply_image
             && blk.has_image
             && decoded.xl_rmid == pg_constants::RM_XLOG_ID
@@ -450,9 +449,7 @@ pub fn save_decoded_record(
             image[4..8].copy_from_slice(&(lsn.0 as u32).to_le_bytes());
             assert_eq!(image.len(), pg_constants::BLCKSZ as usize);
             timeline.put_page_image(tag, blk.blkno, lsn, image.freeze())?;
-        } else 
-	*/
-	{
+        } else {
             let rec = WALRecord {
                 will_init: blk.will_init || blk.apply_image,
                 rec: recdata.clone(),

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -11,7 +11,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Result};
-use bytes::{Buf, Bytes};
+use bytes::{Buf, Bytes, BytesMut};
 use tracing::*;
 
 use crate::relish::*;
@@ -416,7 +416,6 @@ pub fn save_decoded_record(
     if checkpoint.update_next_xid(decoded.xl_xid) {
         *checkpoint_modified = true;
     }
-
     // Iterate through all the blocks that the record modifies, and
     // "put" a separate copy of the record for each block.
     for blk in decoded.blocks.iter() {
@@ -426,14 +425,36 @@ pub fn save_decoded_record(
             relnode: blk.rnode_relnode,
             forknum: blk.forknum as u8,
         });
+        if blk.apply_image
+            && blk.has_image
+            && decoded.xl_rmid == pg_constants::RM_XLOG_ID
+            && (decoded.xl_info == pg_constants::XLOG_FPI
+                || decoded.xl_info == pg_constants::XLOG_FPI_FOR_HINT)
+        {
+            // Extract page image from FPI record
+            let img_len = blk.bimg_len as usize;
+            let img_offs = blk.bimg_offset as usize;
+            let mut image = BytesMut::with_capacity(pg_constants::BLCKSZ as usize);
+            image.extend_from_slice(&recdata[img_offs..img_offs + img_len]);
 
-        let rec = WALRecord {
-            will_init: blk.will_init || blk.apply_image,
-            rec: recdata.clone(),
-            main_data_offset: decoded.main_data_offset as u32,
-        };
+            // Compression of WAL is not yet supported
+            assert!((blk.bimg_info & pg_constants::BKPIMAGE_IS_COMPRESSED) == 0);
 
-        timeline.put_wal_record(lsn, tag, blk.blkno, rec)?;
+            if blk.hole_length != 0 {
+                let tail = image.split_off(blk.hole_offset as usize);
+                image.resize(image.len() + blk.hole_length as usize, 0u8);
+                image.unsplit(tail);
+            }
+            assert_eq!(image.len(), pg_constants::BLCKSZ as usize);
+            timeline.put_page_image(tag, blk.blkno, lsn, image.freeze())?;
+        } else {
+            let rec = WALRecord {
+                will_init: blk.will_init || blk.apply_image,
+                rec: recdata.clone(),
+                main_data_offset: decoded.main_data_offset as u32,
+            };
+            timeline.put_wal_record(lsn, tag, blk.blkno, rec)?;
+        }
     }
 
     let mut buf = decoded.record.clone();

--- a/pageserver/src/restore_local_repo.rs
+++ b/pageserver/src/restore_local_repo.rs
@@ -425,6 +425,7 @@ pub fn save_decoded_record(
             relnode: blk.rnode_relnode,
             forknum: blk.forknum as u8,
         });
+	/*
         if blk.apply_image
             && blk.has_image
             && decoded.xl_rmid == pg_constants::RM_XLOG_ID
@@ -449,7 +450,9 @@ pub fn save_decoded_record(
             image[4..8].copy_from_slice(&(lsn.0 as u32).to_le_bytes());
             assert_eq!(image.len(), pg_constants::BLCKSZ as usize);
             timeline.put_page_image(tag, blk.blkno, lsn, image.freeze())?;
-        } else {
+        } else 
+	*/
+	{
             let rec = WALRecord {
                 will_init: blk.will_init || blk.apply_image,
                 rec: recdata.clone(),

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -49,7 +49,7 @@ pub struct VirtualFile {
     /// if a new file is created, we only pass the create flag when it's initially
     /// opened, in the VirtualFile::create() function, and strip the flag before
     /// storing it here.
-    path: PathBuf,
+    pub path: PathBuf,
     open_options: OpenOptions,
 }
 

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -5,7 +5,6 @@
 //!
 //! We keep one WAL receiver active per timeline.
 
-use crate::layered_repository;
 use crate::relish::*;
 use crate::restore_local_repo;
 use crate::tenant_mgr;
@@ -176,7 +175,7 @@ fn thread_main(conf: &'static PageServerConf, timelineid: ZTimelineId, tenantid:
 }
 
 fn walreceiver_main(
-    conf: &PageServerConf,
+    _conf: &PageServerConf,
     timelineid: ZTimelineId,
     wal_producer_connstr: &str,
     tenantid: ZTenantId,
@@ -295,9 +294,6 @@ fn walreceiver_main(
                     info!("caught up at LSN {}", endlsn);
                     caught_up = true;
                 }
-
-                // Release memory if needed
-                layered_repository::evict_layer_if_needed(conf)?;
 
                 Some(endlsn)
             }


### PR DESCRIPTION
Store page image instead of WALRecord for XLOG_FPI records. It will allow to eliminate redundant wal redo and save space for records containing multiple blocks.
