### PR TITLE
Use `&str` instead of `String` in `BeMessage::ErrorResponse`

### DIFF
--- a/proxy/src/mgmt.rs
+++ b/proxy/src/mgmt.rs
@@ -111,7 +111,7 @@ fn try_process_query(
                 .write_message(&BeMessage::CommandComplete(b"SELECT 1"))?;
         }
         Err(e) => {
-            pgb.write_message(&BeMessage::ErrorResponse(e.to_string()))?;
+            pgb.write_message(&BeMessage::ErrorResponse(&e.to_string()))?;
         }
     }
 

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -152,7 +152,7 @@ impl ProxyConnection {
             Ok(None) => return Ok(None),
             Err(e) => {
                 // Report the error to the client
-                self.pgb.write_message(&Be::ErrorResponse(e.to_string()))?;
+                self.pgb.write_message(&Be::ErrorResponse(&e.to_string()))?;
                 bail!("failed to handle client: {:?}", e);
             }
         };

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -367,7 +367,7 @@ pub enum BeMessage<'a> {
     CloseComplete,
     // None means column is NULL
     DataRow(&'a [Option<&'a [u8]>]),
-    ErrorResponse(String),
+    ErrorResponse(&'a str),
     // single byte - used in response to SSLRequest/GSSENCRequest
     EncryptionResponse(bool),
     NoData,


### PR DESCRIPTION
There's no need in allocating string literals in the heap.