### PR TITLE
Fix safekeeper LSN metrics

### DIFF
--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -653,6 +653,7 @@ where
         }
         // update our end of WAL pointer
         self.flush_lsn = msg.start_streaming_at;
+        self.metrics.flush_lsn.set(u64::from(self.flush_lsn) as f64);
         // and now adopt term history from proposer
         self.s.acceptor_state.term_history = msg.term_history.clone();
         self.storage.persist(&self.s)?;

--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -455,16 +455,14 @@ struct SafeKeeperMetrics {
 }
 
 struct SafeKeeperMetricsBuilder {
-    ztli: Option<ZTimelineId>,
+    ztli: ZTimelineId,
     flush_lsn: Lsn,
     commit_lsn: Lsn,
 }
 
 impl SafeKeeperMetricsBuilder {
     fn build(self) -> SafeKeeperMetrics {
-        let ztli_str = self
-            .ztli
-            .map_or("n/a".to_string(), |ztli| format!("{}", ztli));
+        let ztli_str = format!("{}", self.ztli);
         let m = SafeKeeperMetrics {
             flush_lsn: FLUSH_LSN_GAUGE.with_label_values(&[&ztli_str]),
             commit_lsn: COMMIT_LSN_GAUGE.with_label_values(&[&ztli_str]),
@@ -512,7 +510,7 @@ where
         SafeKeeper {
             flush_lsn,
             metrics: SafeKeeperMetricsBuilder {
-                ztli: Some(ztli),
+                ztli,
                 flush_lsn,
                 commit_lsn: state.commit_lsn,
             }
@@ -583,7 +581,7 @@ where
             .context("failed to persist shared state")?;
 
         self.metrics = SafeKeeperMetricsBuilder {
-            ztli: Some(self.s.server.timeline_id),
+            ztli: self.s.server.timeline_id,
             flush_lsn: self.flush_lsn,
             commit_lsn: self.commit_lsn,
         }

--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -502,10 +502,10 @@ where
         storage: ST,
         state: SafeKeeperState,
     ) -> SafeKeeper<ST> {
-        if state.server.timeline_id != ZTimelineId::from([0u8; 16]) {
-            if ztli != state.server.timeline_id {
-                panic!("Calling SafeKeeper::new with inconsistent ztli ({}) and SafeKeeperState.server.timeline_id ({})", ztli, state.server.timeline_id);
-            }
+        if state.server.timeline_id != ZTimelineId::from([0u8; 16])
+            && ztli != state.server.timeline_id
+        {
+            panic!("Calling SafeKeeper::new with inconsistent ztli ({}) and SafeKeeperState.server.timeline_id ({})", ztli, state.server.timeline_id);
         }
         SafeKeeper {
             flush_lsn,

--- a/walkeeper/src/timeline.rs
+++ b/walkeeper/src/timeline.rs
@@ -136,7 +136,7 @@ impl SharedState {
 
         Ok(Self {
             notified_commit_lsn: Lsn(0),
-            sk: SafeKeeper::new(Lsn(flush_lsn), file_storage, state),
+            sk: SafeKeeper::new(zttid.timeline_id, Lsn(flush_lsn), file_storage, state),
             replicas: Vec::new(),
             active: false,
             num_computes: 0,

--- a/walkeeper/src/timeline.rs
+++ b/walkeeper/src/timeline.rs
@@ -123,20 +123,27 @@ impl SharedState {
         let file_storage = FileStorage::new(zttid, conf);
         let flush_lsn = if state.server.wal_seg_size != 0 {
             let wal_dir = conf.timeline_dir(zttid);
-            find_end_of_wal(
+            Lsn(find_end_of_wal(
                 &wal_dir,
                 state.server.wal_seg_size as usize,
                 true,
                 state.wal_start_lsn,
             )?
-            .0
+            .0)
         } else {
-            0
+            Lsn(0)
         };
+        info!(
+            "timeline {} created or restored: flush_lsn={}, commit_lsn={}, truncate_lsn={}",
+            zttid.timeline_id, flush_lsn, state.commit_lsn, state.truncate_lsn,
+        );
+        if flush_lsn < state.truncate_lsn {
+            warn!("timeline {} potential data loss: flush_lsn by find_end_of_wal is less than truncate_lsn from control file", zttid.timeline_id);
+        }
 
         Ok(Self {
             notified_commit_lsn: Lsn(0),
-            sk: SafeKeeper::new(zttid.timeline_id, Lsn(flush_lsn), file_storage, state),
+            sk: SafeKeeper::new(zttid.timeline_id, flush_lsn, file_storage, state),
             replicas: Vec::new(),
             active: false,
             num_computes: 0,

--- a/walkeeper/src/timeline.rs
+++ b/walkeeper/src/timeline.rs
@@ -137,8 +137,8 @@ impl SharedState {
             "timeline {} created or restored: flush_lsn={}, commit_lsn={}, truncate_lsn={}",
             zttid.timeline_id, flush_lsn, state.commit_lsn, state.truncate_lsn,
         );
-        if flush_lsn < state.truncate_lsn {
-            warn!("timeline {} potential data loss: flush_lsn by find_end_of_wal is less than truncate_lsn from control file", zttid.timeline_id);
+        if flush_lsn < state.commit_lsn || flush_lsn < state.truncate_lsn {
+            warn!("timeline {} potential data loss: flush_lsn by find_end_of_wal is less than either commit_lsn or truncate_lsn from control file", zttid.timeline_id);
         }
 
         Ok(Self {


### PR DESCRIPTION
These metrics were not initialized on load. First reasonable metric was available after some safekeeper<->proposer communication only.