### PR TITLE
Use parking lot Mutex everywhere in pageserver

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -15,6 +15,7 @@ use anyhow::{anyhow, bail, ensure, Context, Result};
 use bookfile::Book;
 use bytes::Bytes;
 use lazy_static::lazy_static;
+use parking_lot::{Mutex, MutexGuard};
 use postgres_ffi::pg_constants::BLCKSZ;
 use tracing::*;
 
@@ -28,7 +29,7 @@ use std::io::Write;
 use std::ops::{Bound::Included, Deref};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{self, AtomicBool, AtomicUsize};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use self::metadata::{metadata_path, TimelineMetadata, METADATA_FILE_NAME};
@@ -142,7 +143,7 @@ pub struct LayeredRepository {
 /// Public interface
 impl Repository for LayeredRepository {
     fn get_timeline(&self, timelineid: ZTimelineId) -> Result<RepositoryTimeline> {
-        let mut timelines = self.timelines.lock().unwrap();
+        let mut timelines = self.timelines.lock();
         Ok(
             match self.get_or_init_timeline(timelineid, &mut timelines)? {
                 LayeredTimelineEntry::Local(local) => RepositoryTimeline::Local(local),
@@ -162,7 +163,7 @@ impl Repository for LayeredRepository {
         timelineid: ZTimelineId,
         initdb_lsn: Lsn,
     ) -> Result<Arc<dyn Timeline>> {
-        let mut timelines = self.timelines.lock().unwrap();
+        let mut timelines = self.timelines.lock();
 
         // Create the timeline directory, and write initial metadata to file.
         crashsafe_dir::create_dir_all(self.conf.timeline_path(&timelineid, &self.tenantid))?;
@@ -192,9 +193,9 @@ impl Repository for LayeredRepository {
         // We need to hold this lock to prevent GC from starting at the same time. GC scans the directory to learn
         // about timelines, so otherwise a race condition is possible, where we create new timeline and GC
         // concurrently removes data that is needed by the new timeline.
-        let _gc_cs = self.gc_cs.lock().unwrap();
+        let _gc_cs = self.gc_cs.lock();
 
-        let mut timelines = self.timelines.lock().unwrap();
+        let mut timelines = self.timelines.lock();
         let src_timeline = match self.get_or_init_timeline(src, &mut timelines)? {
             LayeredTimelineEntry::Local(timeline) => timeline,
             LayeredTimelineEntry::Remote { .. } => {
@@ -263,7 +264,7 @@ impl Repository for LayeredRepository {
         // while holding the lock. Then drop the lock and actually perform the
         // checkpoints.  We don't want to block everything else while the
         // checkpoint runs.
-        let timelines = self.timelines.lock().unwrap();
+        let timelines = self.timelines.lock();
         let timelines_to_checkpoint = timelines
             .iter()
             .map(|(timelineid, timeline)| (*timelineid, timeline.clone()))
@@ -294,7 +295,7 @@ impl Repository for LayeredRepository {
         timeline_id: ZTimelineId,
         new_state: TimelineSyncState,
     ) -> Result<()> {
-        let mut timelines_accessor = self.timelines.lock().unwrap();
+        let mut timelines_accessor = self.timelines.lock();
 
         match new_state {
             TimelineSyncState::Ready(_) => {
@@ -326,7 +327,7 @@ impl Repository for LayeredRepository {
     /// [`TimelineSyncState::Evicted`] and other non-local and non-remote states are not stored in the layered repo at all,
     /// hence their statuses cannot be returned by the repo.
     fn get_timeline_state(&self, timeline_id: ZTimelineId) -> Option<TimelineSyncState> {
-        let timelines_accessor = self.timelines.lock().unwrap();
+        let timelines_accessor = self.timelines.lock();
         let timeline_entry = timelines_accessor.get(&timeline_id)?;
         Some(
             if timeline_entry
@@ -544,9 +545,9 @@ impl LayeredRepository {
         let now = Instant::now();
 
         // grab mutex to prevent new timelines from being created here.
-        let _gc_cs = self.gc_cs.lock().unwrap();
+        let _gc_cs = self.gc_cs.lock();
 
-        let mut timelines = self.timelines.lock().unwrap();
+        let mut timelines = self.timelines.lock();
 
         // Scan all timelines. For each timeline, remember the timeline ID and
         // the branch point where it was created.
@@ -655,7 +656,7 @@ impl LayeredRepository {
                 let result = timeline.gc_timeline(branchpoints, cutoff)?;
 
                 totals += result;
-                timelines = self.timelines.lock().unwrap();
+                timelines = self.timelines.lock();
             }
         }
 
@@ -903,7 +904,7 @@ impl Timeline for LayeredTimeline {
         // We will filter dropped relishes below.
         //
         loop {
-            let rels = timeline.layers.lock().unwrap().list_relishes(tag, lsn)?;
+            let rels = timeline.layers.lock().list_relishes(tag, lsn)?;
 
             for (&new_relish, &new_relish_exists) in rels.iter() {
                 match all_relishes_map.entry(new_relish) {
@@ -1049,7 +1050,7 @@ impl Timeline for LayeredTimeline {
     fn writer<'a>(&'a self) -> Box<dyn TimelineWriter + 'a> {
         Box::new(LayeredTimelineWriter {
             tl: self,
-            _write_guard: self.write_lock.lock().unwrap(),
+            _write_guard: self.write_lock.lock(),
         })
     }
 
@@ -1110,7 +1111,7 @@ impl LayeredTimeline {
     /// Returns all timeline-related files that were found and loaded.
     ///
     fn load_layer_map(&self, disk_consistent_lsn: Lsn) -> anyhow::Result<()> {
-        let mut layers = self.layers.lock().unwrap();
+        let mut layers = self.layers.lock();
         let mut num_layers = 0;
 
         // Scan timeline directory and create ImageFileName and DeltaFilename
@@ -1208,7 +1209,7 @@ impl LayeredTimeline {
         seg: SegmentTag,
         lsn: Lsn,
     ) -> Result<Option<(Arc<dyn Layer>, Lsn)>> {
-        let self_layers = self.layers.lock().unwrap();
+        let self_layers = self.layers.lock();
         self.get_layer_for_read_locked(seg, lsn, &self_layers)
     }
 
@@ -1255,7 +1256,7 @@ impl LayeredTimeline {
         loop {
             let layers_owned: MutexGuard<LayerMap>;
             let layers = if self as *const LayeredTimeline != timeline as *const LayeredTimeline {
-                layers_owned = timeline.layers.lock().unwrap();
+                layers_owned = timeline.layers.lock();
                 &layers_owned
             } else {
                 self_layers
@@ -1311,7 +1312,7 @@ impl LayeredTimeline {
     /// Get a handle to the latest layer for appending.
     ///
     fn get_layer_for_write(&self, seg: SegmentTag, lsn: Lsn) -> Result<Arc<InMemoryLayer>> {
-        let mut layers = self.layers.lock().unwrap();
+        let mut layers = self.layers.lock();
 
         assert!(lsn.is_aligned());
 
@@ -1417,10 +1418,10 @@ impl LayeredTimeline {
     /// NOTE: This has nothing to do with checkpoint in PostgreSQL.
     fn checkpoint_internal(&self, checkpoint_distance: u64, reconstruct_pages: bool) -> Result<()> {
         // Prevent concurrent checkpoints
-        let _checkpoint_cs = self.checkpoint_cs.lock().unwrap();
+        let _checkpoint_cs = self.checkpoint_cs.lock();
 
-        let mut write_guard = self.write_lock.lock().unwrap();
-        let mut layers = self.layers.lock().unwrap();
+        let mut write_guard = self.write_lock.lock();
+        let mut layers = self.layers.lock();
 
         // Bump the generation number in the layer map, so that we can distinguish
         // entries inserted after the checkpoint started
@@ -1478,8 +1479,8 @@ impl LayeredTimeline {
             let mut this_layer_paths = self.evict_layer(oldest_layer_id, reconstruct_pages)?;
             layer_paths.append(&mut this_layer_paths);
 
-            write_guard = self.write_lock.lock().unwrap();
-            layers = self.layers.lock().unwrap();
+            write_guard = self.write_lock.lock();
+            layers = self.layers.lock();
         }
 
         // Call unload() on all frozen layers, to release memory.
@@ -1565,8 +1566,8 @@ impl LayeredTimeline {
         // We call `get_last_record_lsn` again, which may be different from the
         // original load, as we may have released the write lock since then.
 
-        let mut write_guard = self.write_lock.lock().unwrap();
-        let mut layers = self.layers.lock().unwrap();
+        let mut write_guard = self.write_lock.lock();
+        let mut layers = self.layers.lock();
 
         let mut layer_paths = Vec::new();
 
@@ -1586,8 +1587,8 @@ impl LayeredTimeline {
 
             let new_historics = oldest_layer.write_to_disk(self, reconstruct_pages)?;
 
-            write_guard = self.write_lock.lock().unwrap();
-            layers = self.layers.lock().unwrap();
+            write_guard = self.write_lock.lock();
+            layers = self.layers.lock();
 
             // Finally, replace the frozen in-memory layer with the new on-disk layers
             layers.remove_historic(oldest_layer);
@@ -1654,7 +1655,7 @@ impl LayeredTimeline {
         // 3. newer on-disk layer exists (only for non-dropped segments);
         // 4. this layer doesn't serve as a tombstone for some older layer;
         //
-        let mut layers = self.layers.lock().unwrap();
+        let mut layers = self.layers.lock();
         'outer: for l in layers.iter_historic_layers() {
             // This layer is in the process of being flushed to disk.
             // It will be swapped out of the layer map, replaced with

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -52,13 +52,13 @@ use serde::{Deserialize, Serialize};
 use zenith_utils::vec_map::VecMap;
 // avoid binding to Write (conflicts with std::io::Write)
 // while being able to use std::fmt::Write's methods
+use parking_lot::{Mutex, MutexGuard};
 use std::fmt::Write as _;
 use std::fs;
 use std::io::{BufWriter, Write};
 use std::ops::Bound::Included;
 use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
 
 use bookfile::{Book, BookWriter, BoundedReader, ChapterWriter};
 
@@ -317,7 +317,7 @@ impl Layer for DeltaLayer {
     /// it will need to be loaded back.
     ///
     fn unload(&self) -> Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         inner.page_version_metas = VecMap::default();
         inner.seg_sizes = VecMap::default();
         inner.loaded = false;
@@ -411,7 +411,7 @@ impl DeltaLayer {
     ///
     fn load(&self) -> Result<MutexGuard<DeltaLayerInner>> {
         // quick exit if already loaded
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         if inner.loaded {
             return Ok(inner);

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -32,12 +32,12 @@ use crate::{ZTenantId, ZTimelineId};
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use bytes::Bytes;
 use log::*;
+use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::fs;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard};
 
 use bookfile::{Book, BookWriter, ChapterWriter};
 
@@ -269,7 +269,7 @@ impl ImageLayer {
     ///
     fn load(&self) -> Result<MutexGuard<ImageLayerInner>> {
         // quick exit if already loaded
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
 
         if inner.book.is_some() {
             return Ok(inner);

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -12,10 +12,11 @@ use crate::CheckpointConfig;
 use anyhow::{anyhow, bail, Context, Result};
 use lazy_static::lazy_static;
 use log::*;
+use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map, HashMap};
 use std::fmt;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 use zenith_utils::zid::{ZTenantId, ZTimelineId};
 
 lazy_static! {
@@ -54,7 +55,7 @@ impl fmt::Display for TenantState {
 }
 
 fn access_tenants() -> MutexGuard<'static, HashMap<ZTenantId, Tenant>> {
-    TENANTS.lock().unwrap()
+    TENANTS.lock()
 }
 
 /// Updates tenants' repositories, changing their timelines state in memory.

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -23,6 +23,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use lazy_static::lazy_static;
 use log::*;
 use nix::poll::*;
+use parking_lot::Mutex;
 use serde::Serialize;
 use std::fs;
 use std::fs::OpenOptions;
@@ -32,7 +33,6 @@ use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
-use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 use zenith_metrics::{register_histogram, register_int_counter, Histogram, IntCounter};
@@ -266,7 +266,7 @@ impl PostgresRedoManager {
 
         let apply_result: Result<Bytes, Error>;
 
-        let mut process_guard = self.process.lock().unwrap();
+        let mut process_guard = self.process.lock();
         let lock_time = Instant::now();
 
         // launch the WAL redo process on first use


### PR DESCRIPTION
Closes https://github.com/zenithdb/zenith/issues/956

Note that the task asks to use `parking_lot::RwLock`, but I'm against using it after trying it out due to 

https://docs.rs/parking_lot/0.11.2/parking_lot/type.RwLock.html
> This lock uses a task-fair locking policy which avoids both reader and writer starvation. This means that readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock. Because of this, attempts to recursively acquire a read lock within a single thread may result in a deadlock.

We actually do deadlock if simply replace our code imports to use `paking_lot::RwLock` and related: https://github.com/zenithdb/zenith/pull/1111

We use `RwLock` relatively rare and removing `unwrap()`'s at cost of possible subtle bugs does not seem exciting enough for me to try to narrow down the issue to a particular module.
At a quick glance at the thread traces of the locally stuck pageserver, the application gets stuck at `inmemory_layer.rs` code, it's reproducible with the `test_branch_behind` test.