### PR TITLE
Optimize get_relish_size by maintaining cache of last segment number

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -869,7 +869,7 @@ impl Timeline for LayeredTimeline {
         }
         debug_assert!(lsn <= self.get_last_record_lsn());
 
-        let mut segno = 0;
+        let mut segno = self.get_last_segno(rel, lsn).unwrap_or(0);
         loop {
             let seg = SegmentTag { rel, segno };
 
@@ -1221,6 +1221,14 @@ impl LayeredTimeline {
             self.current_logical_size.load(atomic::Ordering::Relaxed)
         );
         Ok(())
+    }
+
+    ///
+    /// Try to get cached last segment number visible at givin LSN
+    ///
+    fn get_last_segno(&self, rel: RelishTag, lsn: Lsn) -> Option<u32> {
+        let self_layers = self.layers.lock().unwrap();
+        self_layers.get_last_segno(rel, lsn)
     }
 
     ///


### PR DESCRIPTION
See https://github.com/zenithdb/zenith/issues/906