### PR TITLE
Include backtrace in error messages in the log.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +55,9 @@ name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "async-compression"
@@ -147,6 +165,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2884b8f2aaeb4a4bf80b219b4fe1d340139ca9331679c57e0fd4a24f571a78bd"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -656,6 +689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
 name = "git-version"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,6 +1088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1191,15 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1652,6 +1710,12 @@ dependencies = [
  "tokio-stream",
  "url",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hash"

--- a/pageserver/Cargo.toml
+++ b/pageserver/Cargo.toml
@@ -24,7 +24,7 @@ postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbf
 tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858" }
 tokio-stream = "0.1.8"
 routerify = "2"
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 crc32c = "0.6.0"
 thiserror = "1.0"
 hex = { version = "0.4.3", features = ["serde"] }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -201,7 +201,7 @@ pub fn thread_main(
             .name("serving Page Service thread".into())
             .spawn(move || {
                 if let Err(err) = page_service_conn_main(conf, local_auth, socket, auth_type) {
-                    error!(%err, "page server thread exited with error");
+                    error!("page server thread exited with error: {:?}", err);
                 }
             })
             .unwrap();
@@ -320,7 +320,7 @@ impl PageServerHandler {
                         let response = response.unwrap_or_else(|e| {
                             // print the all details to the log with {:#}, but for the client the
                             // error message is enough
-                            error!("error reading relation or page version: {:#}", e);
+                            error!("error reading relation or page version: {:?}", e);
                             PagestreamBeMessage::Error(PagestreamErrorResponse {
                                 message: e.to_string(),
                             })

--- a/pageserver/src/remote_storage.rs
+++ b/pageserver/src/remote_storage.rs
@@ -208,7 +208,7 @@ fn local_tenant_timeline_files(
                 }
             }
             Err(e) => error!(
-                "Failed to list tenants dir entry {:?} in directory {}, reason: {:#}",
+                "Failed to list tenants dir entry {:?} in directory {}, reason: {:?}",
                 tenants_dir_entry,
                 tenants_dir.display(),
                 e
@@ -249,14 +249,14 @@ fn collect_timelines_for_tenant(
                         );
                     }
                     Err(e) => error!(
-                        "Failed to process timeline dir contents at '{}', reason: {:#}",
+                        "Failed to process timeline dir contents at '{}', reason: {:?}",
                         timeline_path.display(),
                         e
                     ),
                 }
             }
             Err(e) => error!(
-                "Failed to list timelines for entry tenant {}, reason: {:#}",
+                "Failed to list timelines for entry tenant {}, reason: {:?}",
                 tenant_id, e
             ),
         }

--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -375,7 +375,7 @@ pub(super) fn spawn_storage_sync_thread<
             Ok(local_path) => Some(local_path),
             Err(e) => {
                 error!(
-                    "Failed to find local path for remote path {:?}: {:#}",
+                    "Failed to find local path for remote path {:?}: {:?}",
                     remote_path, e
                 );
                 None
@@ -507,7 +507,7 @@ async fn loop_step<
                 Ok(extra_step) => extra_step,
                 Err(e) => {
                     error!(
-                        "Failed to process storage sync task for tenant {}, timeline {}: {:#}",
+                        "Failed to process storage sync task for tenant {}, timeline {}: {:?}",
                         sync_id.0, sync_id.1, e
                     );
                     None

--- a/pageserver/src/remote_storage/storage_sync/download.rs
+++ b/pageserver/src/remote_storage/storage_sync/download.rs
@@ -80,7 +80,7 @@ pub(super) async fn download_timeline<
                 {
                     Ok(remote_timeline) => Cow::Owned(remote_timeline),
                     Err(e) => {
-                        error!("Failed to download full timeline index: {:#}", e);
+                        error!("Failed to download full timeline index: {:?}", e);
                         return match remote_disk_consistent_lsn {
                             Some(disk_consistent_lsn) => {
                                 sync_queue::push(SyncTask::new(
@@ -112,7 +112,7 @@ pub(super) async fn download_timeline<
 
     if let Err(e) = download_missing_branches(conf, remote_assets.as_ref(), sync_id.0).await {
         error!(
-            "Failed to download missing branches for sync id {}: {:#}",
+            "Failed to download missing branches for sync id {}: {:?}",
             sync_id, e
         );
         sync_queue::push(SyncTask::new(
@@ -150,7 +150,7 @@ pub(super) async fn download_timeline<
             Err(e) => {
                 let archives_left = archives_total - archives_downloaded;
                 error!(
-                    "Failed to download archive {:?} (archives downloaded: {}; archives left: {}) for tenant {} timeline {}, requeueing the download: {:#}",
+                    "Failed to download archive {:?} (archives downloaded: {}; archives left: {}) for tenant {} timeline {}, requeueing the download: {:?}",
                     archive_id, archives_downloaded, archives_left, tenant_id, timeline_id, e
                 );
                 sync_queue::push(SyncTask::new(
@@ -307,7 +307,7 @@ async fn download_missing_branches<
         while let Some(download_result) = remote_only_branches_downloads.next().await {
             if let Err(e) = download_result {
                 branch_downloads_failed = true;
-                error!("Failed to download a branch file: {:#}", e);
+                error!("Failed to download a branch file: {:?}", e);
             }
         }
         ensure!(

--- a/pageserver/src/remote_storage/storage_sync/upload.rs
+++ b/pageserver/src/remote_storage/storage_sync/upload.rs
@@ -43,7 +43,7 @@ pub(super) async fn upload_timeline_checkpoint<
     debug!("Uploading checkpoint for sync id {}", sync_id);
     if let Err(e) = upload_missing_branches(config, remote_assets.as_ref(), sync_id.0).await {
         error!(
-            "Failed to upload missing branches for sync id {}: {:#}",
+            "Failed to upload missing branches for sync id {}: {:?}",
             sync_id, e
         );
         sync_queue::push(SyncTask::new(
@@ -69,7 +69,7 @@ pub(super) async fn upload_timeline_checkpoint<
             match update_index_description(remote_assets.as_ref(), &timeline_dir, sync_id).await {
                 Ok(remote_timeline) => Some(Cow::Owned(remote_timeline)),
                 Err(e) => {
-                    error!("Failed to download full timeline index: {:#}", e);
+                    error!("Failed to download full timeline index: {:?}", e);
                     sync_queue::push(SyncTask::new(
                         sync_id,
                         retries,
@@ -132,7 +132,7 @@ pub(super) async fn upload_timeline_checkpoint<
         }
         Err(e) => {
             error!(
-                "Failed to upload checkpoint: {:#}, requeueing the upload",
+                "Failed to upload checkpoint: {:?}, requeueing the upload",
                 e
             );
             sync_queue::push(SyncTask::new(
@@ -253,7 +253,7 @@ async fn upload_missing_branches<
                 .await
                 .add_branch_file(tenant_id, local_only_branch.clone()),
             Err(e) => {
-                error!("Failed to upload branch file: {:#}", e);
+                error!("Failed to upload branch file: {:?}", e);
                 branch_uploads_failed = true;
             }
         }

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -79,7 +79,7 @@ pub fn set_timeline_states(
         });
         if let Err(e) = put_timelines_into_tenant(conf, tenant, tenant_id, timeline_states) {
             error!(
-                "Failed to update timeline states for tenant {}: {:#}",
+                "Failed to update timeline states for tenant {}: {:?}",
                 tenant_id, e
             );
         }

--- a/zenith_utils/src/http/error.rs
+++ b/zenith_utils/src/http/error.rs
@@ -69,7 +69,7 @@ impl HttpErrorBody {
 }
 
 pub async fn handler(err: routerify::RouteError) -> Response<Body> {
-    tracing::error!("{}", err);
+    tracing::error!("Error processing HTTP request: {:?}", err);
     err.downcast::<ApiError>()
         .expect("handler should always return api error")
         .into_response()


### PR DESCRIPTION
'anyhow' crate can include a backtrace in all errors, when the
'backtrace' feature is enabled. Enable it, and change the places that used
'{:#}' or '{}' to '{:?}', so that the backtrace is printed.