### PR TITLE
avoid duplication of timeline download tasks

### DIFF
--- a/pageserver/src/repository.rs
+++ b/pageserver/src/repository.rs
@@ -78,6 +78,7 @@ pub enum RepositoryTimeline {
         id: ZTimelineId,
         /// metadata contents of the latest successfully uploaded checkpoint
         disk_consistent_lsn: Lsn,
+        awaits_download: bool,
     },
 }
 


### PR DESCRIPTION
duplication can lead to timeline state become permanently invalid in
the following scenario:
 1. schedule download
 2. while download is not completed schedule another one
 3. first download completes and sets timeline state to Local/Ready
 4. duplicate task can fail and set state back to AwaitsDownload or
    Evicted if error persists

Error in the duplicate download can appear for example when there are
multiple checkpoint archives and after successful execution of the first
task second one will fail to apply checkpoints because they are older
than current tip of the branch.