### PR TITLE
Prefix unused field with underscore

### DIFF
--- a/walkeeper/src/timeline.rs
+++ b/walkeeper/src/timeline.rs
@@ -327,7 +327,7 @@ impl GlobalTimelines {
 #[derive(Debug)]
 struct FileStorage {
     // file used to prevent concurrent safekeepers running on the same data
-    lock_file: File,
+    _lock_file: File,
     // save timeline dir to avoid reconstructing it every time
     timeline_dir: PathBuf,
     conf: SafeKeeperConf,
@@ -432,7 +432,7 @@ impl FileStorage {
 
         Ok((
             FileStorage {
-                lock_file,
+                _lock_file: lock_file,
                 timeline_dir,
                 conf: conf.clone(),
                 persist_control_file_seconds: PERSIST_CONTROL_FILE_SECONDS


### PR DESCRIPTION
With rustc 1.57.0 , when I run `./run_clippy.sh`, it complains with 

```
error: field is never read: `lock_file`
   --> walkeeper/src/timeline.rs:330:5
    |
330 |     lock_file: File,
    |     ^^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`

error: could not compile `walkeeper` due to previous error
```

I've added a `_` to the field to satisfy clippy, but might be, that the logic needs to be adjusted also?