### PR TITLE
Feature/proxy deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,27 @@ jobs:
             ansible-playbook .circleci/storage-redeploy.playbook.yml
             rm -f zenith_install.tar.gz
 
+  deploy-staging-proxy:
+    docker:
+      - image: cimg/base:2021.04
+    environment:
+      KUBECONFIG: .kubeconfig
+    steps:
+      - checkout
+      - run:
+          name: Store kubeconfig file
+          command: echo "${STAGING_KUBECONFIG_DATA}" | base64 --decode >.kubeconfig
+      - run:
+          name: Setup helm v3
+          command: |
+            curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+            helm repo add zenithdb https://zenithdb.github.io/helm-charts
+      - run:
+          name: Re-deploy proxy
+          command: |
+            DOCKER_TAG=$(git log --oneline|wc -l)
+            helm upgrade zenith-proxy zenithdb/zenith-proxy --install -f proxy.staging.yaml --set image.tag=${DOCKER_TAG} --wait
+
   # Trigger a new remote CI job
   remote-ci-trigger:
     docker:
@@ -595,6 +616,7 @@ workflows:
             branches:
               only:
                 - main
+                - feature/proxy-deploy
           requires:
             - pg_regress-tests-release
             - other-tests-release
@@ -612,11 +634,20 @@ workflows:
       - deploy-staging:
           # Context gives an ability to login
           context: Docker Hub
-          # Build image only for commits to main
+          # deploy only for commits to main
           filters:
             branches:
               only:
                 - main
+          requires:
+            - docker-image
+      - deploy-staging-proxy:
+          # deploy only for commits to main
+          filters:
+            branches:
+              only:
+                - main
+                - feature/proxy-deploy
           requires:
             - docker-image
       - remote-ci-trigger:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,7 +504,9 @@ jobs:
       - checkout
       - run:
           name: Store kubeconfig file
-          command: echo "${STAGING_KUBECONFIG_DATA}" | base64 --decode >.kubeconfig
+          command: |
+            echo "${STAGING_KUBECONFIG_DATA}" | base64 --decode > ${KUBECONFIG}
+            chmod 0600 ${KUBECONFIG}
       - run:
           name: Setup helm v3
           command: |
@@ -514,7 +516,7 @@ jobs:
           name: Re-deploy proxy
           command: |
             DOCKER_TAG=$(git log --oneline|wc -l)
-            helm upgrade zenith-proxy zenithdb/zenith-proxy --install -f proxy.staging.yaml --set image.tag=${DOCKER_TAG} --wait
+            helm upgrade zenith-proxy zenithdb/zenith-proxy --install -f .circleci/proxy.staging.yaml --set image.tag=${DOCKER_TAG} --wait
 
   # Trigger a new remote CI job
   remote-ci-trigger:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -618,7 +618,6 @@ workflows:
             branches:
               only:
                 - main
-                - feature/proxy-deploy
           requires:
             - pg_regress-tests-release
             - other-tests-release
@@ -649,7 +648,6 @@ workflows:
             branches:
               only:
                 - main
-                - feature/proxy-deploy
           requires:
             - docker-image
       - remote-ci-trigger:

--- a/.circleci/proxy.staging.yaml
+++ b/.circleci/proxy.staging.yaml
@@ -1,0 +1,13 @@
+# Helm chart values for zenith-proxy.
+# This is a YAML-formatted file.
+
+settings:
+  authEndpoint: "https://console.stage.zenith.tech/authenticate_proxy_request/"
+  uri: "https://console.stage.zenith.tech/psql_session/"
+
+exposedService:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    external-dns.alpha.kubernetes.io/hostname: start.stage.zenith.tech


### PR DESCRIPTION
zenith proxy deployment for staging environment (staging kubernetes cluster)

this PR contains:
- zenith proxy helm chart deploy task in CircleCI
- values file for zenith proxy that automatically creates AWS NLB with DNS `start.stage.zenith.tech`
- proxy mgmt will be available from console at `zenith-proxy:7000` within Kubernetes

close #951 