### PR TITLE
Refactor WAL record handling

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -38,7 +38,7 @@ use crate::relish::*;
 use crate::remote_storage::{schedule_timeline_checkpoint_upload, schedule_timeline_download};
 use crate::repository::{
     BlockNumber, GcResult, Repository, RepositoryTimeline, Timeline, TimelineSyncState,
-    TimelineWriter, WALRecord,
+    TimelineWriter, ZenithWalRecord,
 };
 use crate::tenant_mgr;
 use crate::walreceiver;
@@ -1981,7 +1981,7 @@ impl LayeredTimeline {
                     assert!(data.page_img.is_none());
                     if let Some((first_rec_lsn, first_rec)) = data.records.first() {
                         assert!(&cached_lsn < first_rec_lsn);
-                        assert!(!first_rec.will_init);
+                        assert!(!first_rec.will_init());
                     }
                     data.page_img = Some(cached_img);
                     break;
@@ -2028,7 +2028,7 @@ impl LayeredTimeline {
             //
             // If we don't have a base image, then the oldest WAL record better initialize
             // the page
-            if data.page_img.is_none() && !data.records.first().unwrap().1.will_init {
+            if data.page_img.is_none() && !data.records.first().unwrap().1.will_init() {
                 // FIXME: this ought to be an error?
                 warn!(
                     "Base image for page {}/{} at {} not found, but got {} WAL records",
@@ -2125,8 +2125,8 @@ impl<'a> TimelineWriter for LayeredTimelineWriter<'a> {
         &self,
         lsn: Lsn,
         rel: RelishTag,
-        rel_blknum: BlockNumber,
-        rec: WALRecord,
+        rel_blknum: u32,
+        rec: ZenithWalRecord,
     ) -> Result<()> {
         if !rel.is_blocky() && rel_blknum != 0 {
             bail!(

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -257,7 +257,7 @@ impl Layer for DeltaLayer {
                         break;
                     }
                     PageVersion::Wal(rec) => {
-                        let will_init = rec.will_init;
+                        let will_init = rec.will_init();
                         reconstruct_data.records.push((*pv_lsn, rec));
                         if will_init {
                             // This WAL record initializes the page, so no need to go further back
@@ -373,12 +373,12 @@ impl Layer for DeltaLayer {
                     write!(&mut desc, " img {} bytes", img.len())?;
                 }
                 PageVersion::Wal(rec) => {
-                    let wal_desc = walrecord::describe_wal_record(&rec.rec);
+                    let wal_desc = walrecord::describe_wal_record(&rec);
                     write!(
                         &mut desc,
                         " rec {} bytes will_init: {} {}",
-                        rec.rec.len(),
-                        rec.will_init,
+                        blob_range.size,
+                        rec.will_init(),
                         wal_desc
                     )?;
                 }

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -15,7 +15,7 @@ use crate::layered_repository::storage_layer::{
 };
 use crate::layered_repository::LayeredTimeline;
 use crate::layered_repository::ZERO_PAGE;
-use crate::repository::WALRecord;
+use crate::repository::ZenithWalRecord;
 use crate::{ZTenantId, ZTimelineId};
 use anyhow::{ensure, Result};
 use bytes::Bytes;
@@ -187,7 +187,7 @@ impl Layer for InMemoryLayer {
                     }
                     PageVersion::Wal(rec) => {
                         reconstruct_data.records.push((*entry_lsn, rec.clone()));
-                        if rec.will_init {
+                        if rec.will_init() {
                             // This WAL record initializes the page, so no need to go further back
                             need_image = false;
                             break;
@@ -369,7 +369,12 @@ impl InMemoryLayer {
     // Write operations
 
     /// Remember new page version, as a WAL record over previous version
-    pub fn put_wal_record(&self, lsn: Lsn, blknum: SegmentBlk, rec: WALRecord) -> Result<u32> {
+    pub fn put_wal_record(
+        &self,
+        lsn: Lsn,
+        blknum: SegmentBlk,
+        rec: ZenithWalRecord,
+    ) -> Result<u32> {
         self.put_page_version(blknum, lsn, PageVersion::Wal(rec))
     }
 

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -3,7 +3,7 @@
 //!
 
 use crate::relish::RelishTag;
-use crate::repository::{BlockNumber, WALRecord};
+use crate::repository::{BlockNumber, ZenithWalRecord};
 use crate::{ZTenantId, ZTimelineId};
 use anyhow::Result;
 use bytes::Bytes;
@@ -67,7 +67,7 @@ impl SegmentTag {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PageVersion {
     Page(Bytes),
-    Wal(WALRecord),
+    Wal(ZenithWalRecord),
 }
 
 ///
@@ -78,7 +78,7 @@ pub enum PageVersion {
 /// 'records' contains the records to apply over the base image.
 ///
 pub struct PageReconstructData {
-    pub records: Vec<(Lsn, WALRecord)>,
+    pub records: Vec<(Lsn, ZenithWalRecord)>,
     pub page_img: Option<Bytes>,
 }
 

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -19,7 +19,7 @@
 //! process, he cannot escape out of it.
 //!
 use byteorder::{ByteOrder, LittleEndian};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use lazy_static::lazy_static;
 use log::*;
 use nix::poll::*;
@@ -43,15 +43,12 @@ use zenith_utils::zid::ZTenantId;
 
 use crate::config::PageServerConf;
 use crate::relish::*;
-use crate::repository::WALRecord;
-use crate::walrecord::XlMultiXactCreate;
-use crate::walrecord::XlXactParsedRecord;
+use crate::repository::ZenithWalRecord;
 use postgres_ffi::nonrelfile_utils::mx_offset_to_flags_bitshift;
 use postgres_ffi::nonrelfile_utils::mx_offset_to_flags_offset;
 use postgres_ffi::nonrelfile_utils::mx_offset_to_member_offset;
 use postgres_ffi::nonrelfile_utils::transaction_id_set_status;
 use postgres_ffi::pg_constants;
-use postgres_ffi::XLogRecord;
 
 ///
 /// `RelTag` + block number (`blknum`) gives us a unique id of the page in the cluster.
@@ -82,7 +79,7 @@ pub trait WalRedoManager: Send + Sync {
         blknum: u32,
         lsn: Lsn,
         base_img: Option<Bytes>,
-        records: Vec<(Lsn, WALRecord)>,
+        records: Vec<(Lsn, ZenithWalRecord)>,
     ) -> Result<Bytes, WalRedoError>;
 }
 
@@ -99,7 +96,7 @@ impl crate::walredo::WalRedoManager for DummyRedoManager {
         _blknum: u32,
         _lsn: Lsn,
         _base_img: Option<Bytes>,
-        _records: Vec<(Lsn, WALRecord)>,
+        _records: Vec<(Lsn, ZenithWalRecord)>,
     ) -> Result<Bytes, WalRedoError> {
         Err(WalRedoError::InvalidState)
     }
@@ -142,23 +139,43 @@ pub struct PostgresRedoManager {
     process: Mutex<Option<PostgresRedoProcess>>,
 }
 
-#[derive(Debug)]
-struct WalRedoRequest {
-    rel: RelishTag,
-    blknum: u32,
-    lsn: Lsn,
-
-    base_img: Option<Bytes>,
-    records: Vec<(Lsn, WALRecord)>,
-}
-
-impl WalRedoRequest {
-    // Can this request be served by zenith redo funcitons
-    // or we need to pass it to wal-redo postgres process?
-    fn can_apply_in_zenith(&self) -> bool {
-        !matches!(self.rel, RelishTag::Relation(_))
+/// Can this request be served by zenith redo funcitons
+/// or we need to pass it to wal-redo postgres process?
+fn can_apply_in_zenith(rec: &ZenithWalRecord) -> bool {
+    // Currently, we don't have bespoken Rust code to replay any
+    // Postgres WAL records. But everything else is handled in zenith.
+    #[allow(clippy::match_like_matches_macro)]
+    match rec {
+        ZenithWalRecord::Postgres {
+            will_init: _,
+            rec: _,
+        } => false,
+        _ => true,
     }
 }
+
+fn check_forknum(rel: &RelishTag, expected_forknum: u8) -> bool {
+    if let RelishTag::Relation(RelTag {
+        forknum,
+        spcnode: _,
+        dbnode: _,
+        relnode: _,
+    }) = rel
+    {
+        *forknum == expected_forknum
+    } else {
+        false
+    }
+}
+
+fn check_slru_segno(rel: &RelishTag, expected_slru: SlruKind, expected_segno: u32) -> bool {
+    if let RelishTag::Slru { slru, segno } = rel {
+        *slru == expected_slru && *segno == expected_segno
+    } else {
+        false
+    }
+}
+
 /// An error happened in WAL redo
 #[derive(Debug, thiserror::Error)]
 pub enum WalRedoError {
@@ -187,53 +204,37 @@ impl WalRedoManager for PostgresRedoManager {
         blknum: u32,
         lsn: Lsn,
         base_img: Option<Bytes>,
-        records: Vec<(Lsn, WALRecord)>,
+        records: Vec<(Lsn, ZenithWalRecord)>,
     ) -> Result<Bytes, WalRedoError> {
-        let start_time;
-        let end_time;
-
-        let request = WalRedoRequest {
-            rel,
-            blknum,
-            lsn,
-            base_img,
-            records,
-        };
-
-        start_time = Instant::now();
-        let result;
-
-        if request.can_apply_in_zenith() {
-            result = self.handle_apply_request_zenith(&request);
-
-            end_time = Instant::now();
-            WAL_REDO_TIME.observe(end_time.duration_since(start_time).as_secs_f64());
-        } else {
-            let mut process_guard = self.process.lock().unwrap();
-            let lock_time = Instant::now();
-
-            // launch the WAL redo process on first use
-            if process_guard.is_none() {
-                let p = PostgresRedoProcess::launch(self.conf, &self.tenantid)?;
-                *process_guard = Some(p);
-            }
-            let process = process_guard.as_mut().unwrap();
-
-            result = self.handle_apply_request_postgres(process, &request);
-
-            WAL_REDO_WAIT_TIME.observe(lock_time.duration_since(start_time).as_secs_f64());
-            end_time = Instant::now();
-            WAL_REDO_TIME.observe(end_time.duration_since(lock_time).as_secs_f64());
-
-            // If something went wrong, don't try to reuse the process. Kill it, and
-            // next request will launch a new one.
-            if result.is_err() {
-                let process = process_guard.take().unwrap();
-                process.kill();
-            }
+        if records.is_empty() {
+            error!("invalid WAL redo request with no records");
+            return Err(WalRedoError::InvalidRequest);
         }
 
-        result
+        let mut img: Option<Bytes> = base_img;
+        let mut batch_zenith = can_apply_in_zenith(&records[0].1);
+        let mut batch_start = 0;
+        for i in 1..records.len() {
+            let rec_zenith = can_apply_in_zenith(&records[i].1);
+
+            if rec_zenith != batch_zenith {
+                let result = if batch_zenith {
+                    self.apply_batch_zenith(rel, blknum, lsn, img, &records[batch_start..i])
+                } else {
+                    self.apply_batch_postgres(rel, blknum, lsn, img, &records[batch_start..i])
+                };
+                img = Some(result?);
+
+                batch_zenith = rec_zenith;
+                batch_start = i;
+            }
+        }
+        // last batch
+        if batch_zenith {
+            self.apply_batch_zenith(rel, blknum, lsn, img, &records[batch_start..])
+        } else {
+            self.apply_batch_postgres(rel, blknum, lsn, img, &records[batch_start..])
+        }
     }
 }
 
@@ -253,203 +254,229 @@ impl PostgresRedoManager {
     ///
     /// Process one request for WAL redo using wal-redo postgres
     ///
-    fn handle_apply_request_postgres(
+    fn apply_batch_postgres(
         &self,
-        process: &mut PostgresRedoProcess,
-        request: &WalRedoRequest,
+        rel: RelishTag,
+        blknum: u32,
+        lsn: Lsn,
+        base_img: Option<Bytes>,
+        records: &[(Lsn, ZenithWalRecord)],
     ) -> Result<Bytes, WalRedoError> {
-        let blknum = request.blknum;
-        let lsn = request.lsn;
-        let base_img = request.base_img.clone();
-        let records = &request.records;
-        let nrecords = records.len();
-
-        let start = Instant::now();
+        let start_time = Instant::now();
 
         let apply_result: Result<Bytes, Error>;
 
-        if let RelishTag::Relation(rel) = request.rel {
+        let mut process_guard = self.process.lock().unwrap();
+        let lock_time = Instant::now();
+
+        // launch the WAL redo process on first use
+        if process_guard.is_none() {
+            let p = PostgresRedoProcess::launch(self.conf, &self.tenantid)?;
+            *process_guard = Some(p);
+        }
+        let process = process_guard.as_mut().unwrap();
+
+        WAL_REDO_WAIT_TIME.observe(lock_time.duration_since(start_time).as_secs_f64());
+
+        let result = if let RelishTag::Relation(rel) = rel {
             // Relational WAL records are applied using wal-redo-postgres
             let buf_tag = BufferTag { rel, blknum };
             apply_result = process.apply_wal_records(buf_tag, base_img, records);
 
-            let duration = start.elapsed();
-
-            debug!(
-                "postgres applied {} WAL records in {} us to reconstruct page image at LSN {}",
-                nrecords,
-                duration.as_micros(),
-                lsn
-            );
-
             apply_result.map_err(WalRedoError::IoError)
         } else {
+            error!("unexpected non-relation relish: {:?}", rel);
             Err(WalRedoError::InvalidRequest)
+        };
+
+        let end_time = Instant::now();
+        let duration = end_time.duration_since(lock_time);
+        WAL_REDO_TIME.observe(duration.as_secs_f64());
+        debug!(
+            "postgres applied {} WAL records in {} us to reconstruct page image at LSN {}",
+            records.len(),
+            duration.as_micros(),
+            lsn
+        );
+
+        // If something went wrong, don't try to reuse the process. Kill it, and
+        // next request will launch a new one.
+        if result.is_err() {
+            let process = process_guard.take().unwrap();
+            process.kill();
         }
+        result
     }
 
     ///
-    /// Process one request for WAL redo using custom zenith code
+    /// Process a batch of WAL records using bespoken Zenith code.
     ///
-    fn handle_apply_request_zenith(&self, request: &WalRedoRequest) -> Result<Bytes, WalRedoError> {
-        let rel = request.rel;
-        let blknum = request.blknum;
-        let lsn = request.lsn;
-        let base_img = request.base_img.clone();
-        let records = &request.records;
+    fn apply_batch_zenith(
+        &self,
+        rel: RelishTag,
+        blknum: u32,
+        lsn: Lsn,
+        base_img: Option<Bytes>,
+        records: &[(Lsn, ZenithWalRecord)],
+    ) -> Result<Bytes, WalRedoError> {
+        let start_time = Instant::now();
 
-        let nrecords = records.len();
-
-        let start = Instant::now();
-
-        let apply_result: Result<Bytes, Error>;
-
-        // Non-relational WAL records are handled here, with custom code that has the
-        // same effects as the corresponding Postgres WAL redo function.
-        const ZERO_PAGE: [u8; 8192] = [0u8; 8192];
         let mut page = BytesMut::new();
         if let Some(fpi) = base_img {
             // If full-page image is provided, then use it...
             page.extend_from_slice(&fpi[..]);
         } else {
-            // otherwise initialize page with zeros
-            page.extend_from_slice(&ZERO_PAGE);
-        }
-        // Apply all collected WAL records
-        for (_lsn, record) in records {
-            let mut buf = record.rec.clone();
-
-            WAL_REDO_RECORD_COUNTER.inc();
-
-            // 1. Parse XLogRecord struct
-            // FIXME: refactor to avoid code duplication.
-            let xlogrec = XLogRecord::from_bytes(&mut buf);
-
-            //move to main data
-            // TODO probably, we should store some records in our special format
-            // to avoid this weird parsing on replay
-            let skip = (record.main_data_offset - pg_constants::SIZEOF_XLOGRECORD) as usize;
-            if buf.remaining() > skip {
-                buf.advance(skip);
-            }
-
-            if xlogrec.xl_rmid == pg_constants::RM_XACT_ID {
-                // Transaction manager stuff
-                let rec_segno = match rel {
-                    RelishTag::Slru { slru, segno } => {
-                        assert!(
-                            slru == SlruKind::Clog,
-                            "Not valid XACT relish tag {:?}",
-                            rel
-                        );
-                        segno
-                    }
-                    _ => panic!("Not valid XACT relish tag {:?}", rel),
-                };
-                let parsed_xact =
-                    XlXactParsedRecord::decode(&mut buf, xlogrec.xl_xid, xlogrec.xl_info);
-                if parsed_xact.info == pg_constants::XLOG_XACT_COMMIT
-                    || parsed_xact.info == pg_constants::XLOG_XACT_COMMIT_PREPARED
-                {
-                    // Iterate the main XID, followed by all the subxids.
-                    for xid in std::iter::once(&parsed_xact.xid).chain(parsed_xact.subxacts.iter())
-                    {
-                        let pageno = *xid as u32 / pg_constants::CLOG_XACTS_PER_PAGE;
-                        let segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
-                        let rpageno = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
-                        // only update xids on the requested page
-                        if rec_segno == segno && blknum == rpageno {
-                            transaction_id_set_status(
-                                *xid,
-                                pg_constants::TRANSACTION_STATUS_COMMITTED,
-                                &mut page,
-                            );
-                        }
-                    }
-                } else if parsed_xact.info == pg_constants::XLOG_XACT_ABORT
-                    || parsed_xact.info == pg_constants::XLOG_XACT_ABORT_PREPARED
-                {
-                    // Iterate the main XID, followed by all the subxids.
-                    for xid in std::iter::once(&parsed_xact.xid).chain(parsed_xact.subxacts.iter())
-                    {
-                        let pageno = *xid as u32 / pg_constants::CLOG_XACTS_PER_PAGE;
-                        let segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
-                        let rpageno = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
-                        // only update xids on the requested page
-                        if rec_segno == segno && blknum == rpageno {
-                            transaction_id_set_status(
-                                *xid,
-                                pg_constants::TRANSACTION_STATUS_ABORTED,
-                                &mut page,
-                            );
-                        }
-                    }
-                }
-            } else if xlogrec.xl_rmid == pg_constants::RM_MULTIXACT_ID {
-                // Multixact operations
-                let info = xlogrec.xl_info & pg_constants::XLR_RMGR_INFO_MASK;
-                if info == pg_constants::XLOG_MULTIXACT_CREATE_ID {
-                    let xlrec = XlMultiXactCreate::decode(&mut buf);
-                    if let RelishTag::Slru {
-                        slru,
-                        segno: rec_segno,
-                    } = rel
-                    {
-                        if slru == SlruKind::MultiXactMembers {
-                            for i in 0..xlrec.nmembers {
-                                let offset = xlrec.moff + i;
-                                let pageno =
-                                    offset / pg_constants::MULTIXACT_MEMBERS_PER_PAGE as u32;
-                                let segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
-                                let rpageno = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
-                                if segno == rec_segno && rpageno == blknum {
-                                    // update only target block
-                                    let memberoff = mx_offset_to_member_offset(offset);
-                                    let flagsoff = mx_offset_to_flags_offset(offset);
-                                    let bshift = mx_offset_to_flags_bitshift(offset);
-                                    let mut flagsval =
-                                        LittleEndian::read_u32(&page[flagsoff..flagsoff + 4]);
-                                    flagsval &=
-                                        !(((1 << pg_constants::MXACT_MEMBER_BITS_PER_XACT) - 1)
-                                            << bshift);
-                                    flagsval |= xlrec.members[i as usize].status << bshift;
-                                    LittleEndian::write_u32(
-                                        &mut page[flagsoff..flagsoff + 4],
-                                        flagsval,
-                                    );
-                                    LittleEndian::write_u32(
-                                        &mut page[memberoff..memberoff + 4],
-                                        xlrec.members[i as usize].xid,
-                                    );
-                                }
-                            }
-                        } else {
-                            // Multixact offsets SLRU
-                            let offs = (xlrec.mid % pg_constants::MULTIXACT_OFFSETS_PER_PAGE as u32
-                                * 4) as usize;
-                            LittleEndian::write_u32(&mut page[offs..offs + 4], xlrec.moff);
-                        }
-                    } else {
-                        panic!();
-                    }
-                } else {
-                    panic!();
-                }
-            }
+            // All the current WAL record types that we can handle require a base image.
+            error!("invalid zenith WAL redo request with no base image");
+            return Err(WalRedoError::InvalidRequest);
         }
 
-        apply_result = Ok::<Bytes, Error>(page.freeze());
-
-        let duration = start.elapsed();
+        // Apply all the WAL records in the batch
+        for (record_lsn, record) in records.iter() {
+            self.apply_record_zenith(rel, blknum, &mut page, *record_lsn, record)?;
+        }
+        // Success!
+        let end_time = Instant::now();
+        let duration = end_time.duration_since(start_time);
+        WAL_REDO_TIME.observe(duration.as_secs_f64());
 
         debug!(
             "zenith applied {} WAL records in {} ms to reconstruct page image at LSN {}",
-            nrecords,
-            duration.as_millis(),
+            records.len(),
+            duration.as_micros(),
             lsn
         );
 
-        apply_result.map_err(WalRedoError::IoError)
+        Ok(page.freeze())
+    }
+
+    fn apply_record_zenith(
+        &self,
+        rel: RelishTag,
+        blknum: u32,
+        page: &mut BytesMut,
+        _record_lsn: Lsn,
+        record: &ZenithWalRecord,
+    ) -> Result<(), WalRedoError> {
+        match record {
+            ZenithWalRecord::Postgres {
+                will_init: _,
+                rec: _,
+            } => panic!("tried to pass postgres wal record to zenith WAL redo"),
+            ZenithWalRecord::ClearVisibilityMapFlags { heap_blkno, flags } => {
+                // Calculate the VM block and offset that corresponds to the heap block.
+                let map_block = pg_constants::HEAPBLK_TO_MAPBLOCK(*heap_blkno);
+                let map_byte = pg_constants::HEAPBLK_TO_MAPBYTE(*heap_blkno);
+                let map_offset = pg_constants::HEAPBLK_TO_OFFSET(*heap_blkno);
+
+                // Check that we're modifying the correct VM block.
+                assert!(
+                    check_forknum(&rel, pg_constants::VISIBILITYMAP_FORKNUM),
+                    "ClearVisibilityMapFlags record on unexpected rel {:?}",
+                    rel
+                );
+                assert!(map_block == blknum);
+
+                // equivalent to PageGetContents(page)
+                let map = &mut page[pg_constants::MAXALIGN_SIZE_OF_PAGE_HEADER_DATA..];
+
+                let mask: u8 = flags << map_offset;
+                map[map_byte as usize] &= !mask;
+            }
+            // Non-relational WAL records are handled here, with custom code that has the
+            // same effects as the corresponding Postgres WAL redo function.
+            ZenithWalRecord::ClogSetCommitted { xids } => {
+                for &xid in xids {
+                    let pageno = xid as u32 / pg_constants::CLOG_XACTS_PER_PAGE;
+                    let expected_segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+                    let expected_blknum = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+
+                    // Check that we're modifying the correct CLOG block.
+                    assert!(
+                        check_slru_segno(&rel, SlruKind::Clog, expected_segno),
+                        "ClogSetCommitted record for XID {} with unexpected rel {:?}",
+                        xid,
+                        rel
+                    );
+                    assert!(blknum == expected_blknum);
+
+                    transaction_id_set_status(
+                        xid,
+                        pg_constants::TRANSACTION_STATUS_COMMITTED,
+                        page,
+                    );
+                }
+            }
+            ZenithWalRecord::ClogSetAborted { xids } => {
+                for &xid in xids {
+                    let pageno = xid as u32 / pg_constants::CLOG_XACTS_PER_PAGE;
+                    let expected_segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+                    let expected_blknum = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+
+                    // Check that we're modifying the correct CLOG block.
+                    assert!(
+                        check_slru_segno(&rel, SlruKind::Clog, expected_segno),
+                        "ClogSetCommitted record for XID {} with unexpected rel {:?}",
+                        xid,
+                        rel
+                    );
+                    assert!(blknum == expected_blknum);
+
+                    transaction_id_set_status(xid, pg_constants::TRANSACTION_STATUS_ABORTED, page);
+                }
+            }
+            ZenithWalRecord::MultixactOffsetCreate { mid, moff } => {
+                // Compute the block and offset to modify.
+                // See RecordNewMultiXact in PostgreSQL sources.
+                let pageno = mid / pg_constants::MULTIXACT_OFFSETS_PER_PAGE as u32;
+                let entryno = mid % pg_constants::MULTIXACT_OFFSETS_PER_PAGE as u32;
+                let offset = (entryno * 4) as usize;
+
+                // Check that we're modifying the correct multixact-offsets block.
+                let expected_segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+                let expected_blknum = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+                assert!(
+                    check_slru_segno(&rel, SlruKind::MultiXactOffsets, expected_segno),
+                    "MultiXactOffsetsCreate record for multi-xid {} with unexpected rel {:?}",
+                    mid,
+                    rel
+                );
+                assert!(blknum == expected_blknum);
+
+                LittleEndian::write_u32(&mut page[offset..offset + 4], *moff);
+            }
+            ZenithWalRecord::MultixactMembersCreate { moff, members } => {
+                for (i, member) in members.iter().enumerate() {
+                    let offset = moff + i as u32;
+
+                    // Compute the block and offset to modify.
+                    // See RecordNewMultiXact in PostgreSQL sources.
+                    let pageno = offset / pg_constants::MULTIXACT_MEMBERS_PER_PAGE as u32;
+                    let memberoff = mx_offset_to_member_offset(offset);
+                    let flagsoff = mx_offset_to_flags_offset(offset);
+                    let bshift = mx_offset_to_flags_bitshift(offset);
+
+                    // Check that we're modifying the correct multixact-members block.
+                    let expected_segno = pageno / pg_constants::SLRU_PAGES_PER_SEGMENT;
+                    let expected_blknum = pageno % pg_constants::SLRU_PAGES_PER_SEGMENT;
+                    assert!(
+                        check_slru_segno(&rel, SlruKind::MultiXactMembers, expected_segno),
+                        "MultiXactMembersCreate record at offset {} with unexpected rel {:?}",
+                        moff,
+                        rel
+                    );
+                    assert!(blknum == expected_blknum);
+
+                    let mut flagsval = LittleEndian::read_u32(&page[flagsoff..flagsoff + 4]);
+                    flagsval &= !(((1 << pg_constants::MXACT_MEMBER_BITS_PER_XACT) - 1) << bshift);
+                    flagsval |= member.status << bshift;
+                    LittleEndian::write_u32(&mut page[flagsoff..flagsoff + 4], flagsval);
+                    LittleEndian::write_u32(&mut page[memberoff..memberoff + 4], member.xid);
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -556,7 +583,7 @@ impl PostgresRedoProcess {
         &mut self,
         tag: BufferTag,
         base_img: Option<Bytes>,
-        records: &[(Lsn, WALRecord)],
+        records: &[(Lsn, ZenithWalRecord)],
     ) -> Result<Bytes, std::io::Error> {
         // Serialize all the messages to send the WAL redo process first.
         //
@@ -569,7 +596,15 @@ impl PostgresRedoProcess {
             build_push_page_msg(tag, &img, &mut writebuf);
         }
         for (lsn, rec) in records.iter() {
-            build_apply_record_msg(*lsn, &rec.rec, &mut writebuf);
+            if let ZenithWalRecord::Postgres {
+                will_init: _,
+                rec: postgres_rec,
+            } = rec
+            {
+                build_apply_record_msg(*lsn, postgres_rec, &mut writebuf);
+            } else {
+                panic!("tried to pass zenith wal record to postgres WAL redo");
+            }
         }
         build_get_page_msg(tag, &mut writebuf);
         WAL_REDO_RECORD_COUNTER.inc_by(records.len() as u64);

--- a/postgres_ffi/build.rs
+++ b/postgres_ffi/build.rs
@@ -75,6 +75,7 @@ fn main() {
         .allowlist_var("XLOG_PAGE_MAGIC")
         .allowlist_var("PG_CONTROL_FILE_SIZE")
         .allowlist_var("PG_CONTROLFILEDATA_OFFSETOF_CRC")
+        .allowlist_type("PageHeaderData")
         .allowlist_type("DBState")
         // Because structs are used for serialization, tell bindgen to emit
         // explicit padding fields.

--- a/postgres_ffi/pg_control_ffi.h
+++ b/postgres_ffi/pg_control_ffi.h
@@ -9,5 +9,6 @@
 #include "access/xlog_internal.h"
 
 #include "storage/block.h"
+#include "storage/bufpage.h"
 #include "storage/off.h"
 #include "access/multixact.h"

--- a/postgres_ffi/src/lib.rs
+++ b/postgres_ffi/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+// bindgen creates some unsafe code with no doc comments.
+#![allow(clippy::missing_safety_doc)]
 // suppress warnings on rust 1.53 due to bindgen unit tests.
 // https://github.com/rust-lang/rust-bindgen/issues/1651
 #![allow(deref_nullptr)]

--- a/postgres_ffi/src/pg_constants.rs
+++ b/postgres_ffi/src/pg_constants.rs
@@ -7,6 +7,8 @@
 //! comments on them.
 //!
 
+use crate::PageHeaderData;
+
 //
 // From pg_tablespace_d.h
 //
@@ -32,6 +34,14 @@ pub const BLCKSZ: u16 = 8192;
 pub const RELSEG_SIZE: u32 = 1024 * 1024 * 1024 / (BLCKSZ as u32);
 
 //
+// From bufpage.h
+//
+
+// Assumes 8 byte alignment
+const SIZEOF_PAGE_HEADER_DATA: usize = std::mem::size_of::<PageHeaderData>();
+pub const MAXALIGN_SIZE_OF_PAGE_HEADER_DATA: usize = (SIZEOF_PAGE_HEADER_DATA + 7) & !7;
+
+//
 // constants from clog.h
 //
 pub const CLOG_XACTS_PER_BYTE: u32 = 4;
@@ -39,19 +49,36 @@ pub const CLOG_XACTS_PER_PAGE: u32 = BLCKSZ as u32 * CLOG_XACTS_PER_BYTE;
 pub const CLOG_BITS_PER_XACT: u8 = 2;
 pub const CLOG_XACT_BITMASK: u8 = (1 << CLOG_BITS_PER_XACT) - 1;
 
-//
-// Constants from visbilitymap.h
-//
-pub const SIZE_OF_PAGE_HEADER: u16 = 24;
-pub const BITS_PER_HEAPBLOCK: u16 = 2;
-pub const HEAPBLOCKS_PER_PAGE: u16 = (BLCKSZ - SIZE_OF_PAGE_HEADER) * 8 / BITS_PER_HEAPBLOCK;
-
 pub const TRANSACTION_STATUS_COMMITTED: u8 = 0x01;
 pub const TRANSACTION_STATUS_ABORTED: u8 = 0x02;
 pub const TRANSACTION_STATUS_SUB_COMMITTED: u8 = 0x03;
 
 pub const CLOG_ZEROPAGE: u8 = 0x00;
 pub const CLOG_TRUNCATE: u8 = 0x10;
+
+//
+// Constants from visibilitymap.h, visibilitymapdefs.h and visibilitymap.c
+//
+pub const SIZE_OF_PAGE_HEADER: u16 = 24;
+pub const BITS_PER_BYTE: u16 = 8;
+pub const HEAPBLOCKS_PER_PAGE: u32 =
+    (BLCKSZ - SIZE_OF_PAGE_HEADER) as u32 * 8 / BITS_PER_HEAPBLOCK as u32;
+pub const HEAPBLOCKS_PER_BYTE: u16 = BITS_PER_BYTE / BITS_PER_HEAPBLOCK;
+
+pub const fn HEAPBLK_TO_MAPBLOCK(x: u32) -> u32 {
+    x / HEAPBLOCKS_PER_PAGE
+}
+pub const fn HEAPBLK_TO_MAPBYTE(x: u32) -> u32 {
+    (x % HEAPBLOCKS_PER_PAGE) / HEAPBLOCKS_PER_BYTE as u32
+}
+pub const fn HEAPBLK_TO_OFFSET(x: u32) -> u32 {
+    (x % HEAPBLOCKS_PER_BYTE as u32) * BITS_PER_HEAPBLOCK as u32
+}
+
+pub const BITS_PER_HEAPBLOCK: u16 = 2;
+pub const VISIBILITYMAP_ALL_VISIBLE: u8 = 0x01;
+pub const VISIBILITYMAP_ALL_FROZEN: u8 = 0x02;
+pub const VISIBILITYMAP_VALID_BITS: u8 = 0x03;
 
 // From xact.h
 pub const XLOG_XACT_COMMIT: u8 = 0x00;


### PR DESCRIPTION
Introduce the concept of a "ZenithWalRecord", which can be a Postgres WAL
record that is replayed with the Postgres WAL redo process, or a built-in
type that is handled entirely by pageserver code.

Replace the special code to replay Postgres XACT commit/abort records
with new Zenith WAL records. A separate zenith WAL record is created for
each modified CLOG page. This allows removing the 'main_data_offset'
field from stored PostgreSQL WAL records, which saves some memory and
some disk space in delta layers.

Introduce zenith WAL records for updating bits in the visibility map.
Previously, when e.g. a heap insert cleared the VM bit, we duplicated the
heap insert WAL record for the affected VM page. That was very wasteful.
The heap WAL record could be massive, containing a full page image in
the worst case. This addresses github issue #941.
