### PR TITLE
Extend branch creation and basebackup checks

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -10,7 +10,7 @@
 //! This module is responsible for creation of such tarball
 //! from data stored in object storage.
 //!
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bytes::{BufMut, BytesMut};
 use log::*;
 use std::fmt::Write as FmtWrite;
@@ -242,10 +242,12 @@ impl<'a> Basebackup<'a> {
     fn add_pgcontrol_file(&mut self) -> anyhow::Result<()> {
         let checkpoint_bytes = self
             .timeline
-            .get_page_at_lsn(RelishTag::Checkpoint, 0, self.lsn)?;
-        let pg_control_bytes =
-            self.timeline
-                .get_page_at_lsn(RelishTag::ControlFile, 0, self.lsn)?;
+            .get_page_at_lsn(RelishTag::Checkpoint, 0, self.lsn)
+            .context("failed to get checkpoint bytes")?;
+        let pg_control_bytes = self
+            .timeline
+            .get_page_at_lsn(RelishTag::ControlFile, 0, self.lsn)
+            .context("failed get control bytes")?;
         let mut pg_control = ControlFileData::decode(&pg_control_bytes)?;
         let mut checkpoint = CheckPoint::decode(&checkpoint_bytes)?;
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -132,13 +132,7 @@ async fn branch_detail_handler(request: Request<Body>) -> Result<Response<Body>,
     let response_data = tokio::task::spawn_blocking(move || {
         let _enter = info_span!("branch_detail", tenant = %tenantid, branch=%branch_name).entered();
         let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
-        BranchInfo::from_path(
-            path,
-            conf,
-            &tenantid,
-            &repo,
-            include_non_incremental_logical_size,
-        )
+        BranchInfo::from_path(path, &repo, include_non_incremental_logical_size)
     })
     .await
     .map_err(ApiError::from_err)??;

--- a/pageserver/src/layered_repository/filename.rs
+++ b/pageserver/src/layered_repository/filename.rs
@@ -292,7 +292,7 @@ pub fn list_files(
             deltafiles.push(deltafilename);
         } else if let Some(imgfilename) = ImageFileName::parse_str(fname) {
             imgfiles.push(imgfilename);
-        } else if fname == METADATA_FILE_NAME || fname == "ancestor" || fname.ends_with(".old") {
+        } else if fname == METADATA_FILE_NAME || fname.ends_with(".old") {
             // ignore these
         } else {
             warn!("unrecognized filename in timeline dir: {}", fname);

--- a/pageserver/src/layered_repository/metadata.rs
+++ b/pageserver/src/layered_repository/metadata.rs
@@ -42,7 +42,8 @@ pub struct TimelineMetadata {
     prev_record_lsn: Option<Lsn>,
     ancestor_timeline: Option<ZTimelineId>,
     ancestor_lsn: Lsn,
-    latest_gc_cutoff: Lsn,
+    latest_gc_cutoff_lsn: Lsn,
+    initdb_lsn: Lsn,
 }
 
 /// Points to a place in pageserver's local directory,
@@ -62,14 +63,16 @@ impl TimelineMetadata {
         prev_record_lsn: Option<Lsn>,
         ancestor_timeline: Option<ZTimelineId>,
         ancestor_lsn: Lsn,
-        latest_gc_cutoff: Lsn,
+        latest_gc_cutoff_lsn: Lsn,
+        initdb_lsn: Lsn,
     ) -> Self {
         Self {
             disk_consistent_lsn,
             prev_record_lsn,
             ancestor_timeline,
             ancestor_lsn,
-            latest_gc_cutoff,
+            latest_gc_cutoff_lsn,
+            initdb_lsn,
         }
     }
 
@@ -125,8 +128,12 @@ impl TimelineMetadata {
         self.ancestor_lsn
     }
 
-    pub fn latest_gc_cutoff(&self) -> Lsn {
-        self.latest_gc_cutoff
+    pub fn latest_gc_cutoff_lsn(&self) -> Lsn {
+        self.latest_gc_cutoff_lsn
+    }
+
+    pub fn initdb_lsn(&self) -> Lsn {
+        self.initdb_lsn
     }
 }
 
@@ -146,7 +153,8 @@ mod serialize {
         prev_record_lsn: &'a Option<Lsn>,
         ancestor_timeline: &'a Option<ZTimelineId>,
         ancestor_lsn: &'a Lsn,
-        latest_gc_cutoff: &'a Lsn,
+        latest_gc_cutoff_lsn: &'a Lsn,
+        initdb_lsn: &'a Lsn,
     }
 
     impl<'a> From<&'a TimelineMetadata> for SeTimelineMetadata<'a> {
@@ -156,7 +164,8 @@ mod serialize {
                 prev_record_lsn: &other.prev_record_lsn,
                 ancestor_timeline: &other.ancestor_timeline,
                 ancestor_lsn: &other.ancestor_lsn,
-                latest_gc_cutoff: &other.latest_gc_cutoff,
+                latest_gc_cutoff_lsn: &other.latest_gc_cutoff_lsn,
+                initdb_lsn: &other.initdb_lsn,
             }
         }
     }
@@ -167,7 +176,8 @@ mod serialize {
         prev_record_lsn: Option<Lsn>,
         ancestor_timeline: Option<ZTimelineId>,
         ancestor_lsn: Lsn,
-        latest_gc_cutoff: Lsn,
+        latest_gc_cutoff_lsn: Lsn,
+        initdb_lsn: Lsn,
     }
 
     impl From<DeTimelineMetadata> for TimelineMetadata {
@@ -177,7 +187,8 @@ mod serialize {
                 prev_record_lsn: other.prev_record_lsn,
                 ancestor_timeline: other.ancestor_timeline,
                 ancestor_lsn: other.ancestor_lsn,
-                latest_gc_cutoff: other.latest_gc_cutoff,
+                latest_gc_cutoff_lsn: other.latest_gc_cutoff_lsn,
+                initdb_lsn: other.initdb_lsn,
             }
         }
     }
@@ -196,7 +207,8 @@ mod tests {
             prev_record_lsn: Some(Lsn(0x100)),
             ancestor_timeline: Some(TIMELINE_ID),
             ancestor_lsn: Lsn(0),
-            latest_gc_cutoff: Lsn(0),
+            latest_gc_cutoff_lsn: Lsn(0),
+            initdb_lsn: Lsn(0),
         };
 
         let metadata_bytes = original_metadata

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -134,10 +134,6 @@ impl PageServerConf {
         self.timelines_path(tenantid).join(timelineid.to_string())
     }
 
-    fn ancestor_path(&self, timelineid: &ZTimelineId, tenantid: &ZTenantId) -> PathBuf {
-        self.timeline_path(timelineid, tenantid).join("ancestor")
-    }
-
     //
     // Postgres distribution paths
     //

--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -1623,6 +1623,6 @@ mod tests {
     }
 
     fn dummy_metadata(disk_consistent_lsn: Lsn) -> TimelineMetadata {
-        TimelineMetadata::new(disk_consistent_lsn, None, None, Lsn(0), Lsn(0))
+        TimelineMetadata::new(disk_consistent_lsn, None, None, Lsn(0), Lsn(0), Lsn(0))
     }
 }

--- a/test_runner/batch_others/test_readonly_node.py
+++ b/test_runner/batch_others/test_readonly_node.py
@@ -86,6 +86,6 @@ def test_readonly_node(zenith_simple_env: ZenithEnv):
     assert cur.fetchone() == (1, )
 
     # Create node at pre-initdb lsn
-    with pytest.raises(Exception, match='extracting base backup failed'):
+    with pytest.raises(Exception, match="invalid basebackup lsn"):
         # compute node startup with invalid LSN should fail
-        env.zenith_cli(["pg", "start", "test_branch_preinitdb", "test_readonly_node@0/42"])
+        env.zenith_cli(["pg", "start", "test_readonly_node_preinitdb", "test_readonly_node@0/42"])

--- a/zenith/src/main.rs
+++ b/zenith/src/main.rs
@@ -233,7 +233,7 @@ fn main() -> Result<()> {
         }
     };
     if let Err(e) = subcmd_result {
-        eprintln!("command failed: {}", e);
+        eprintln!("command failed: {:#}", e);
         exit(1);
     }
 


### PR DESCRIPTION
Out of scope LSNs include pre initdb LSNs, and LSNs prior to
latest_gc_cutoff.
    
To get there there was also two cleanups:
* Fix error handling in Execute message handler. This fixes behaviour
  when basebackup retured an error. Previously pageserver thread just
  died.
* Remove "ancestor" file which previously contained ancestor id and
  branch lsn. Currently the same data can be obtained from metadata file.
  And just the way we handled ancestor file in the code introduced the
  case when branching fails timeline directory is created but there is no data in it
  except ancestor file. And this confused gc because it scans
  directories. So it is better to just remove ancestor file and clean up
  this timeline directory creation so it happens after all validity
  checks have passed

This originates from this discussion: https://github.com/zenithdb/zenith/pull/927#discussion_r752238314

Also I'm concerned that using latest_gc_cutoff_lsn in get_page_at_lsn. Some data which is actually older than latest_gc_cutoff_lsn is perfectly valid to access using get_page_at_lsn. So maybe it is desirable to change the error condition so it only appears if there is no page in place, but if request asks for older page and it is in place just return it 
