### PR TITLE
Wal stream disconnect

### DIFF
--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -78,7 +78,9 @@ impl postgres_backend::Handler for SendWalHandler {
         if query_string.starts_with(b"IDENTIFY_SYSTEM") {
             self.handle_identify_system(pgb)?;
         } else if query_string.starts_with(b"START_REPLICATION") {
-            ReplicationConn::new(pgb).run(self, pgb, &query_string)?;
+            ReplicationConn::new(pgb)
+                .run(self, pgb, &query_string)
+                .with_context(|| "failed to run ReplicationConn")?;
         } else if query_string.starts_with(b"START_WAL_PUSH") {
             // TODO: this repeats query decoding logic from page_service so it is probably
             // a good idea to refactor it in pgbackend and pass string to process query instead of bytes

--- a/zenith_utils/src/postgres_backend.rs
+++ b/zenith_utils/src/postgres_backend.rs
@@ -426,6 +426,10 @@ impl PostgresBackend {
                     // send that in the ErrorResponse though, because it's not relevant to the
                     // compute node logs.
                     warn!("query handler for {:?} failed: {:#}", m.body, e);
+                    if e.to_string().contains("failed to run") {
+                        self.write_message_noflush(&BeMessage::ErrorResponse(errmsg))?;
+                        return Ok(ProcessMsgResult::Break);
+                    }
                     self.write_message_noflush(&BeMessage::ErrorResponse(errmsg))?;
                 }
                 self.write_message(&BeMessage::ReadyForQuery)?;


### PR DESCRIPTION
The final goal of this PR is to shut down all threads of an inactive tenant in both WAL service and Pageserver.
Tenant is inactive when there are no running compute nodes, serving its timelines.

WAL stream uses the 2 connections:

1. Compute node (walproposer)  -> Safekeeper (ReceiveWalConn module)

When compute node is shut down, safekeeper needs to stop the respective receiving thread. 
Prior to this PR it didn't work because PostgresBackend haven't handled disconnection properly.

2. Safekeeper (ReplicationConn module) -> pageserver (walreceiver thread)

When incoming WAL stream is gone, safekeeper can stop streaming WAL and cancel connection as soon as replica is caught up.
Note that the WAL can be streamed to multiple replicas simultaneously, only disconnect ones that are caught up to the last_recieved_lsn.

Previously, pageserver's walreceiver was trying to reestablish a replication connection in case of failure.
This logic is removed in commit [64c9b7f9](https://github.com/zenithdb/zenith/pull/984/commits/64c9b7f94dc2c581ca287a8380585839d3d8ca80) because it is not needed. 
If necessary, WAL service will send a callback request to ask pageserver to reconnect.

In pageserver, when walreceiver thread is gone, tenant threads (checkpointer & gc) will finish too as soon as they finish processing all received WAL. This logic is already present in pageserver's code, it just wasn't used before.