### PR TITLE
Prefix per-cluster directory with ztenant_id in safekeeper.

### DIFF
--- a/walkeeper/src/handler.rs
+++ b/walkeeper/src/handler.rs
@@ -16,7 +16,7 @@ use zenith_utils::lsn::Lsn;
 use zenith_utils::postgres_backend;
 use zenith_utils::postgres_backend::PostgresBackend;
 use zenith_utils::pq_proto::{BeMessage, FeStartupPacket, RowDescriptor, INT4_OID, TEXT_OID};
-use zenith_utils::zid::{ZTenantId, ZTimelineId};
+use zenith_utils::zid::{ZTenantId, ZTenantTimelineId, ZTimelineId};
 
 use crate::callmemaybe::CallmeEvent;
 use crate::timeline::CreateControlFile;
@@ -116,8 +116,11 @@ impl postgres_backend::Handler for SafekeeperPostgresHandler {
                         | SafekeeperPostgresCommand::JSONCtrl { .. } => CreateControlFile::True,
                         _ => CreateControlFile::False,
                     };
-                    self.timeline
-                        .set(&self.conf, tenantid, timelineid, create_control_file)?;
+                    self.timeline.set(
+                        &self.conf,
+                        ZTenantTimelineId::new(tenantid, timelineid),
+                        create_control_file,
+                    )?;
                 }
             }
         }

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -2,7 +2,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use zenith_utils::zid::ZTimelineId;
+use zenith_utils::zid::ZTenantTimelineId;
 
 pub mod callmemaybe;
 pub mod handler;
@@ -47,8 +47,10 @@ pub struct SafeKeeperConf {
 }
 
 impl SafeKeeperConf {
-    pub fn timeline_dir(&self, timelineid: &ZTimelineId) -> PathBuf {
-        self.workdir.join(timelineid.to_string())
+    pub fn timeline_dir(&self, zttid: &ZTenantTimelineId) -> PathBuf {
+        self.workdir
+            .join(zttid.tenant_id.to_string())
+            .join(zttid.timeline_id.to_string())
     }
 }
 

--- a/walkeeper/src/receive_wal.rs
+++ b/walkeeper/src/receive_wal.rs
@@ -105,7 +105,7 @@ impl<'pg> ReceiveWalConn<'pg> {
                 // Need to establish replication channel with page server.
                 // Add far as replication in postgres is initiated by receiver
                 // we should use callmemaybe mechanism.
-                let timeline_id = spg.timeline.get().timeline_id;
+                let timeline_id = spg.timeline.get().zttid.timeline_id;
                 let subscription_key = SubscriptionStateKey::new(
                     tenant_id,
                     timeline_id,

--- a/zenith_utils/src/zid.rs
+++ b/zenith_utils/src/zid.rs
@@ -195,6 +195,32 @@ pub mod opt_display_serde {
     }
 }
 
+// A pair uniquely identifying Zenith instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ZTenantTimelineId {
+    pub tenant_id: ZTenantId,
+    pub timeline_id: ZTimelineId,
+}
+
+impl ZTenantTimelineId {
+    pub fn new(tenant_id: ZTenantId, timeline_id: ZTimelineId) -> Self {
+        ZTenantTimelineId {
+            tenant_id,
+            timeline_id,
+        }
+    }
+
+    pub fn generate() -> Self {
+        Self::new(ZTenantId::generate(), ZTimelineId::generate())
+    }
+}
+
+impl fmt::Display for ZTenantTimelineId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}-{}", self.tenant_id, self.timeline_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::Display;


### PR DESCRIPTION
Currently ztimelineids are unique, but all APIs accept the pair, so let's keep
it everywhere for uniformity.

Carry around ZClusterId containing both ZTenantId and ZTimelineId for
simplicity.

(existing clusters on staging ought to be preprocessed for that)