### PR TITLE
Remove old ephemeral files on pageserver restart.

### DIFF
--- a/pageserver/src/layered_repository/ephemeral_file.rs
+++ b/pageserver/src/layered_repository/ephemeral_file.rs
@@ -95,6 +95,15 @@ impl EphemeralFile {
     }
 }
 
+/// Does the given filename look like an ephemeral file?
+pub fn is_ephemeral_file(filename: &str) -> bool {
+    if let Some(rest) = filename.strip_prefix("ephemeral-") {
+        rest.parse::<u32>().is_ok()
+    } else {
+        false
+    }
+}
+
 impl FileExt for EphemeralFile {
     fn read_at(&self, dstbuf: &mut [u8], offset: u64) -> Result<usize, Error> {
         // Look up the right page


### PR DESCRIPTION
The ephemeral files are not usable after restart, so just delete them.
Before this, you got "unrecognized filename in timeline dir" warnings
about them, as Konstantin noted at:
https://github.com/zenithdb/zenith/issues/906#issuecomment-995530870.

While we're at it, refactor away the list_files() function, moving the
logic fully into the caller. Seems more straightforward.