### PR TITLE
Add safekeeper --dump-control-file option.

### DIFF
--- a/walkeeper/src/bin/safekeeper.rs
+++ b/walkeeper/src/bin/safekeeper.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::thread;
 use tracing::*;
+use walkeeper::timeline::{CreateControlFile, FileStorage};
 use zenith_utils::http::endpoint;
 use zenith_utils::{logging, tcp_listener, GIT_VERSION};
 
@@ -86,7 +87,20 @@ fn main() -> Result<()> {
                 .takes_value(false)
                 .help("Do not wait for changes to be written safely to disk"),
         )
+        .arg(
+            Arg::with_name("dump-control-file")
+                .long("dump-control-file")
+                .takes_value(true)
+                .help("Dump control file at path specifed by this argument and exit"),
+        )
         .get_matches();
+
+    if let Some(addr) = arg_matches.value_of("dump-control-file") {
+        let state = FileStorage::load_control_file(Path::new(addr), CreateControlFile::False)?;
+        let json = serde_json::to_string(&state)?;
+        print!("{}", json);
+        return Ok(());
+    }
 
     let mut conf: SafeKeeperConf = Default::default();
 

--- a/walkeeper/src/upgrade.rs
+++ b/walkeeper/src/upgrade.rs
@@ -5,7 +5,12 @@ use crate::safekeeper::{
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use tracing::*;
-use zenith_utils::{bin_ser::LeSer, lsn::Lsn};
+use zenith_utils::{
+    bin_ser::LeSer,
+    lsn::Lsn,
+    pq_proto::SystemId,
+    zid::{ZTenantId, ZTimelineId},
+};
 
 /// Persistent consensus state of the acceptor.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +40,36 @@ struct SafeKeeperStateV1 {
     wal_start_lsn: Lsn,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServerInfoV2 {
+    /// Postgres server version
+    pub pg_version: u32,
+    pub system_id: SystemId,
+    pub tenant_id: ZTenantId,
+    /// Zenith timelineid
+    pub ztli: ZTimelineId,
+    pub wal_seg_size: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SafeKeeperStateV2 {
+    /// persistent acceptor state
+    pub acceptor_state: AcceptorState,
+    /// information about server
+    pub server: ServerInfoV2,
+    /// Unique id of the last *elected* proposer we dealed with. Not needed
+    /// for correctness, exists for monitoring purposes.
+    pub proposer_uuid: PgUuid,
+    /// part of WAL acknowledged by quorum and available locally
+    pub commit_lsn: Lsn,
+    /// minimal LSN which may be needed for recovery of some safekeeper (end_lsn
+    /// of last record streamed to everyone)
+    pub truncate_lsn: Lsn,
+    // Safekeeper starts receiving WAL from this LSN, zeros before it ought to
+    // be skipped during decoding.
+    pub wal_start_lsn: Lsn,
+}
+
 pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState> {
     // migrate to storing full term history
     if version == 1 {
@@ -50,6 +85,25 @@ pub fn upgrade_control_file(buf: &[u8], version: u32) -> Result<SafeKeeperState>
         return Ok(SafeKeeperState {
             acceptor_state: ac,
             server: oldstate.server.clone(),
+            proposer_uuid: oldstate.proposer_uuid,
+            commit_lsn: oldstate.commit_lsn,
+            truncate_lsn: oldstate.truncate_lsn,
+            wal_start_lsn: oldstate.wal_start_lsn,
+        });
+    // migrate to hexing some zids
+    } else if version == 2 {
+        info!("reading safekeeper control file version {}", version);
+        let oldstate = SafeKeeperStateV2::des(&buf[..buf.len()])?;
+        let server = ServerInfo {
+            pg_version: oldstate.server.pg_version,
+            system_id: oldstate.server.system_id,
+            tenant_id: oldstate.server.tenant_id,
+            timeline_id: oldstate.server.ztli,
+            wal_seg_size: oldstate.server.wal_seg_size,
+        };
+        return Ok(SafeKeeperState {
+            acceptor_state: oldstate.acceptor_state,
+            server,
             proposer_uuid: oldstate.proposer_uuid,
             commit_lsn: oldstate.commit_lsn,
             truncate_lsn: oldstate.truncate_lsn,


### PR DESCRIPTION
Hexalize zids there for better output; since Serde doesn't support several
formats for one struct, on-disk representation is changed as well, make
upgrade.rs cope with it.