### PR TITLE
Do not block on pageserver's shutdown

### DIFF
--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -161,7 +161,8 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
         "Starting pageserver http handler on {}",
         conf.listen_http_addr
     );
-    let http_listener = tcp_listener::bind(conf.listen_http_addr.clone())?;
+    let http_listener =
+        tcp_listener::to_blocking_listener(tcp_listener::bind(conf.listen_http_addr.clone())?)?;
 
     info!(
         "Starting pageserver pg protocol handler on {}",

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -9,7 +9,10 @@ use anyhow::bail;
 use clap::{App, Arg};
 use state::{ProxyConfig, ProxyState};
 use std::thread;
-use zenith_utils::{tcp_listener, GIT_VERSION};
+use zenith_utils::{
+    tcp_listener::{self, to_blocking_listener},
+    GIT_VERSION,
+};
 
 mod cplane_api;
 mod mgmt;
@@ -102,10 +105,10 @@ fn main() -> anyhow::Result<()> {
         // for each connection.
         thread::Builder::new()
             .name("Listener thread".into())
-            .spawn(move || proxy::thread_main(state, pageserver_listener))?,
+            .spawn(move || proxy::thread_main(state, to_blocking_listener(pageserver_listener)?))?,
         thread::Builder::new()
             .name("Mgmt thread".into())
-            .spawn(move || mgmt::thread_main(state, mgmt_listener))?,
+            .spawn(move || mgmt::thread_main(state, to_blocking_listener(mgmt_listener)?))?,
     ];
 
     for t in threads {

--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -137,16 +137,20 @@ fn start_safekeeper(conf: SafeKeeperConf) -> Result<()> {
         )
     })?;
 
-    let http_listener = tcp_listener::bind(conf.listen_http_addr.clone()).map_err(|e| {
-        error!("failed to bind to address {}: {}", conf.listen_http_addr, e);
-        e
-    })?;
+    let http_listener = tcp_listener::to_blocking_listener(
+        tcp_listener::bind(conf.listen_http_addr.clone()).map_err(|e| {
+            error!("failed to bind to address {}: {}", conf.listen_http_addr, e);
+            e
+        })?,
+    )?;
 
     info!("Starting safekeeper on {}", conf.listen_pg_addr);
-    let pg_listener = tcp_listener::bind(conf.listen_pg_addr.clone()).map_err(|e| {
-        error!("failed to bind to address {}: {}", conf.listen_pg_addr, e);
-        e
-    })?;
+    let pg_listener = tcp_listener::to_blocking_listener(
+        tcp_listener::bind(conf.listen_pg_addr.clone()).map_err(|e| {
+            error!("failed to bind to address {}: {}", conf.listen_pg_addr, e);
+            e
+        })?,
+    )?;
 
     // XXX: Don't spawn any threads before daemonizing!
     if conf.daemonize {

--- a/zenith_utils/src/tcp_listener.rs
+++ b/zenith_utils/src/tcp_listener.rs
@@ -1,16 +1,19 @@
-use std::{
-    io,
+use tokio::{
     net::{TcpListener, ToSocketAddrs},
-    os::unix::prelude::AsRawFd,
+    runtime,
 };
 
-use nix::sys::socket::{setsockopt, sockopt::ReuseAddr};
+lazy_static::lazy_static! {
+    static ref RUNTIME: runtime::Runtime = runtime::Builder::new_current_thread().enable_all().build().unwrap();
+}
 
-/// Bind a [`TcpListener`] to addr with `SO_REUSEADDR` set to true.
-pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {
-    let listener = TcpListener::bind(addr)?;
+/// Bind a [`TcpListener`] to addr with `SO_REUSEADDR` set to true (done implicitly in tokio).
+pub fn bind<A: ToSocketAddrs>(addr: A) -> std::io::Result<TcpListener> {
+    RUNTIME.block_on(TcpListener::bind(addr))
+}
 
-    setsockopt(listener.as_raw_fd(), ReuseAddr, &true)?;
-
-    Ok(listener)
+pub fn to_blocking_listener(tokio_listener: TcpListener) -> std::io::Result<std::net::TcpListener> {
+    let std_listener = tokio_listener.into_std()?;
+    std_listener.set_nonblocking(false)?;
+    Ok(std_listener)
 }


### PR DESCRIPTION
Part of https://github.com/zenithdb/zenith/issues/1036
I think I'll be able to cover the rest of the cases in a similar manner, but I'd like to discuss it a bit first.
Note that the current PR's base is https://github.com/zenithdb/zenith/pull/1079 to reuse a fraction of its code, but I can move over that particular commit I need from that PR here. Here's the commit I need from there: https://github.com/zenithdb/zenith/pull/1079/commits/a0c896dae85302373bff2d5203076e011ea694e2

I'm also not sure how to write tests on that: the case I've fixed now is very easy to reproduce manually: you have to launch  a single pageserver only (no safekeepers or anything else, just the pageserver) and try to terminate it.
I've tested it manually and can confirm that this termination now blocks on current `main` and does not on my PR.

------------

Reuses the same `join!` approach used in https://github.com/zenithdb/zenith/pull/1079 to force the pageserver to be able to react on external signals, while it waits for certain blocking things like `accept()`.

For the rest of the code, `tokio` `TcpListener` is returned now, requiring additional step to convert it back to a sync version (also added) in the places where it's needed still.
This way, we're able to use async in the places where we really benefit from it, without rewriting everything to async.

Also to note, safekeeper uses similar approach with `tokio::oneshot` channel. Yet, it does not implement `Clone` and we need to unblock pageserver in more than one place, so I did not use that.
