### PR TITLE
remove incorrect check in get_page_at_lsn

### DIFF
--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -461,7 +461,7 @@ impl PageServerHandler {
             .context("Cannot handle basebackup request for a remote timeline")?;
         if let Some(lsn) = lsn {
             timeline
-                .check_lsn_is_in_scope(lsn)
+                .check_lsn_is_in_pitr_interval(lsn)
                 .context("invalid basebackup lsn")?;
         }
 


### PR DESCRIPTION
because it is not an error to request pages older than latest_gc_cutoff

Mentioned [here](https://github.com/zenithdb/zenith/issues/1122#issuecomment-1012975852) and [here](https://github.com/zenithdb/zenith/issues/1047#issuecomment-1013100568)