### PR TITLE
Generate safekeeper unique IDs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "postgres",
  "postgres-protocol",
  "postgres_ffi",
+ "rand",
  "regex",
  "routerify",
  "rust-s3",

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 hex = "0.4.3"
 const_format = "0.2.21"
 tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
+rand = "0.8.0"
 
 postgres_ffi = { path = "../postgres_ffi" }
 workspace_hack = { path = "../workspace_hack" }

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -1,4 +1,7 @@
-//
+use hex::FromHex;
+use hex::FromHexError;
+use rand::Rng;
+use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -68,3 +71,30 @@ impl Default for SafeKeeperConf {
         }
     }
 }
+
+/// Safekeeper unique 64 bit ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SafekeeperId(pub [u8; 8]);
+
+impl SafekeeperId {
+    pub fn generate() -> Self {
+        let mut tli_buf = [0u8; 8];
+        rand::thread_rng().fill(&mut tli_buf);
+        SafekeeperId(tli_buf)
+    }
+
+    pub fn from_slice<T: AsRef<[u8]>>(data: T) -> Result<Self, FromHexError> {
+        let decoded = <[u8; 8]>::from_hex(data)?;
+        Ok(Self(decoded))
+    }
+}
+
+// Display the ID as hex.
+impl fmt::Display for SafekeeperId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&hex::encode(self.0))
+    }
+}
+
+/// This safekeeper ID.
+pub static mut MY_ID: SafekeeperId = SafekeeperId([0u8; 8]);


### PR DESCRIPTION
Immediate goal is to distinguish neighbours in peer-to-peer communication, but
this is generally useful.