### PR TITLE
Reduce logging of walkeeper normal operations.

### DIFF
--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -774,7 +774,7 @@ where
         }
 
         let resp = self.append_response();
-        info!(
+        trace!(
             "processed AppendRequest of len {}, end_lsn={:?}, commit_lsn={:?}, truncate_lsn={:?}, resp {:?}",
             msg.wal_data.len(),
             msg.h.end_lsn,

--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -167,7 +167,7 @@ impl ReplicationConn {
                             let buf = Bytes::copy_from_slice(&m[9..]);
                             let reply = ZenithFeedback::parse(buf);
 
-                            info!("ZenithFeedback is {:?}", reply);
+                            trace!("ZenithFeedback is {:?}", reply);
                             // Only pageserver sends ZenithFeedback, so set the flag.
                             // This replica is the source of information to resend to compute.
                             state.zenith_feedback = Some(reply);
@@ -385,7 +385,7 @@ impl ReplicationConn {
 
             start_pos += send_size as u64;
 
-            info!("sent WAL up to {}", start_pos);
+            trace!("sent WAL up to {}", start_pos);
 
             // Decide whether to reuse this file. If we don't set wal_file here
             // a new file will be opened next time.

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -13,7 +13,7 @@ use std::io::{self, Cursor};
 use std::str;
 use std::time::{Duration, SystemTime};
 use tokio::io::AsyncReadExt;
-use tracing::info;
+use tracing::{trace, warn};
 
 pub type Oid = u32;
 pub type SystemId = u64;
@@ -956,7 +956,7 @@ impl ZenithFeedback {
                 }
                 _ => {
                     let len = buf.get_i32();
-                    info!(
+                    warn!(
                         "ZenithFeedback parse. unknown key {} of len {}. Skip it.",
                         key, len
                     );
@@ -964,7 +964,7 @@ impl ZenithFeedback {
                 }
             }
         }
-        info!("ZenithFeedback parsed is {:?}", zf);
+        trace!("ZenithFeedback parsed is {:?}", zf);
         zf
     }
 }


### PR DESCRIPTION
It was printing a lot of stuff to the log with INFO level, for routine
things like receiving or sending messages. Reduce the noise. The amount
of logging was excessive, and it was also consuming a fair amount of CPU
(about 20% of safekeeper's CPU usage in a little test I ran).