### PR TITLE
Do not write full page images at each checkpoint

### DIFF
--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1612,6 +1612,7 @@ impl LayeredTimeline {
         let global_layer_map = GLOBAL_LAYER_MAP.read().unwrap();
         if let Some(oldest_layer) = global_layer_map.get(&layer_id) {
             let last_lsn = self.get_last_record_lsn();
+            // Count number of layers only if we nned this information: when creation of image layer was not prohibited
             let n_delta_layers = if reconstruct_pages {
                 layers.count_delta_layers(oldest_layer.get_seg_tag(), last_lsn)
             } else {

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -1613,7 +1613,10 @@ impl LayeredTimeline {
         if let Some(oldest_layer) = global_layer_map.get(&layer_id) {
             let last_lsn = self.get_last_record_lsn();
             // Avoid creation of image layers if there are not so much deltas
-            if reconstruct_pages && oldest_layer.get_seg_tag().rel.is_blocky() {
+            if reconstruct_pages
+                && oldest_layer.get_seg_tag().rel.is_blocky()
+                && self.conf.image_layer_generation_threshold != 0
+            {
                 let (n_delta_layers, total_delta_size) =
                     layers.count_delta_layers(oldest_layer.get_seg_tag(), last_lsn)?;
                 let logical_segment_size =

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -161,6 +161,14 @@ pub struct DeltaLayerInner {
 }
 
 impl DeltaLayerInner {
+    fn get_physical_size(&self) -> Result<u64> {
+        Ok(if let Some(book) = &self.book {
+            book.chapter_reader(PAGE_VERSIONS_CHAPTER)?.len()
+        } else {
+            0
+        })
+    }
+
     fn get_seg_size(&self, lsn: Lsn) -> Result<SegmentBlk> {
         // Scan the VecMap backwards, starting from the given entry.
         let slice = self
@@ -287,6 +295,12 @@ impl Layer for DeltaLayer {
         } else {
             Ok(PageReconstructResult::Complete)
         }
+    }
+
+    // Get physical size of the layer
+    fn get_physical_size(&self) -> Result<u64> {
+        // TODO: is it actually necessary to load layer to get it's size?
+        self.load()?.get_physical_size()
     }
 
     /// Get size of the relation at given LSN

--- a/pageserver/src/layered_repository/ephemeral_file.rs
+++ b/pageserver/src/layered_repository/ephemeral_file.rs
@@ -41,7 +41,7 @@ pub struct EphemeralFile {
     _timelineid: ZTimelineId,
     file: Arc<VirtualFile>,
 
-    pos: u64,
+    pub pos: u64,
 }
 
 impl EphemeralFile {

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -201,6 +201,11 @@ impl Layer for ImageLayer {
         }
     }
 
+    // Get physical size of the layer
+    fn get_physical_size(&self) -> Result<u64> {
+        Ok(self.get_seg_size(Lsn(0))? as u64 * BLOCK_SIZE as u64)
+    }
+
     /// Does this segment exist at given LSN?
     fn get_seg_exists(&self, _lsn: Lsn) -> Result<bool> {
         Ok(true)

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -28,6 +28,8 @@ use zenith_utils::vec_map::VecMap;
 
 use super::page_versions::PageVersions;
 
+// The garbage collector needs image layers in order to delete files.
+// If this number is too large it can result in too many small files on disk.
 const MAX_DELTA_LAYERS: usize = 10;
 
 pub struct InMemoryLayer {
@@ -626,7 +628,7 @@ impl InMemoryLayer {
                     > inner.page_versions.size() * 2
                 && n_delta_layers < MAX_DELTA_LAYERS)
         {
-            // The segment was dropped. Create just a delta layer containing all the
+            // Create just a delta layer containing all the
             // changes up to and including the drop.
             delta_end_lsn = Some(end_lsn_exclusive);
             image_lsn = None;

--- a/pageserver/src/layered_repository/interval_tree.rs
+++ b/pageserver/src/layered_repository/interval_tree.rs
@@ -249,7 +249,7 @@ where
         loop {
             // Return next remaining element from the current point
             if let Some((point_key, elem_iter)) = &mut self.elem_iter {
-                for elem in elem_iter {
+                while let Some(elem) = elem_iter.next_back() {
                     if elem.start_key() == *point_key {
                         return Some(Arc::clone(elem));
                     }

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -328,6 +328,8 @@ impl SegEntry {
             .any(|layer| !layer.is_incremental())
     }
 
+    // Count number of delta layers preceeding specified `lsn`.
+    // Perform backward iteration from exclusive upper bound until image layer is reached.
     pub fn count_delta_layers(&self, lsn: Lsn) -> usize {
         let mut count: usize = 0;
         let mut iter = self.historic.iter_older(lsn);

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -199,6 +199,14 @@ impl LayerMap {
         }
     }
 
+    pub fn count_delta_layers(&self, seg: SegmentTag, lsn: Lsn) -> usize {
+        if let Some(segentry) = self.segs.get(&seg) {
+            segentry.count_delta_layers(lsn)
+        } else {
+            0
+        }
+    }
+
     /// Is there any layer for given segment that is alive at the lsn?
     ///
     /// This is a public wrapper for SegEntry fucntion,
@@ -318,6 +326,18 @@ impl SegEntry {
         self.historic
             .iter_newer(lsn)
             .any(|layer| !layer.is_incremental())
+    }
+
+    pub fn count_delta_layers(&self, lsn: Lsn) -> usize {
+        let mut count: usize = 0;
+        let mut iter = self.historic.iter_older(lsn);
+        while let Some(layer) = iter.next_back() {
+            if !layer.is_incremental() {
+                break;
+            }
+            count += 1;
+        }
+        count
     }
 
     // Set new open layer for a SegEntry.

--- a/pageserver/src/layered_repository/page_versions.rs
+++ b/pageserver/src/layered_repository/page_versions.rs
@@ -39,6 +39,10 @@ impl PageVersions {
         }
     }
 
+    pub fn size(&self) -> u64 {
+        self.file.pos
+    }
+
     pub fn append_or_update_last(
         &mut self,
         blknum: u32,

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -154,11 +154,14 @@ pub trait Layer: Send + Sync {
         reconstruct_data: &mut PageReconstructData,
     ) -> Result<PageReconstructResult>;
 
-    /// Return size of the segment at given LSN. (Only for blocky relations.)
+    /// Return logical size of the segment at given LSN. (Only for blocky relations.)
     fn get_seg_size(&self, lsn: Lsn) -> Result<SegmentBlk>;
 
     /// Does the segment exist at given LSN? Or was it dropped before it.
     fn get_seg_exists(&self, lsn: Lsn) -> Result<bool>;
+
+    // Get physical size of the layer
+    fn get_physical_size(&self) -> Result<u64>;
 
     /// Does this layer only contain some data for the segment (incremental),
     /// or does it contain a version of every page? This is important to know

--- a/test_runner/batch_others/test_snapfiles_gc.py
+++ b/test_runner/batch_others/test_snapfiles_gc.py
@@ -66,8 +66,8 @@ def test_layerfiles_gc(zenith_simple_env: ZenithEnv):
                     pscur.execute(f"do_gc {env.initial_tenant} {timeline} 0")
                     row = pscur.fetchone()
                     print_gc_result(row)
-                    assert row['layer_relfiles_total'] == layer_relfiles_remain + 2
-                    assert row['layer_relfiles_removed'] == 2
+                    assert row['layer_relfiles_total'] == layer_relfiles_remain + 1
+                    assert row['layer_relfiles_removed'] == 0
                     assert row['layer_relfiles_dropped'] == 0
 
                     # Insert two more rows and run GC.
@@ -81,7 +81,7 @@ def test_layerfiles_gc(zenith_simple_env: ZenithEnv):
                     row = pscur.fetchone()
                     print_gc_result(row)
                     assert row['layer_relfiles_total'] == layer_relfiles_remain + 2
-                    assert row['layer_relfiles_removed'] == 2
+                    assert row['layer_relfiles_removed'] == 0
                     assert row['layer_relfiles_dropped'] == 0
 
                     # Do it again. Should again create two new layer files and remove old ones.
@@ -92,8 +92,8 @@ def test_layerfiles_gc(zenith_simple_env: ZenithEnv):
                     pscur.execute(f"do_gc {env.initial_tenant} {timeline} 0")
                     row = pscur.fetchone()
                     print_gc_result(row)
-                    assert row['layer_relfiles_total'] == layer_relfiles_remain + 2
-                    assert row['layer_relfiles_removed'] == 2
+                    assert row['layer_relfiles_total'] == layer_relfiles_remain + 3
+                    assert row['layer_relfiles_removed'] == 0
                     assert row['layer_relfiles_dropped'] == 0
 
                     # Run GC again, with no changes in the database. Should not remove anything.
@@ -101,7 +101,7 @@ def test_layerfiles_gc(zenith_simple_env: ZenithEnv):
                     pscur.execute(f"do_gc {env.initial_tenant} {timeline} 0")
                     row = pscur.fetchone()
                     print_gc_result(row)
-                    assert row['layer_relfiles_total'] == layer_relfiles_remain
+                    assert row['layer_relfiles_total'] == layer_relfiles_remain + 3
                     assert row['layer_relfiles_removed'] == 0
                     assert row['layer_relfiles_dropped'] == 0
 
@@ -121,9 +121,7 @@ def test_layerfiles_gc(zenith_simple_env: ZenithEnv):
                     # Each relation fork is counted separately, hence 3.
                     assert row['layer_relfiles_needed_as_tombstone'] == 3
 
-                    # The catalog updates also create new layer files of the catalogs, which
-                    # are counted as 'removed'
-                    assert row['layer_relfiles_removed'] > 0
+                    assert row['layer_relfiles_removed'] == 0
 
                     # TODO Change the test to check actual CG of dropped layers.
                     # Each relation fork is counted separately, hence 3.


### PR DESCRIPTION
See #1076 
Closes https://github.com/zenithdb/zenith/pull/1133
If we store image layer at each checkpoint, then we get huge write amplification.
If we postpone creation of image layers, then we get very large number of small delta layer files
(100 iterations of my test_write_amplification produce 600k files and just removing them takes 10 minutes).

So I try to propose some compromise approach which delay creation of image layers is total size of wal records in this inmem layer is small (right now < half of segment size) and number of delta layers is smaller than some threshold (right now hardcoded 10, which restrict total number of files for 100Gb relation by 100k).
