### PR TITLE
storage CI flow for staging environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,8 +465,9 @@ jobs:
           command: |
             rm -rf zenith_install postgres_install.tar.gz zenith_install.tar.gz
             mkdir zenith_install
-            docker pull --quiet zenithdb/zenith:latest
-            ID=$(docker create zenithdb/zenith:latest)
+            DOCKER_TAG=$(git log --oneline|wc -l)
+            docker pull --quiet zenithdb/zenith:${DOCKER_TAG}
+            ID=$(docker create zenithdb/zenith:${DOCKER_TAG})
             docker cp $ID:/data/postgres_install.tar.gz .
             tar -xzf postgres_install.tar.gz -C zenith_install && rm postgres_install.tar.gz
             docker cp $ID:/usr/local/bin/pageserver zenith_install/bin/
@@ -474,6 +475,7 @@ jobs:
             docker cp $ID:/usr/local/bin/proxy zenith_install/bin/
             docker cp $ID:/usr/local/bin/postgres zenith_install/bin/
             docker rm -v $ID
+            echo ${DOCKER_TAG} | tee zenith_install/.zenith_current_version
             tar -czf zenith_install.tar.gz -C zenith_install .
             ls -la zenith_install.tar.gz
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,45 @@ jobs:
             docker build -t zenithdb/compute-node:latest vendor/postgres && docker push zenithdb/compute-node:latest
             docker tag zenithdb/compute-node:latest zenithdb/compute-node:${DOCKER_TAG} && docker push zenithdb/compute-node:${DOCKER_TAG}
 
+  deploy-staging:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Get Zenith binaries
+          command: |
+            rm -rf zenith_install postgres_install.tar.gz zenith_install.tar.gz
+            mkdir zenith_install
+            docker pull --quiet zenithdb/zenith:latest
+            ID=$(docker create zenithdb/zenith:latest)
+            docker cp $ID:/data/postgres_install.tar.gz .
+            tar -xzf postgres_install.tar.gz -C zenith_install && rm postgres_install.tar.gz
+            docker cp $ID:/usr/local/bin/pageserver zenith_install/bin/
+            docker cp $ID:/usr/local/bin/safekeeper zenith_install/bin/
+            docker cp $ID:/usr/local/bin/proxy zenith_install/bin/
+            docker cp $ID:/usr/local/bin/postgres zenith_install/bin/
+            docker rm -v $ID
+            tar -czf zenith_install.tar.gz -C zenith_install .
+            ls -la zenith_install.tar.gz
+      - run:
+          name: Setup ansible
+          command: |
+            pip install --progress-bar off --user ansible boto
+            ansible-galaxy collection install amazon.aws
+      - run:
+          name: Apply re-deploy playbook
+          environment:
+            ANSIBLE_HOST_KEY_CHECKING: false
+          command: |
+            echo "${STAGING_SSH_KEY}" | base64 --decode | ssh-add -
+            export AWS_REGION=${STAGING_AWS_REGION}
+            export AWS_ACCESS_KEY_ID=${STAGING_AWS_ACCESS_KEY_ID}
+            export AWS_SECRET_ACCESS_KEY=${STAGING_AWS_SECRET_ACCESS_KEY}
+            ansible-playbook .circleci/storage-redeploy.playbook.yml
+            rm -f zenith_install.tar.gz
+
   # Trigger a new remote CI job
   remote-ci-trigger:
     docker:
@@ -568,6 +607,16 @@ workflows:
           requires:
             - pg_regress-tests-release
             - other-tests-release
+      - deploy-staging:
+          # Context gives an ability to login
+          context: Docker Hub
+          # Build image only for commits to main
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - docker-image
       - remote-ci-trigger:
           # Context passes credentials for gh api
           context: CI_ACCESS_TOKEN

--- a/.circleci/storage-redeploy.playbook.yml
+++ b/.circleci/storage-redeploy.playbook.yml
@@ -1,0 +1,89 @@
+- name: discover storage nodes
+  hosts: localhost
+  connection: local
+  gather_facts: False
+
+  tasks:
+
+    - name: discover safekeepers
+      no_log: true
+      ec2_instance_info:
+        filters:
+          "tag:zenith_env": "staging"
+          "tag:zenith_service": "safekeeper"
+      register: ec2_safekeepers
+
+    - name: discover pageservers
+      no_log: true
+      ec2_instance_info:
+        filters:
+          "tag:zenith_env": "staging"
+          "tag:zenith_service": "pageserver"
+      register: ec2_pageservers
+
+    - name: add safekeepers to host group
+      no_log: true
+      add_host:
+        name: safekeeper-{{ ansible_loop.index }}
+        ansible_host: "{{ item.public_ip_address }}"
+        groups:
+          - storage
+          - safekeepers
+      with_items: "{{ ec2_safekeepers.instances }}"
+      loop_control:
+        extended: yes
+
+    - name: add pageservers to host group
+      no_log: true
+      add_host:
+        name: pageserver-{{ ansible_loop.index }}
+        ansible_host: "{{ item.public_ip_address }}"
+        groups:
+          - storage
+          - pageservers
+      with_items: "{{ ec2_pageservers.instances }}"
+      loop_control:
+        extended: yes
+
+- name: Extract Zenith binaries
+  hosts: storage
+  gather_facts: False
+  remote_user: admin
+
+  tasks:
+
+    - name: Extract Zenith binaries to /usr/local
+      ansible.builtin.unarchive:
+        src: ../zenith_install.tar.gz
+        dest: /usr/local
+      become: true
+
+- name: Restart safekeepers
+  hosts: safekeepers
+  gather_facts: False
+  remote_user: admin
+
+  tasks:
+
+    - name: Restart systemd service
+      ansible.builtin.systemd:
+        daemon_reload: yes
+        name: safekeeper
+        enabled: yes
+        state: restarted
+      become: true
+
+- name: Restart pageservers
+  hosts: pageservers
+  gather_facts: False
+  remote_user: admin
+
+  tasks:
+
+    - name: Restart systemd service
+      ansible.builtin.systemd:
+        daemon_reload: yes
+        name: pageserver
+        enabled: yes
+        state: restarted
+      become: true

--- a/.circleci/storage-redeploy.playbook.yml
+++ b/.circleci/storage-redeploy.playbook.yml
@@ -45,6 +45,40 @@
       loop_control:
         extended: yes
 
+- name: Retrive versions
+  hosts: storage
+  gather_facts: False
+  remote_user: admin
+
+  tasks:
+
+    - name: Get current version of binaries
+      set_fact:
+        current_version: "{{lookup('file', '../zenith_install/.zenith_current_version') }}"
+
+    - name: Check that file with version exists on host
+      stat:
+        path: /usr/local/.zenith_current_version
+      register: version_file
+
+    - name: Try to get current version from the host
+      when: version_file.stat.exists
+      ansible.builtin.fetch:
+        src: /usr/local/.zenith_current_version
+        dest: .remote_version.{{ inventory_hostname }}
+        fail_on_missing: no
+        flat: yes
+
+    - name: Store remote version to variable
+      when: version_file.stat.exists
+      set_fact:
+        remote_version: "{{ lookup('file', '.remote_version.{{ inventory_hostname }}') }}"
+
+    - name: Store default value of remote version to variable in case when remote version file not found
+      when: not version_file.stat.exists
+      set_fact:
+        remote_version: "000"
+
 - name: Extract Zenith binaries
   hosts: storage
   gather_facts: False
@@ -52,7 +86,12 @@
 
   tasks:
 
+    - name: Skip binaries upload on version conflict
+      when: current_version <= remote_version
+      debug: msg="Current version {{ current_version }} LE than remote {{ remote_version }}"
+
     - name: Extract Zenith binaries to /usr/local
+      when: current_version > remote_version
       ansible.builtin.unarchive:
         src: ../zenith_install.tar.gz
         dest: /usr/local
@@ -65,7 +104,12 @@
 
   tasks:
 
+    - name: Skip restart on version conflict
+      when: current_version <= remote_version
+      debug: msg="Current version {{ current_version }} LE than remote {{ remote_version }}"
+
     - name: Restart systemd service
+      when: current_version > remote_version
       ansible.builtin.systemd:
         daemon_reload: yes
         name: safekeeper
@@ -80,7 +124,12 @@
 
   tasks:
 
+    - name: Skip restart on version conflict
+      when: current_version <= remote_version
+      debug: msg="Current version {{ current_version }} LE than remote {{ remote_version }}"
+
     - name: Restart systemd service
+      when: current_version > remote_version
       ansible.builtin.systemd:
         daemon_reload: yes
         name: pageserver


### PR DESCRIPTION
This PR add simple deployment flow for staging environment:
- discover storage nodes in staging environment (by ec2 instance tags)
- extract new binaries and copy them to storage nodes
- restart safekeepers and pageserver(s)

These variables used and  should be added to CircleCI
- `STAGING_AWS_REGION` - AWS Region where storage nodes resides
- `STAGING_AWS_ACCESS_KEY_ID` and `STAGING_AWS_SECRET_ACCESS_KEY` - AWS credentials with EC2ReadOnlyAccess (to discover EC2 instances by tags)
- `STAGING_SSH_KEY` - base64 encoded private ssh key to access storage nodes

