### PR TITLE
use full commit sha for version info

### DIFF
--- a/zenith_utils/src/lib.rs
+++ b/zenith_utils/src/lib.rs
@@ -72,5 +72,6 @@ pub mod nonblock;
 use git_version::git_version;
 pub const GIT_VERSION: &str = git_version!(
     prefix = "git:",
-    fallback = concat!("git-env:", env!("GIT_VERSION"))
+    fallback = concat!("git-env:", env!("GIT_VERSION")),
+    args = ["--abbrev=40", "--always", "--dirty=-modified"] // always use full sha
 );


### PR DESCRIPTION
for builds in docker this is not needed, since environment variable
with commit sha already contains full version

![image](https://user-images.githubusercontent.com/19991702/144234799-d56be19d-b61c-4ea7-838a-52992afd0a40.png)
