### PR TITLE
Disable failing remote storage tests for now

### DIFF
--- a/test_runner/batch_others/test_remote_storage.py
+++ b/test_runner/batch_others/test_remote_storage.py
@@ -28,6 +28,7 @@ pytest_plugins = ("fixtures.zenith_fixtures")
 #   * queries the specific data, ensuring that it matches the one stored before
 #
 # The tests are done for all types of remote storage pageserver supports.
+@pytest.mark.skip(reason="will be fixed with https://github.com/zenithdb/zenith/issues/1193")
 @pytest.mark.parametrize('storage_type', ['local_fs', 'mock_s3'])
 def test_remote_storage_backup_and_restore(zenith_env_builder: ZenithEnvBuilder, storage_type: str):
     zenith_env_builder.rust_log_override = 'debug'

--- a/test_runner/batch_others/test_tenant_relocation.py
+++ b/test_runner/batch_others/test_tenant_relocation.py
@@ -114,6 +114,7 @@ def assert_local(pageserver_http_client: ZenithPageserverHttpClient, tenant: str
     return timeline_detail
 
 
+@pytest.mark.skip(reason="will be fixed with https://github.com/zenithdb/zenith/issues/1193")
 @pytest.mark.parametrize('with_load', ['with_load', 'without_load'])
 def test_tenant_relocation(zenith_env_builder: ZenithEnvBuilder,
                            port_distributor: PortDistributor,


### PR DESCRIPTION
Having disabled tests is sad, but while it takes some time for us to improve the shared index thus fixing https://github.com/zenithdb/zenith/issues/1193.

For now, it feels like it's better to silence both tests and not confuse others with these particular failures.