### PR TITLE
Forward pageserver connection string from compute to safekeeper

### DIFF
--- a/test_runner/batch_others/test_wal_acceptor.py
+++ b/test_runner/batch_others/test_wal_acceptor.py
@@ -340,6 +340,7 @@ class ProposerPostgres:
                 "synchronous_standby_names = 'walproposer'\n",
                 f"zenith.zenith_timeline = '{self.timeline_id}'\n",
                 f"zenith.zenith_tenant = '{self.tenant_id}'\n",
+                f"zenith.page_server_connstring = ''\n",
                 f"wal_acceptors = '{wal_acceptors}'\n",
             ])
 

--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -44,6 +44,9 @@ fn main() -> Result<()> {
                 .takes_value(true)
                 .help(formatcp!("http endpoint address for metrics on ip:port (default: {DEFAULT_HTTP_LISTEN_ADDR})")),
         )
+        // FIXME this argument is no longer needed since pageserver address is forwarded from compute.
+        // However because this argument is in use by console's e2e tests lets keep it for now and remove separately.
+        // So currently it is a noop.
         .arg(
             Arg::with_name("pageserver")
                 .short("p")
@@ -99,10 +102,6 @@ fn main() -> Result<()> {
 
     if let Some(addr) = arg_matches.value_of("listen-http") {
         conf.listen_http_addr = addr.to_owned();
-    }
-
-    if let Some(addr) = arg_matches.value_of("pageserver") {
-        conf.pageserver_addr = Some(addr.to_owned());
     }
 
     if let Some(ttl) = arg_matches.value_of("ttl") {

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -2,7 +2,6 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use std::env;
 use zenith_utils::zid::ZTimelineId;
 
 pub mod http;
@@ -39,9 +38,6 @@ pub struct SafeKeeperConf {
     pub no_sync: bool,
     pub listen_pg_addr: String,
     pub listen_http_addr: String,
-    pub pageserver_addr: Option<String>,
-    // TODO (create issue) this is temporary, until protocol between PG<->SK<->PS rework
-    pub pageserver_auth_token: Option<String>,
     pub ttl: Option<Duration>,
     pub recall_period: Option<Duration>,
 }
@@ -61,12 +57,10 @@ impl Default for SafeKeeperConf {
             workdir: PathBuf::from("./"),
             daemonize: false,
             no_sync: false,
-            pageserver_addr: None,
             listen_pg_addr: defaults::DEFAULT_PG_LISTEN_ADDR.to_string(),
             listen_http_addr: defaults::DEFAULT_PG_LISTEN_ADDR.to_string(),
             ttl: None,
             recall_period: None,
-            pageserver_auth_token: env::var("PAGESERVER_AUTH_TOKEN").ok(),
         }
     }
 }


### PR DESCRIPTION
This is needed for implementation of tenant rebalancing. With this
change safekeeper becomes aware of which pageserver is supposed to be
used for replication from this particular compute.

Also this removes possibility of launching compute without pageserver. FYI @petuhovskiy This might be a problem for your safekeeper benchmarks, let me know if I should keep this option

Corresponding postgres PR: https://github.com/zenithdb/postgres/pull/104

Resolves https://github.com/zenithdb/zenith/issues/892