### PR TITLE
[compute_tools] Switch cluster_id in spec to string

### DIFF
--- a/compute_tools/src/zenith.rs
+++ b/compute_tools/src/zenith.rs
@@ -37,7 +37,7 @@ pub struct ClusterSpec {
 /// like Rails web console.
 #[derive(Clone, Deserialize)]
 pub struct Cluster {
-    pub cluster_id: i64,
+    pub cluster_id: String,
     pub name: String,
     pub state: Option<String>,
     pub roles: Vec<Role>,

--- a/compute_tools/tests/cluster_spec.json
+++ b/compute_tools/tests/cluster_spec.json
@@ -5,7 +5,7 @@
     "operation_uuid": "0f657b36-4b0f-4a2d-9c2e-1dcd615e7d8b",
 
     "cluster": {
-        "cluster_id": 42,
+        "cluster_id": "test-cluster-42",
         "name": "Zenith Test",
         "state": "restarted",
         "roles": [


### PR DESCRIPTION
Compute part of the zenithdb/console#72