### PR TITLE
callmemaybe refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,9 +540,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -565,15 +565,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -582,18 +582,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -601,23 +599,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -627,8 +624,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -1401,12 +1396,6 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2361,6 +2350,7 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "tracing",
  "walkdir",

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -32,6 +32,7 @@ signal-hook = "0.3.10"
 serde = { version = "1.0", features = ["derive"] }
 hex = "0.4.3"
 const_format = "0.2.21"
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 
 # FIXME: 'pageserver' is needed for ZTimelineId. Refactor
 pageserver = { path = "../pageserver" }

--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -112,7 +112,7 @@ fn main() -> Result<()> {
     }
 
     if let Some(recall) = arg_matches.value_of("recall") {
-        conf.recall_period = Some(humantime::parse_duration(recall)?);
+        conf.recall_period = humantime::parse_duration(recall)?;
     }
 
     start_safekeeper(conf)

--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -184,7 +184,7 @@ fn start_safekeeper(conf: SafeKeeperConf) -> Result<()> {
         );
     }
 
-    let (tx, rx) = mpsc::channel(100);
+    let (tx, rx) = mpsc::unbounded_channel();
     let conf_cloned = conf.clone();
     let wal_acceptor_thread = thread::Builder::new()
         .name("WAL acceptor thread".into())

--- a/walkeeper/src/callmemaybe.rs
+++ b/walkeeper/src/callmemaybe.rs
@@ -200,9 +200,6 @@ impl Drop for SubscriptionStateInner {
 }
 
 pub async fn main_loop(conf: SafeKeeperConf, mut rx: Receiver<CallmeEvent>) -> Result<()> {
-    let default_timeout = Duration::from_secs(5);
-    let recall_period = conf.recall_period.unwrap_or(default_timeout);
-
     let subscriptions: Mutex<HashMap<(ZTenantId, ZTimelineId), SubscriptionState>> =
         Mutex::new(HashMap::new());
 
@@ -259,7 +256,7 @@ pub async fn main_loop(conf: SafeKeeperConf, mut rx: Receiver<CallmeEvent>) -> R
                     },
                 }
             },
-            _ = tokio::time::sleep(recall_period) => { true },
+            _ = tokio::time::sleep(conf.recall_period) => { true },
         };
 
         if call_iteration {
@@ -268,7 +265,7 @@ pub async fn main_loop(conf: SafeKeeperConf, mut rx: Receiver<CallmeEvent>) -> R
             for (&(_tenantid, _timelineid), state) in subscriptions.iter() {
                 let listen_pg_addr = conf.listen_pg_addr.clone();
 
-                state.call(recall_period, listen_pg_addr);
+                state.call(conf.recall_period, listen_pg_addr);
             }
         }
     }

--- a/walkeeper/src/callmemaybe.rs
+++ b/walkeeper/src/callmemaybe.rs
@@ -1,0 +1,275 @@
+//!
+//!  Callmemaybe thread is responsible for periodically requesting
+//!  pageserver to initiate wal streaming.
+//!
+use crate::SafeKeeperConf;
+use anyhow::Result;
+use log::*;
+use std::collections::HashMap;
+use std::net::ToSocketAddrs;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use tokio::runtime;
+use tokio::sync::mpsc::Receiver;
+use tokio::task;
+use tokio_postgres::NoTls;
+use zenith_utils::zid::{ZTenantId, ZTimelineId};
+
+async fn request_callback(
+    pageserver_connstr: String,
+    listen_pg_addr_str: String,
+    timelineid: ZTimelineId,
+    tenantid: ZTenantId,
+) -> Result<()> {
+    debug!(
+        "callmemaybe request_callback Connecting to pageserver {}",
+        &pageserver_connstr
+    );
+    let (client, connection) = tokio_postgres::connect(&pageserver_connstr, NoTls).await?;
+
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            eprintln!("connection error: {}", e);
+        }
+    });
+
+    // Send callmemaybe request
+    let listen_pg_addr = listen_pg_addr_str
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
+
+    let callme = format!(
+        "callmemaybe {} {} host={} port={} options='-c ztimelineid={} ztenantid={}'",
+        tenantid,
+        timelineid,
+        &listen_pg_addr.ip().to_string(),
+        listen_pg_addr.port(),
+        timelineid,
+        tenantid
+    );
+
+    let _ = client.simple_query(&callme).await?;
+
+    Ok(())
+}
+
+pub fn thread_main(conf: SafeKeeperConf, rx: Receiver<CallmeEvent>) -> Result<()> {
+    let runtime = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(main_loop(conf, rx))
+}
+
+#[derive(Debug)]
+pub enum CallmeEvent {
+    // add new subscription to the list
+    Subscribe(ZTenantId, ZTimelineId, String),
+    // remove the subscription from the list
+    Unsubscribe(ZTenantId, ZTimelineId),
+    // don't serve this subscription, but keep it in the list
+    Pause(ZTenantId, ZTimelineId),
+    // resume this subscription, if it exists,
+    // but don't create a new one if it is gone
+    Resume(ZTenantId, ZTimelineId),
+}
+
+struct SubscriptionStateInner {
+    handle: Option<task::JoinHandle<()>>,
+    last_call_time: Instant,
+    paused: bool,
+}
+
+struct SubscriptionState {
+    tenantid: ZTenantId,
+    timelineid: ZTimelineId,
+    pageserver_connstr: String,
+    inner: Mutex<SubscriptionStateInner>,
+}
+
+impl SubscriptionState {
+    fn new(
+        tenantid: ZTenantId,
+        timelineid: ZTimelineId,
+        pageserver_connstr: String,
+    ) -> SubscriptionState {
+        let state_inner = SubscriptionStateInner {
+            handle: None,
+            last_call_time: Instant::now(),
+            paused: false,
+        };
+
+        SubscriptionState {
+            tenantid,
+            timelineid,
+            pageserver_connstr,
+            inner: Mutex::new(state_inner),
+        }
+    }
+
+    fn pause(&self) {
+        let mut state_inner = self.inner.lock().unwrap();
+        state_inner.paused = true;
+
+        if let Some(handle) = state_inner.handle.take() {
+            handle.abort();
+        }
+    }
+
+    fn resume(&self) {
+        let mut state_inner = self.inner.lock().unwrap();
+        state_inner.paused = false;
+    }
+
+    fn call(&self, recall_period: Duration, listen_pg_addr: String) {
+        let mut state_inner = self.inner.lock().unwrap();
+
+        // Ignore call request if this subscription is paused
+        if state_inner.paused {
+            debug!(
+                "ignore call request for paused subscription
+                tenantid: {}, timelineid: {}",
+                self.tenantid, self.timelineid
+            );
+            return;
+        }
+
+        // Check if it too early to recall
+        if state_inner.handle.is_some() && state_inner.last_call_time.elapsed() < recall_period {
+            debug!(
+                "too early to recall. state_inner.last_call_time.elapsed: {:?}, recall_period: {:?}
+                tenantid: {}, timelineid: {}",
+                state_inner.last_call_time, recall_period, self.tenantid, self.timelineid
+            );
+            return;
+        }
+
+        // If previous task didn't complete in recall_period, it must be hanging,
+        // so don't wait for it forever, just abort it and try again.
+        //
+        // Most likely, the task have already successfully completed
+        // and abort() won't have any effect.
+        if let Some(handle) = state_inner.handle.take() {
+            handle.abort();
+
+            let timelineid = self.timelineid;
+            let tenantid = self.tenantid;
+            tokio::spawn(async move {
+                if let Err(err) = handle.await {
+                    if err.is_cancelled() {
+                        warn!("callback task for timelineid={} tenantid={} was cancelled before spawning a new one",
+                            timelineid, tenantid);
+                    }
+                }
+            });
+        }
+
+        let timelineid = self.timelineid;
+        let tenantid = self.tenantid;
+        let pageserver_connstr = self.pageserver_connstr.clone();
+        state_inner.handle = Some(tokio::spawn(async move {
+            request_callback(pageserver_connstr, listen_pg_addr, timelineid, tenantid)
+                .await
+                .unwrap_or_else(|e| {
+                    error!(
+                        "callmemaybe. request_callback for timelineid={} tenantid={} failed: {}",
+                        timelineid, tenantid, e
+                    );
+                })
+        }));
+
+        // Update last_call_time
+        state_inner.last_call_time = Instant::now();
+        debug!(
+            "new call spawned. time {:?}
+            tenantid: {}, timelineid: {}",
+            state_inner.last_call_time, self.tenantid, self.timelineid
+        );
+    }
+}
+
+impl Drop for SubscriptionStateInner {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+pub async fn main_loop(conf: SafeKeeperConf, mut rx: Receiver<CallmeEvent>) -> Result<()> {
+    let default_timeout = Duration::from_secs(5);
+    let recall_period = conf.recall_period.unwrap_or(default_timeout);
+
+    let subscriptions: Mutex<HashMap<(ZTenantId, ZTimelineId), SubscriptionState>> =
+        Mutex::new(HashMap::new());
+
+    loop {
+        let call_iteration = tokio::select! {
+            request = rx.recv() => {
+                match request {
+                    Some(request) =>
+                    {
+                        match request
+                        {
+                            CallmeEvent::Subscribe(tenantid, timelineid, pageserver_connstr) =>
+                            {
+                                let mut subscriptions = subscriptions.lock().unwrap();
+                                subscriptions.insert((tenantid, timelineid), SubscriptionState::new(tenantid, timelineid, pageserver_connstr)) ;
+                                debug!("callmemaybe. thread_main. subscribe callback request for timelineid={} tenantid={}",
+                                timelineid, tenantid);
+                                true
+                            },
+                            CallmeEvent::Unsubscribe(tenantid, timelineid) => {
+                                let mut subscriptions = subscriptions.lock().unwrap();
+                                subscriptions.remove(&(tenantid, timelineid));
+                                debug!("callmemaybe. thread_main. unsubscribe callback request for timelineid={} tenantid={}",
+                                timelineid, tenantid);
+                                false
+                            },
+                            CallmeEvent::Pause(tenantid, timelineid) => {
+                                let subscriptions = subscriptions.lock().unwrap();
+                                if let Some(sub) = subscriptions.get(&(tenantid, timelineid))
+                                {
+                                    sub.pause();
+                                }
+                                debug!("callmemaybe. thread_main. pause callback request for timelineid={} tenantid={}",
+                                timelineid, tenantid);
+                                false
+                            },
+                            CallmeEvent::Resume(tenantid, timelineid) => {
+                                let mut call_iteration = false;
+                                let subscriptions = subscriptions.lock().unwrap();
+                                if let Some(sub) = subscriptions.get(&(tenantid, timelineid))
+                                {
+                                    sub.resume();
+                                    debug!("callmemaybe. thread_main. resume callback request for timelineid={} tenantid={}",
+                                    timelineid, tenantid);
+                                    call_iteration = true;
+                                }
+                                call_iteration
+                            },
+                        }
+                    },
+                    // all senders disconnected
+                    None =>  {
+                        return Ok(());
+                    },
+                }
+            },
+            _ = tokio::time::sleep(recall_period) => { true },
+        };
+
+        if call_iteration {
+            let subscriptions = subscriptions.lock().unwrap();
+
+            for (&(_tenantid, _timelineid), state) in subscriptions.iter() {
+                let listen_pg_addr = conf.listen_pg_addr.clone();
+
+                state.call(recall_period, listen_pg_addr);
+            }
+        }
+    }
+}

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use zenith_utils::zid::ZTimelineId;
 
+pub mod callmemaybe;
 pub mod http;
 pub mod json_ctrl;
 pub mod receive_wal;

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -18,12 +18,14 @@ pub mod wal_service;
 
 pub mod defaults {
     use const_format::formatcp;
+    use std::time::Duration;
 
     pub const DEFAULT_PG_LISTEN_PORT: u16 = 5454;
     pub const DEFAULT_PG_LISTEN_ADDR: &str = formatcp!("127.0.0.1:{DEFAULT_PG_LISTEN_PORT}");
 
     pub const DEFAULT_HTTP_LISTEN_PORT: u16 = 7676;
     pub const DEFAULT_HTTP_LISTEN_ADDR: &str = formatcp!("127.0.0.1:{DEFAULT_HTTP_LISTEN_PORT}");
+    pub const DEFAULT_RECALL_PERIOD: Duration = Duration::from_secs(1);
 }
 
 #[derive(Debug, Clone)]
@@ -41,7 +43,7 @@ pub struct SafeKeeperConf {
     pub listen_pg_addr: String,
     pub listen_http_addr: String,
     pub ttl: Option<Duration>,
-    pub recall_period: Option<Duration>,
+    pub recall_period: Duration,
 }
 
 impl SafeKeeperConf {
@@ -62,7 +64,7 @@ impl Default for SafeKeeperConf {
             listen_pg_addr: defaults::DEFAULT_PG_LISTEN_ADDR.to_string(),
             listen_http_addr: defaults::DEFAULT_PG_LISTEN_ADDR.to_string(),
             ttl: None,
-            recall_period: None,
+            recall_period: defaults::DEFAULT_RECALL_PERIOD,
         }
     }
 }

--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -19,7 +19,7 @@ use zenith_utils::zid::{ZTenantId, ZTimelineId};
 
 use crate::callmemaybe::CallmeEvent;
 use crate::timeline::CreateControlFile;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 
 /// Handler for streaming WAL from acceptor
 pub struct SendWalHandler {
@@ -30,7 +30,7 @@ pub struct SendWalHandler {
     pub timelineid: Option<ZTimelineId>,
     pub timeline: Option<Arc<Timeline>>,
     //sender to communicate with callmemaybe thread
-    pub tx: Sender<CallmeEvent>,
+    pub tx: UnboundedSender<CallmeEvent>,
 }
 
 impl postgres_backend::Handler for SendWalHandler {
@@ -103,7 +103,7 @@ impl postgres_backend::Handler for SendWalHandler {
 }
 
 impl SendWalHandler {
-    pub fn new(conf: SafeKeeperConf, tx: Sender<CallmeEvent>) -> Self {
+    pub fn new(conf: SafeKeeperConf, tx: UnboundedSender<CallmeEvent>) -> Self {
         SendWalHandler {
             conf,
             appname: None,

--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -17,7 +17,9 @@ use zenith_utils::postgres_backend::PostgresBackend;
 use zenith_utils::pq_proto::{BeMessage, FeStartupMessage, RowDescriptor, INT4_OID, TEXT_OID};
 use zenith_utils::zid::{ZTenantId, ZTimelineId};
 
+use crate::callmemaybe::CallmeEvent;
 use crate::timeline::CreateControlFile;
+use tokio::sync::mpsc::Sender;
 
 /// Handler for streaming WAL from acceptor
 pub struct SendWalHandler {
@@ -27,6 +29,8 @@ pub struct SendWalHandler {
     pub tenantid: Option<ZTenantId>,
     pub timelineid: Option<ZTimelineId>,
     pub timeline: Option<Arc<Timeline>>,
+    //sender to communicate with callmemaybe thread
+    pub tx: Sender<CallmeEvent>,
 }
 
 impl postgres_backend::Handler for SendWalHandler {
@@ -99,13 +103,14 @@ impl postgres_backend::Handler for SendWalHandler {
 }
 
 impl SendWalHandler {
-    pub fn new(conf: SafeKeeperConf) -> Self {
+    pub fn new(conf: SafeKeeperConf, tx: Sender<CallmeEvent>) -> Self {
         SendWalHandler {
             conf,
             appname: None,
             tenantid: None,
             timelineid: None,
             timeline: None,
+            tx,
         }
     }
 

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -11,14 +11,14 @@ use tracing::*;
 use crate::callmemaybe::CallmeEvent;
 use crate::send_wal::SendWalHandler;
 use crate::SafeKeeperConf;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::UnboundedSender;
 use zenith_utils::postgres_backend::{AuthType, PostgresBackend};
 
 /// Accept incoming TCP connections and spawn them into a background thread.
 pub fn thread_main(
     conf: SafeKeeperConf,
     listener: TcpListener,
-    tx: Sender<CallmeEvent>,
+    tx: UnboundedSender<CallmeEvent>,
 ) -> Result<()> {
     loop {
         match listener.accept() {
@@ -51,7 +51,11 @@ fn get_tid() -> u64 {
 
 /// This is run by `thread_main` above, inside a background thread.
 ///
-fn handle_socket(socket: TcpStream, conf: SafeKeeperConf, tx: Sender<CallmeEvent>) -> Result<()> {
+fn handle_socket(
+    socket: TcpStream,
+    conf: SafeKeeperConf,
+    tx: UnboundedSender<CallmeEvent>,
+) -> Result<()> {
     let _enter = info_span!("", tid = ?get_tid()).entered();
 
     socket.set_nodelay(true)?;

--- a/walkeeper/src/wal_service.rs
+++ b/walkeeper/src/wal_service.rs
@@ -8,22 +8,29 @@ use std::net::{TcpListener, TcpStream};
 use std::thread;
 use tracing::*;
 
+use crate::callmemaybe::CallmeEvent;
 use crate::send_wal::SendWalHandler;
 use crate::SafeKeeperConf;
+use tokio::sync::mpsc::Sender;
 use zenith_utils::postgres_backend::{AuthType, PostgresBackend};
 
 /// Accept incoming TCP connections and spawn them into a background thread.
-pub fn thread_main(conf: SafeKeeperConf, listener: TcpListener) -> Result<()> {
+pub fn thread_main(
+    conf: SafeKeeperConf,
+    listener: TcpListener,
+    tx: Sender<CallmeEvent>,
+) -> Result<()> {
     loop {
         match listener.accept() {
             Ok((socket, peer_addr)) => {
                 debug!("accepted connection from {}", peer_addr);
                 let conf = conf.clone();
 
+                let tx_clone = tx.clone();
                 let _ = thread::Builder::new()
                     .name("WAL service thread".into())
                     .spawn(move || {
-                        if let Err(err) = handle_socket(socket, conf) {
+                        if let Err(err) = handle_socket(socket, conf, tx_clone) {
                             error!("connection handler exited: {}", err);
                         }
                     })
@@ -44,12 +51,12 @@ fn get_tid() -> u64 {
 
 /// This is run by `thread_main` above, inside a background thread.
 ///
-fn handle_socket(socket: TcpStream, conf: SafeKeeperConf) -> Result<()> {
+fn handle_socket(socket: TcpStream, conf: SafeKeeperConf, tx: Sender<CallmeEvent>) -> Result<()> {
     let _enter = info_span!("", tid = ?get_tid()).entered();
 
     socket.set_nodelay(true)?;
 
-    let mut conn_handler = SendWalHandler::new(conf);
+    let mut conn_handler = SendWalHandler::new(conf, tx);
     let pgbackend = PostgresBackend::new(socket, AuthType::Trust, None, false)?;
     // libpq replication protocol between safekeeper and replicas/pagers
     pgbackend.run(&mut conn_handler)?;


### PR DESCRIPTION
- Don't spawn a separate thread for each connection.
Instead use one thread per safekeeper, that iterates over all connections and sends callback requests for them.

-Use tokio postgres to connect to the pageserver, to avoid spawning a new thread for each connection.
