### PR TITLE
Timeline IDs are not globally unique, fix some code that assumed that.

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -368,7 +368,7 @@ fn shutdown_timeline(
             timeline
                 .upload_relishes
                 .store(false, atomic::Ordering::Relaxed);
-            walreceiver::stop_wal_receiver(timeline_id);
+            walreceiver::stop_wal_receiver(tenant_id, timeline_id);
             trace!("repo shutdown. checkpoint timeline {}", timeline_id);
             // Do not reconstruct pages to reduce shutdown time
             timeline.checkpoint(CheckpointConfig::Flush)?;

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -594,7 +594,7 @@ impl postgres_backend::Handler for PageServerHandler {
             tenant_mgr::get_timeline_for_tenant(tenantid, timelineid)
                 .context("Failed to fetch local timeline for callmemaybe requests")?;
 
-            walreceiver::launch_wal_receiver(self.conf, timelineid, &connstr, tenantid.to_owned());
+            walreceiver::launch_wal_receiver(self.conf, tenantid, timelineid, &connstr);
 
             pgb.write_message_noflush(&BeMessage::CommandComplete(b"SELECT 1"))?;
         } else if query_string.starts_with("branch_create ") {


### PR DESCRIPTION
A timeline ID is only guaranteed to be unique for a particular tenant,
so you need to use tenant ID + timeline ID as the key, rather than just
timeline ID.

The safekeeper currently makes the same assumption, and we should fix that
too, but this commit just addresses this one case in the page server.

In the passing, reorder some function arguments to be more consistent.