### PR TITLE
Relax back check in test_readonly_node

### DIFF
--- a/test_runner/batch_others/test_readonly_node.py
+++ b/test_runner/batch_others/test_readonly_node.py
@@ -86,6 +86,10 @@ def test_readonly_node(zenith_simple_env: ZenithEnv):
     assert cur.fetchone() == (1, )
 
     # Create node at pre-initdb lsn
-    with pytest.raises(Exception, match='extracting base backup failed'):
+    # This can fail in two different ways:
+    # 1. With "extracting base backup failed"
+    # 2. With "directory <repo dir> is not a database cluster directory"
+    # TODO have explicit check so the failure has constant reason
+    with pytest.raises(Exception):
         # compute node startup with invalid LSN should fail
         env.zenith_cli(["pg", "start", "test_branch_preinitdb", "test_readonly_node@0/42"])


### PR DESCRIPTION
It was changed in https://github.com/zenithdb/zenith/pull/877 and this
lead to unstable test behaviour