### PR TITLE
Bump safekeeper control file version and allow reading the previous one.

### DIFF
--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -13,6 +13,7 @@ pub mod s3_offload;
 pub mod safekeeper;
 pub mod send_wal;
 pub mod timeline;
+pub mod upgrade;
 pub mod wal_service;
 
 pub mod defaults {

--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -30,7 +30,7 @@ use zenith_utils::pq_proto::SystemId;
 use zenith_utils::zid::{ZTenantId, ZTimelineId};
 
 pub const SK_MAGIC: u32 = 0xcafeceefu32;
-pub const SK_FORMAT_VERSION: u32 = 1;
+pub const SK_FORMAT_VERSION: u32 = 2;
 const SK_PROTOCOL_VERSION: u32 = 1;
 const UNKNOWN_SERVER_VERSION: u32 = 0;
 
@@ -102,7 +102,7 @@ impl fmt::Debug for TermHistory {
 }
 
 /// Unique id of proposer. Not needed for correctness, used for monitoring.
-type PgUuid = [u8; 16];
+pub type PgUuid = [u8; 16];
 
 /// Persistent consensus state of the acceptor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -140,12 +140,9 @@ pub struct ServerInfo {
 }
 
 /// Persistent information stored on safekeeper node
+/// On disk data is prefixed by magic and format version and followed by checksum.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafeKeeperState {
-    /// magic for verifying content the control file
-    pub magic: u32,
-    /// safekeeper format version
-    pub format_version: u32,
     /// persistent acceptor state
     pub acceptor_state: AcceptorState,
     /// information about server
@@ -166,8 +163,6 @@ pub struct SafeKeeperState {
 impl SafeKeeperState {
     pub fn new() -> SafeKeeperState {
         SafeKeeperState {
-            magic: SK_MAGIC,
-            format_version: SK_FORMAT_VERSION,
             acceptor_state: AcceptorState {
                 term: 0,
                 term_history: TermHistory::empty(),

--- a/walkeeper/src/upgrade.rs
+++ b/walkeeper/src/upgrade.rs
@@ -1,0 +1,60 @@
+//! Code to deal with safekeeper control file upgrades
+use crate::safekeeper::{
+    AcceptorState, PgUuid, SafeKeeperState, ServerInfo, Term, TermHistory, TermSwitchEntry,
+};
+use anyhow::{bail, Result};
+use log::*;
+use serde::{Deserialize, Serialize};
+use zenith_utils::{bin_ser::LeSer, lsn::Lsn};
+
+/// Persistent consensus state of the acceptor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AcceptorStateV1 {
+    /// acceptor's last term it voted for (advanced in 1 phase)
+    term: Term,
+    /// acceptor's epoch (advanced, i.e. bumped to 'term' when VCL is reached).
+    epoch: Term,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SafeKeeperStateV1 {
+    /// persistent acceptor state
+    acceptor_state: AcceptorStateV1,
+    /// information about server
+    server: ServerInfo,
+    /// Unique id of the last *elected* proposer we dealed with. Not needed
+    /// for correctness, exists for monitoring purposes.
+    proposer_uuid: PgUuid,
+    /// part of WAL acknowledged by quorum and available locally
+    commit_lsn: Lsn,
+    /// minimal LSN which may be needed for recovery of some safekeeper (end_lsn
+    /// of last record streamed to everyone)
+    truncate_lsn: Lsn,
+    // Safekeeper starts receiving WAL from this LSN, zeros before it ought to
+    // be skipped during decoding.
+    wal_start_lsn: Lsn,
+}
+
+pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState> {
+    // migrate to storing full term history
+    if version == 1 {
+        info!("reading safekeeper control file version {}", version);
+        let oldstate = SafeKeeperStateV1::des(&buf[..buf.len()])?;
+        let ac = AcceptorState {
+            term: oldstate.acceptor_state.term,
+            term_history: TermHistory(vec![TermSwitchEntry {
+                term: oldstate.acceptor_state.epoch,
+                lsn: Lsn(0),
+            }]),
+        };
+        return Ok(SafeKeeperState {
+            acceptor_state: ac,
+            server: oldstate.server.clone(),
+            proposer_uuid: oldstate.proposer_uuid,
+            commit_lsn: oldstate.commit_lsn,
+            truncate_lsn: oldstate.truncate_lsn,
+            wal_start_lsn: oldstate.wal_start_lsn,
+        });
+    }
+    bail!("unsupported safekeeper control file version {}", version)
+}


### PR DESCRIPTION
Should have been a part of cba4da3f4d90e to provide upgrade for previously
existing clusters. Separates version independent header (magic + version) out of
SafeKeeperState to choose what to deserialize.