### PR TITLE
Fix multixacts members WAL redo.

### DIFF
--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -403,12 +403,13 @@ impl PostgresRedoManager {
                     {
                         if slru == SlruKind::MultiXactMembers {
                             for i in 0..xlrec.nmembers {
-                                let pageno = i / pg_constants::MULTIXACT_MEMBERS_PER_PAGE as u32;
+                                let offset = xlrec.moff + i;
+                                let pageno =
+                                    offset / pg_constants::MULTIXACT_MEMBERS_PER_PAGE as u32;
                                 let segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
                                 let rpageno = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
                                 if segno == rec_segno && rpageno == blknum {
                                     // update only target block
-                                    let offset = xlrec.moff + i;
                                     let memberoff = mx_offset_to_member_offset(offset);
                                     let flagsoff = mx_offset_to_flags_offset(offset);
                                     let bshift = mx_offset_to_flags_bitshift(offset);


### PR DESCRIPTION
The logic to compute the page number was broken, and as a result, only
the first page of multixact members was updated correctly. All the
rest were left as zeros. Improve test_multixact.py to generate more
multixacts, to cover this case.

Also fix the check that the restored PG data directory matches the
original one. Previously, the test compared the 'pg_new' cluster,
which is a bit silly because the test restored the 'pg_new' cluster
only a few lines earlier, so if the multixact WAL redo is somehow
broken, the comparison will just compare two broken data directories
and report success. Change it to compare the original datadir, the one
where the multixacts were originally created, with a restored image of
the same.