### PR TITLE
Use parking_lot::Mutex instead of std::Mutex in walreceiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "log",
  "nix",
  "once_cell",
+ "parking_lot",
  "postgres",
  "postgres-protocol",
  "postgres-types",

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -40,6 +40,7 @@ signal-hook = "0.3.10"
 url = "2"
 nix = "0.23"
 once_cell = "1.8.0"
+parking_lot = "0.11.2"
 
 rust-s3 = { version = "0.28", default-features = false, features = ["no-verify-ssl", "tokio-rustls-tls"] }
 async-compression = {version = "0.3", features = ["zstd", "tokio"]}

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -12,7 +12,7 @@ use crate::walingest::WalIngest;
 use crate::PageServerConf;
 use anyhow::{bail, Context, Error, Result};
 use lazy_static::lazy_static;
-use parking_lot::FairMutex;
+use parking_lot::Mutex;
 use postgres::fallible_iterator::FallibleIterator;
 use postgres::replication::ReplicationIter;
 use postgres::{Client, NoTls, SimpleQueryMessage, SimpleQueryRow};
@@ -41,8 +41,8 @@ struct WalReceiverEntry {
 }
 
 lazy_static! {
-    static ref WAL_RECEIVERS: FairMutex<HashMap<ZTimelineId, WalReceiverEntry>> =
-        FairMutex::new(HashMap::new());
+    static ref WAL_RECEIVERS: Mutex<HashMap<ZTimelineId, WalReceiverEntry>> =
+        Mutex::new(HashMap::new());
 }
 
 thread_local! {


### PR DESCRIPTION
Making progress towards https://github.com/zenithdb/zenith/issues/956

Note that `parking_lot` mutexes don't poison. If a thread panics while holding a mutex, the mutex is **released**, without crashing the next thread to ask for it.
