### PR TITLE
Propagate disk consistent lsn with timeline sync statuses

### DIFF
--- a/pageserver/src/branches.rs
+++ b/pageserver/src/branches.rs
@@ -56,7 +56,7 @@ impl BranchInfo {
 
         let timeline = match repo.get_timeline(timeline_id)? {
             RepositoryTimeline::Local(local_entry) => local_entry,
-            RepositoryTimeline::Remote(_) => {
+            RepositoryTimeline::Remote { .. } => {
                 bail!("Timeline {} is remote, no branches to display", timeline_id)
             }
         };

--- a/pageserver/src/remote_storage.rs
+++ b/pageserver/src/remote_storage.rs
@@ -163,11 +163,16 @@ pub fn start_local_timeline_sync(
                 ZTenantId,
                 HashMap<ZTimelineId, TimelineSyncState>,
             > = HashMap::new();
-            for TimelineSyncId(tenant_id, timeline_id) in local_timeline_files.into_keys() {
+            for (TimelineSyncId(tenant_id, timeline_id), (timeline_metadata, _)) in
+                local_timeline_files
+            {
                 initial_timeline_states
                     .entry(tenant_id)
                     .or_default()
-                    .insert(timeline_id, TimelineSyncState::Ready);
+                    .insert(
+                        timeline_id,
+                        TimelineSyncState::Ready(timeline_metadata.disk_consistent_lsn()),
+                    );
             }
             Ok(SyncStartupData {
                 initial_timeline_states,

--- a/pageserver/src/remote_storage/storage_sync/index.rs
+++ b/pageserver/src/remote_storage/storage_sync/index.rs
@@ -119,14 +119,28 @@ pub enum TimelineIndexEntry {
 impl TimelineIndexEntry {
     pub fn uploaded_checkpoints(&self) -> BTreeSet<Lsn> {
         match self {
-            TimelineIndexEntry::Description(description) => {
+            Self::Description(description) => {
                 description.keys().map(|archive_id| archive_id.0).collect()
             }
-            TimelineIndexEntry::Full(remote_timeline) => remote_timeline
+            Self::Full(remote_timeline) => remote_timeline
                 .checkpoint_archives
                 .keys()
                 .map(|archive_id| archive_id.0)
                 .collect(),
+        }
+    }
+
+    /// Gets latest uploaded checkpoint's disk consisten Lsn for the corresponding timeline.
+    pub fn disk_consistent_lsn(&self) -> Option<Lsn> {
+        match self {
+            Self::Description(description) => {
+                description.keys().map(|archive_id| archive_id.0).max()
+            }
+            Self::Full(remote_timeline) => remote_timeline
+                .checkpoint_archives
+                .keys()
+                .map(|archive_id| archive_id.0)
+                .max(),
         }
     }
 }

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -212,6 +212,9 @@ fn walreceiver_main(
                 tenantid, timelineid,
             )
         })?;
+    let _timeline_synced_disk_consistent_lsn = tenant_mgr::get_repository_for_tenant(tenantid)?
+        .get_timeline_state(timelineid)
+        .and_then(|state| state.remote_disk_consistent_lsn());
 
     //
     // Start streaming the WAL, from where we left off previously.


### PR DESCRIPTION
Part of https://github.com/zenithdb/zenith/issues/944

Adds a `disk_consistent_lsn` into `TimelineSyncState`, making it possible to know timeline's latest `dick_consistent_lsn` on the remote storage.