### PR TITLE
[proxy] WIP Async cplane_api, waiters, auth, and routers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,7 +783,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
 ]
 
 [[package]]
@@ -780,6 +791,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -980,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
 dependencies = [
  "base64 0.12.3",
- "pem",
+ "pem 0.8.3",
  "ring",
  "serde",
  "serde_json",
@@ -1340,6 +1354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+dependencies = [
+ "base64 0.13.0",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,19 +1566,26 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "futures",
+ "hashbrown 0.11.2",
  "hex",
  "hyper",
  "lazy_static",
  "md5",
  "parking_lot",
+ "pin-project-lite",
  "rand",
+ "rcgen",
  "reqwest",
  "routerify",
  "rustls 0.19.1",
+ "scopeguard",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres 0.7.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
+ "tokio-postgres-rustls",
+ "tokio-rustls",
  "zenith_metrics",
  "zenith_utils",
 ]
@@ -1613,6 +1643,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
+dependencies = [
+ "chrono",
+ "pem 1.0.2",
+ "ring",
+ "yasna",
 ]
 
 [[package]]
@@ -2253,6 +2295,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres-rustls"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd8c37d8c23cb6ecdc32fc171bade4e9c7f1be65f693a17afbaad02091a0a19"
+dependencies = [
+ "futures",
+ "ring",
+ "rustls 0.19.1",
+ "tokio",
+ "tokio-postgres 0.7.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
+ "tokio-rustls",
+ "webpki 0.21.4",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2780,15 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "zenith"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1564,6 +1564,7 @@ name = "proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ members = [
 # This is useful for profiling and, to some extent, debug.
 # Besides, debug info should not affect the performance.
 debug = true
+
+# This is only needed for proxy's tests
+# TODO: we should probably fork tokio-postgres-rustls instead
+[patch.crates-io]
+tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="2949d98df52587d562986aad155dd4e889e408b7" }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -31,6 +31,7 @@ scopeguard = "1.1.0"
 
 zenith_utils = { path = "../zenith_utils" }
 zenith_metrics = { path = "../zenith_metrics" }
+async-trait = "0.1.52"
 
 [dev-dependencies]
 tokio-postgres-rustls = "0.8.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -16,13 +16,22 @@ hex = "0.4.3"
 hyper = "0.14"
 routerify = "2"
 parking_lot = "0.11.2"
+hashbrown = "0.11.2"
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.11", features = ["macros"] }
 tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="2949d98df52587d562986aad155dd4e889e408b7" }
+tokio-rustls = "0.22.0"
 clap = "2.33.0"
 rustls = "0.19.1"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+pin-project-lite = "0.2.7"
+futures = "0.3.13"
+scopeguard = "1.1.0"
 
 zenith_utils = { path = "../zenith_utils" }
 zenith_metrics = { path = "../zenith_metrics" }
+
+[dev-dependencies]
+tokio-postgres-rustls = "0.8.0"
+rcgen = "0.8.14"

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -1,0 +1,152 @@
+use crate::cplane_api::DatabaseInfo;
+use pin_project_lite::pin_project;
+use crate::stream::PqStream;
+use tokio::io::{AsyncRead, AsyncWrite};
+use crate::state::ProxyWaiters;
+use zenith_utils::pq_proto::{BeMessage as Be, *};
+use async_trait::async_trait;
+
+
+// TODO this should be a trait instead, but async_trait is a bit finicky.
+#[non_exhaustive]
+pub enum Auth {
+    Forward(ForwardAuth),
+    Md5(Md5Auth),
+    Link(LinkAuth),
+}
+
+pub async fn authenticate(
+    auth: Auth,
+    client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
+    creds: &crate::cplane_api::ClientCredentials,
+) -> anyhow::Result<DatabaseInfo> {
+    match auth {
+        Auth::Forward(auth) => auth.authenticate(client, creds).await,
+        Auth::Md5(auth) => auth.authenticate(client, creds).await,
+        Auth::Link(auth) => auth.authenticate(client, creds).await,
+    }
+}
+
+/// Read cleartext password, use it to auth.
+/// NOTE Don't use in production.
+pub struct ForwardAuth {
+    pub host: String,
+    pub port: u16,
+}
+
+/// Use password-based auth in [`AuthStream`].
+pub struct Md5Auth {
+    pub auth_endpoint: String,
+    pub waiters: ProxyWaiters,
+    pub session_id: String,
+}
+
+/// Login via link to console
+pub struct LinkAuth {
+    pub redirect_uri: String,
+    pub session_id: String,
+    pub waiters: ProxyWaiters,
+}
+
+fn hello_message(redirect_uri: &str, session_id: &str) -> String {
+    format!(
+        concat![
+            "☀️  Welcome to Zenith!\n",
+            "To proceed with database creation, open the following link:\n\n",
+            "    {redirect_uri}{session_id}\n\n",
+            "It needs to be done once and we will send you '.pgpass' file,\n",
+            "which will allow you to access or create ",
+            "databases without opening your web browser."
+        ],
+        redirect_uri = redirect_uri,
+        session_id = session_id,
+    )
+}
+
+// #[async_trait(?Send)]
+impl LinkAuth {
+    pub async fn authenticate(
+        &self,
+        client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
+        _creds: &crate::cplane_api::ClientCredentials,
+    ) -> anyhow::Result<DatabaseInfo> {
+        let greeting = hello_message(&self.redirect_uri, &self.session_id);
+
+        // First, register this session
+        // TODO is there need for this?
+        let waiter = self.waiters.register(self.session_id.clone());
+
+        // Give user a URL to spawn a new database
+        client
+            .write_message_noflush(&Be::AuthenticationOk)?
+            .write_message_noflush(&BeParameterStatusMessage::encoding())?
+            .write_message(&Be::NoticeResponse(greeting)).await?;
+
+        // Wait for web console response
+        // TODO is this blocking?
+        let db_info = waiter.wait()?.map_err(|e| anyhow::anyhow!(e))?;
+
+        client.write_message(&Be::NoticeResponse("Connecting to database.".into())).await?;
+
+        Ok(db_info)
+    }
+}
+
+// #[async_trait(?Send)]
+impl Md5Auth {
+    pub async fn authenticate(
+        &self,
+        client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
+        creds: &crate::cplane_api::ClientCredentials,
+    ) -> anyhow::Result<DatabaseInfo> {
+        let md5_salt = rand::random::<[u8; 4]>();
+
+        // Ask password
+        client.write_message(&Be::AuthenticationMD5Password(&md5_salt)).await?;
+
+        // Check password
+        let msg = client.read_password_message().await?;
+
+        let (_trailing_null, md5_response) = msg
+            .split_last()
+            .ok_or_else(|| anyhow::anyhow!("unexpected password message"))?;
+
+        let cplane = crate::cplane_api::CPlaneApi::new(&self.auth_endpoint, &self.waiters);
+        let db_info = cplane.authenticate_proxy_request(
+            &creds.user,
+            &creds.dbname,
+            md5_response,
+            &md5_salt,
+            &self.session_id,
+        )?;
+
+        client
+            .write_message_noflush(&Be::AuthenticationOk)?
+            .write_message_noflush(&BeParameterStatusMessage::encoding())?;
+
+        Ok(db_info)
+    }
+}
+
+impl ForwardAuth {
+    pub async fn authenticate(
+        &self,
+        client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
+        creds: &crate::cplane_api::ClientCredentials,
+    ) -> anyhow::Result<DatabaseInfo> {
+        client.write_message(&Be::AuthenticationCleartextPassword).await?;
+        let cleartext_password_bytes = client.read_password_message().await?;
+        let cleartext_password = std::str::from_utf8(&cleartext_password_bytes)?
+            .split('\0').next().unwrap();
+
+        let db_info = crate::cplane_api::DatabaseInfo {
+            host: self.host.clone(),
+            port: self.port,
+            dbname: creds.dbname.clone(),
+            user: creds.user.clone(),
+            password: Some(cleartext_password.into()),
+        };
+
+        Ok(db_info)
+    }
+}

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -1,4 +1,4 @@
-use crate::cplane_api::DatabaseInfo;
+use crate::cplane_api::{DatabaseInfo, LinkCPlaneApi, CPlaneApi};
 use pin_project_lite::pin_project;
 use crate::stream::PqStream;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -9,14 +9,14 @@ use async_trait::async_trait;
 
 // TODO this should be a trait instead, but async_trait is a bit finicky.
 #[non_exhaustive]
-pub enum Auth {
+pub enum Auth<'a> {
     Forward(ForwardAuth),
-    Md5(Md5Auth),
-    Link(LinkAuth),
+    Md5(Md5Auth<'a>),
+    Link(LinkAuth<'a>),
 }
 
 pub async fn authenticate(
-    auth: Auth,
+    auth: Auth<'_>,
     client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
     creds: &crate::cplane_api::ClientCredentials,
 ) -> anyhow::Result<DatabaseInfo> {
@@ -35,46 +35,23 @@ pub struct ForwardAuth {
 }
 
 /// Use password-based auth in [`AuthStream`].
-pub struct Md5Auth {
-    pub auth_endpoint: String,
-    pub waiters: ProxyWaiters,
-    pub session_id: String,
+pub struct Md5Auth<'a> {
+    cplane_api: CPlaneApi<'a>
 }
 
 /// Login via link to console
-pub struct LinkAuth {
-    pub redirect_uri: String,
-    pub session_id: String,
-    pub waiters: ProxyWaiters,
-}
-
-fn hello_message(redirect_uri: &str, session_id: &str) -> String {
-    format!(
-        concat![
-            "☀️  Welcome to Zenith!\n",
-            "To proceed with database creation, open the following link:\n\n",
-            "    {redirect_uri}{session_id}\n\n",
-            "It needs to be done once and we will send you '.pgpass' file,\n",
-            "which will allow you to access or create ",
-            "databases without opening your web browser."
-        ],
-        redirect_uri = redirect_uri,
-        session_id = session_id,
-    )
+pub struct LinkAuth<'a> {
+    link_cplane_api: LinkCPlaneApi<'a>,
 }
 
 // #[async_trait(?Send)]
-impl LinkAuth {
+impl LinkAuth<'_> {
     pub async fn authenticate(
         &self,
         client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
         _creds: &crate::cplane_api::ClientCredentials,
     ) -> anyhow::Result<DatabaseInfo> {
-        let greeting = hello_message(&self.redirect_uri, &self.session_id);
-
-        // First, register this session
-        // TODO is there need for this?
-        let waiter = self.waiters.register(self.session_id.clone());
+        let (greeting, waiter) = self.link_cplane_api.get_hello_message();
 
         // Give user a URL to spawn a new database
         client
@@ -83,7 +60,6 @@ impl LinkAuth {
             .write_message(&Be::NoticeResponse(greeting)).await?;
 
         // Wait for web console response
-        // TODO is this blocking?
         let db_info = waiter.wait()?.map_err(|e| anyhow::anyhow!(e))?;
 
         client.write_message(&Be::NoticeResponse("Connecting to database.".into())).await?;
@@ -93,7 +69,7 @@ impl LinkAuth {
 }
 
 // #[async_trait(?Send)]
-impl Md5Auth {
+impl Md5Auth<'_> {
     pub async fn authenticate(
         &self,
         client: &mut PqStream<impl AsyncRead + AsyncWrite + Unpin>,
@@ -111,13 +87,11 @@ impl Md5Auth {
             .split_last()
             .ok_or_else(|| anyhow::anyhow!("unexpected password message"))?;
 
-        let cplane = crate::cplane_api::CPlaneApi::new(&self.auth_endpoint, &self.waiters);
-        let db_info = cplane.authenticate_proxy_request(
+        let db_info = self.cplane_api.authenticate_proxy_request(
             &creds.user,
             &creds.dbname,
             md5_response,
             &md5_salt,
-            &self.session_id,
         )?;
 
         client

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -60,7 +60,7 @@ impl LinkAuth<'_> {
             .write_message(&Be::NoticeResponse(greeting)).await?;
 
         // Wait for web console response
-        let db_info = waiter.wait()?.map_err(|e| anyhow::anyhow!(e))?;
+        let db_info = waiter.await.map_err(|e| anyhow::anyhow!(e))?;
 
         client.write_message(&Be::NoticeResponse("Connecting to database.".into())).await?;
 
@@ -92,7 +92,7 @@ impl Md5Auth<'_> {
             &creds.dbname,
             md5_response,
             &md5_salt,
-        )?;
+        ).await?;
 
         client
             .write_message_noflush(&Be::AuthenticationOk)?

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -1,10 +1,7 @@
-use crate::cplane_api::{DatabaseInfo, LinkCPlaneApi, CPlaneApi};
-use pin_project_lite::pin_project;
+use crate::cplane_api::{DatabaseInfo, LinkApi, Md5Api};
 use crate::stream::PqStream;
 use tokio::io::{AsyncRead, AsyncWrite};
-use crate::state::ProxyWaiters;
 use zenith_utils::pq_proto::{BeMessage as Be, *};
-use async_trait::async_trait;
 
 
 // TODO this should be a trait instead, but async_trait is a bit finicky.
@@ -36,12 +33,12 @@ pub struct ForwardAuth {
 
 /// Use password-based auth in [`AuthStream`].
 pub struct Md5Auth<'a> {
-    cplane_api: CPlaneApi<'a>
+    md5_cplane_api: Md5Api<'a>
 }
 
 /// Login via link to console
 pub struct LinkAuth<'a> {
-    link_cplane_api: LinkCPlaneApi<'a>,
+    link_cplane_api: LinkApi<'a>,
 }
 
 // #[async_trait(?Send)]
@@ -87,7 +84,7 @@ impl Md5Auth<'_> {
             .split_last()
             .ok_or_else(|| anyhow::anyhow!("unexpected password message"))?;
 
-        let db_info = self.cplane_api.authenticate_proxy_request(
+        let db_info = self.md5_cplane_api.authenticate_proxy_request(
             &creds.user,
             &creds.dbname,
             md5_response,

--- a/proxy/src/cancellation.rs
+++ b/proxy/src/cancellation.rs
@@ -1,0 +1,90 @@
+use anyhow::{anyhow, Context};
+use hashbrown::HashMap;
+use lazy_static::lazy_static;
+use parking_lot::Mutex;
+use std::net::SocketAddr;
+use tokio::net::TcpStream;
+use tokio_postgres::{CancelToken, NoTls};
+use zenith_utils::pq_proto::CancelKeyData;
+
+lazy_static! {
+    /// Enables serving CancelRequests.
+    static ref CANCEL_MAP: Mutex<HashMap<CancelKeyData, Option<CancelClosure>>> = Default::default();
+}
+
+/// This should've been a [`std::future::Future`], but
+/// it's impossible to name a type of an unboxed future
+/// (we'd need something like `#![feature(type_alias_impl_trait)]`).
+#[derive(Clone)]
+pub struct CancelClosure {
+    socket_addr: SocketAddr,
+    cancel_token: CancelToken,
+}
+
+impl CancelClosure {
+    pub fn new(socket_addr: SocketAddr, cancel_token: CancelToken) -> Self {
+        Self {
+            socket_addr,
+            cancel_token,
+        }
+    }
+
+    /// Cancels the query running on user's compute node.
+    pub async fn try_cancel_query(self) -> anyhow::Result<()> {
+        let socket = TcpStream::connect(self.socket_addr).await?;
+        self.cancel_token.cancel_query_raw(socket, NoTls).await?;
+
+        Ok(())
+    }
+}
+
+/// Cancel a running query for the corresponding connection.
+pub async fn cancel_session(key: CancelKeyData) -> anyhow::Result<()> {
+    let cancel_closure = CANCEL_MAP
+        .lock()
+        .get(&key)
+        .and_then(|x| x.clone())
+        .with_context(|| format!("unknown session: {:?}", key))?;
+
+    cancel_closure.try_cancel_query().await
+}
+
+/// Helper for registering query cancellation tokens.
+pub struct Session(CancelKeyData);
+
+impl Session {
+    /// Store the cancel token for the given session.
+    pub fn enable_cancellation(self, cancel_closure: CancelClosure) -> CancelKeyData {
+        CANCEL_MAP.lock().insert(self.0, Some(cancel_closure));
+        self.0
+    }
+}
+
+/// Run async action within an ephemeral session identified by [`CancelKeyData`].
+pub async fn with_session<F, R, V>(f: F) -> anyhow::Result<V>
+where
+    F: FnOnce(Session) -> R,
+    R: std::future::Future<Output = anyhow::Result<V>>,
+{
+    // HACK: We'd rather get the real backend_pid but tokio_postgres doesn't
+    // expose it and we don't want to do another roundtrip to query
+    // for it. The client will be able to notice that this is not the
+    // actual backend_pid, but backend_pid is not used for anything
+    // so it doesn't matter.
+    let key = rand::random();
+
+    // The birthday problem is unlikely to happen here, but it's still possible
+    CANCEL_MAP
+        .lock()
+        .try_insert(key, None)
+        .map_err(|_| anyhow!("session already exists: {:?}", key))?;
+
+    // This will guarantee that the session gets dropped
+    // as soon as the future is finished.
+    scopeguard::defer! {
+        CANCEL_MAP.lock().remove(&key);
+    }
+
+    let session = Session(key);
+    f(session).await
+}

--- a/proxy/src/cplane_api.rs
+++ b/proxy/src/cplane_api.rs
@@ -40,7 +40,7 @@ pub struct DatabaseInfo {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
-enum ProxyAuthResponse {
+pub enum ProxyAuthResponse {
     Ready { conn_info: DatabaseInfo },
     Error { error: String },
     NotReady { ready: bool }, // TODO: get rid of `ready`
@@ -120,12 +120,12 @@ impl Md5Api<'_> {
         let waiter = self.waiters.register(psql_session_id.to_owned());
 
         println!("cplane request: {}", url);
-        let resp = reqwest::blocking::get(url)?;
+        let resp = reqwest::get(url).await?;
         if !resp.status().is_success() {
             bail!("Auth failed: {}", resp.status())
         }
 
-        let auth_info: ProxyAuthResponse = serde_json::from_str(resp.text()?.as_str())?;
+        let auth_info = resp.json().await?;
         println!("got auth info: #{:?}", auth_info);
 
         use ProxyAuthResponse::*;

--- a/proxy/src/cplane_api.rs
+++ b/proxy/src/cplane_api.rs
@@ -90,7 +90,7 @@ impl<'a> CPlaneApi<'a> {
 }
 
 impl CPlaneApi<'_> {
-    pub fn authenticate_proxy_request(
+    pub async fn authenticate_proxy_request(
         &self,
         user: &str,
         database: &str,
@@ -121,7 +121,7 @@ impl CPlaneApi<'_> {
         match auth_info {
             Ready { conn_info } => Ok(conn_info),
             Error { error } => bail!(error),
-            NotReady { .. } => waiter.wait()?.map_err(|e| anyhow!(e)),
+            NotReady { .. } => waiter.await.map_err(|e| anyhow!(e)),
         }
     }
 }

--- a/proxy/src/cplane_api.rs
+++ b/proxy/src/cplane_api.rs
@@ -75,12 +75,23 @@ impl From<DatabaseInfo> for tokio_postgres::Config {
     }
 }
 
-pub struct CPlaneApi<'a> {
+pub struct FullApi<'a> {
+    md5_api: Md5Api<'a>,
+    link_api: LinkApi<'a>,
+}
+
+pub struct Md5Api<'a> {
     auth_endpoint: &'a str,
     waiters: &'a ProxyWaiters,
 }
 
-impl<'a> CPlaneApi<'a> {
+pub struct LinkApi<'a> {
+    redirect_uri: &'a str,
+    waiters: &'a ProxyWaiters,
+}
+
+
+impl<'a> Md5Api<'a> {
     pub fn new(auth_endpoint: &'a str, waiters: &'a ProxyWaiters) -> Self {
         Self {
             auth_endpoint,
@@ -89,7 +100,7 @@ impl<'a> CPlaneApi<'a> {
     }
 }
 
-impl CPlaneApi<'_> {
+impl Md5Api<'_> {
     pub async fn authenticate_proxy_request(
         &self,
         user: &str,
@@ -126,12 +137,7 @@ impl CPlaneApi<'_> {
     }
 }
 
-pub struct LinkCPlaneApi<'a> {
-    redirect_uri: &'a str,
-    waiters: &'a ProxyWaiters,
-}
-
-impl<'a> LinkCPlaneApi<'a> {
+impl<'a> LinkApi<'a> {
     pub fn new(redirect_uri: &'a str, waiters: &'a ProxyWaiters) -> Self {
         Self {
             redirect_uri,
@@ -140,7 +146,7 @@ impl<'a> LinkCPlaneApi<'a> {
     }
 }
 
-impl LinkCPlaneApi<'_> {
+impl LinkApi<'_> {
     pub fn get_hello_message(&self) -> (String, crate::waiters::Waiter<Result<DatabaseInfo, String>>) {
         let session_id = hex::encode(rand::random::<[u8; 8]>());
         let message = format!(

--- a/proxy/src/cplane_mock.rs
+++ b/proxy/src/cplane_mock.rs
@@ -1,0 +1,66 @@
+use anyhow::anyhow;
+use hyper::{Body, Request, Response, StatusCode};
+use routerify::RouterBuilder;
+use routerify::ext::RequestExt;
+use tokio::net::TcpStream;
+use std::net::TcpListener;
+use zenith_utils::http::endpoint;
+use zenith_utils::http::error::ApiError;
+use zenith_utils::http::json::json_response;
+
+use crate::{cplane_api::{DatabaseInfo, ProxyAuthResponse}, mgmt::{PsqlSessionResponse, PsqlSessionResult}};
+
+async fn auth_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
+    Ok(json_response(StatusCode::OK, ProxyAuthResponse::Ready {
+        conn_info: DatabaseInfo {
+            host: "127.0.0.1".into(),
+            port: 5432,
+            dbname: "postgres".into(),
+            user: "postgres".into(),
+            password: Some("postgres".into()),
+        }
+    })?)
+}
+
+async fn link_handler(req: Request<Body>) -> Result<Response<Body>, ApiError> {
+    let session_id = req.param("sessionId").unwrap().to_string();
+
+    let payload = PsqlSessionResponse {
+        session_id,
+        result: PsqlSessionResult::Success(DatabaseInfo {
+                host: "127.0.0.1".into(),
+                port: 5432,
+                dbname: "postgres".into(),
+                user: "postgres".into(),
+                password: Some("postgres".into()),
+            })
+
+    };
+    let query_text = &serde_json::to_string(&payload).unwrap();
+
+    let _output = std::process::Command::new("psql")
+        .args(["-h", "127.0.0.1",
+               "-p", "7000",
+               "-c", query_text])
+        .output()
+        .unwrap();
+
+    Ok(json_response(StatusCode::OK, "")?)
+}
+
+fn make_router() -> RouterBuilder<hyper::Body, ApiError> {
+    let router = endpoint::make_router();
+    router
+        .get("/auth", auth_handler)
+        .get("/link/:sessionId", link_handler)
+}
+
+pub async fn thread_main(http_listener: TcpListener) -> anyhow::Result<()> {
+    let service = || routerify::RouterService::new(make_router().build()?);
+
+    hyper::Server::from_tcp(http_listener)?
+        .serve(service().map_err(|e| anyhow!(e))?)
+        .await?;
+
+    Ok(())
+}

--- a/proxy/src/cplane_mock.rs
+++ b/proxy/src/cplane_mock.rs
@@ -51,8 +51,8 @@ async fn link_handler(req: Request<Body>) -> Result<Response<Body>, ApiError> {
 fn make_router() -> RouterBuilder<hyper::Body, ApiError> {
     let router = endpoint::make_router();
     router
-        .get("/auth", auth_handler)
-        .get("/link/:sessionId", link_handler)
+        .get("/authenticate_proxy_request", auth_handler)
+        .get("/psql_session/:sessionId", link_handler)
 }
 
 pub async fn thread_main(http_listener: TcpListener) -> anyhow::Result<()> {

--- a/proxy/src/http.rs
+++ b/proxy/src/http.rs
@@ -1,6 +1,7 @@
+use anyhow::anyhow;
 use hyper::{Body, Request, Response, StatusCode};
 use routerify::RouterBuilder;
-
+use std::net::TcpListener;
 use zenith_utils::http::endpoint;
 use zenith_utils::http::error::ApiError;
 use zenith_utils::http::json::json_response;
@@ -9,7 +10,17 @@ async fn status_handler(_: Request<Body>) -> Result<Response<Body>, ApiError> {
     Ok(json_response(StatusCode::OK, "")?)
 }
 
-pub fn make_router() -> RouterBuilder<hyper::Body, ApiError> {
+fn make_router() -> RouterBuilder<hyper::Body, ApiError> {
     let router = endpoint::make_router();
     router.get("/v1/status", status_handler)
+}
+
+pub async fn thread_main(http_listener: TcpListener) -> anyhow::Result<()> {
+    let service = || routerify::RouterService::new(make_router().build()?);
+
+    hyper::Server::from_tcp(http_listener)?
+        .serve(service().map_err(|e| anyhow!(e))?)
+        .await?;
+
+    Ok(())
 }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -10,6 +10,7 @@ use clap::{App, Arg};
 use state::{ProxyConfig, ProxyState};
 use zenith_utils::{tcp_listener, GIT_VERSION};
 
+mod auth;
 mod cancellation;
 mod cplane_api;
 mod http;

--- a/proxy/src/mgmt.rs
+++ b/proxy/src/mgmt.rs
@@ -104,7 +104,9 @@ fn try_process_query(
         Failure(message) => Err(message),
     };
 
-    match mgmt.state.waiters.notify(&resp.session_id, msg) {
+    // XXX deal with this
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    match rt.block_on(mgmt.state.waiters.notify(&resp.session_id, msg)) {
         Ok(()) => {
             pgb.write_message_noflush(&SINGLE_COL_ROWDESC)?
                 .write_message_noflush(&BeMessage::DataRow(&[Some(b"ok")]))?

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -43,6 +43,7 @@ pub async fn thread_main(
                 .set_nodelay(true)
                 .context("failed to set socket option")?;
 
+            // TODO fix this
             let cplane = cplane::CPlaneApi::new("", &state.waiters);
             let tls = state.conf.ssl_config.clone();
             handle_client(socket, cplane, tls).await

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -43,8 +43,9 @@ pub async fn thread_main(
                 .set_nodelay(true)
                 .context("failed to set socket option")?;
 
+            let cplane = cplane::CPlaneApi::new("", &state.waiters);
             let tls = state.conf.ssl_config.clone();
-            handle_client(socket, tls).await
+            handle_client(socket, cplane, tls).await
         }));
     }
 }
@@ -61,6 +62,7 @@ where
 
 async fn handle_client(
     stream: impl AsyncRead + AsyncWrite + Unpin,
+    cplane: cplane::CPlaneApi<'_>,
     tls: Option<SslConfig>,
 ) -> anyhow::Result<()> {
     // The `closed` counter will increase when this future is destroyed.

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -1,7 +1,6 @@
 use crate::auth::Auth;
 use crate::cancellation::{self, CancelClosure};
 use crate::cplane_api as cplane;
-use crate::router::Router;
 use crate::state::SslConfig;
 use crate::stream::{PqStream, Stream};
 use crate::ProxyState;

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -44,7 +44,7 @@ pub async fn thread_main(
                 .context("failed to set socket option")?;
 
             // TODO fix this
-            let cplane = cplane::CPlaneApi::new("", &state.waiters);
+            let cplane = cplane::Md5Api::new("", &state.waiters);
             let tls = state.conf.ssl_config.clone();
             handle_client(socket, cplane, tls).await
         }));
@@ -63,7 +63,7 @@ where
 
 async fn handle_client(
     stream: impl AsyncRead + AsyncWrite + Unpin,
-    cplane: cplane::CPlaneApi<'_>,
+    cplane: cplane::Md5Api<'_>,
     tls: Option<SslConfig>,
 ) -> anyhow::Result<()> {
     // The `closed` counter will increase when this future is destroyed.

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -156,8 +156,6 @@ async fn connect_client_to_db(
     let cancel_key_data = session.enable_cancellation(cancel_closure);
 
     client
-        .write_message_noflush(&Be::AuthenticationOk)?
-        .write_message_noflush(&BeParameterStatusMessage::encoding())?
         .write_message_noflush(&BeMessage::ParameterStatus(
             BeParameterStatusMessage::ServerVersion(&version),
         ))?

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -1,294 +1,177 @@
-use crate::cplane_api::{CPlaneApi, DatabaseInfo};
+use crate::cancellation::{self, CancelClosure};
+use crate::cplane_api as cplane;
+use crate::state::SslConfig;
+use crate::stream::{PqStream, Stream};
 use crate::ProxyState;
-use anyhow::{anyhow, bail, Context};
+use anyhow::{bail, Context};
 use lazy_static::lazy_static;
-use parking_lot::Mutex;
-use rand::prelude::StdRng;
-use rand::{Rng, SeedableRng};
-use std::cell::Cell;
-use std::collections::HashMap;
-use std::net::{SocketAddr, TcpStream};
-use std::{io, thread};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
 use tokio_postgres::NoTls;
 use zenith_metrics::{new_common_metric_name, register_int_counter, IntCounter};
-use zenith_utils::postgres_backend::{self, PostgresBackend, ProtoState, Stream};
-use zenith_utils::pq_proto::{BeMessage as Be, FeMessage as Fe, *};
-use zenith_utils::sock_split::{ReadStream, WriteStream};
-
-struct CancelClosure {
-    socket_addr: SocketAddr,
-    cancel_token: tokio_postgres::CancelToken,
-}
-
-impl CancelClosure {
-    async fn try_cancel_query(&self) {
-        if let Ok(socket) = tokio::net::TcpStream::connect(self.socket_addr).await {
-            // NOTE ignoring the result because:
-            // 1. This is a best effort attempt, the database doesn't have to listen
-            // 2. Being opaque about errors here helps avoid leaking info to unauthenticated user
-            let _ = self.cancel_token.cancel_query_raw(socket, NoTls).await;
-        }
-    }
-}
+use zenith_utils::pq_proto::{BeMessage as Be, *};
 
 lazy_static! {
-    // Enables serving CancelRequests
-    static ref CANCEL_MAP: Mutex<HashMap<CancelKeyData, CancelClosure>> = Mutex::new(HashMap::new());
-
-    // Metrics
     static ref NUM_CONNECTIONS_ACCEPTED_COUNTER: IntCounter = register_int_counter!(
         new_common_metric_name("num_connections_accepted"),
         "Number of TCP client connections accepted."
-    ).unwrap();
+    )
+    .unwrap();
     static ref NUM_CONNECTIONS_CLOSED_COUNTER: IntCounter = register_int_counter!(
         new_common_metric_name("num_connections_closed"),
         "Number of TCP client connections closed."
-    ).unwrap();
-    static ref NUM_CONNECTIONS_FAILED_COUNTER: IntCounter = register_int_counter!(
-        new_common_metric_name("num_connections_failed"),
-        "Number of TCP client connections that closed due to error."
-    ).unwrap();
+    )
+    .unwrap();
     static ref NUM_BYTES_PROXIED_COUNTER: IntCounter = register_int_counter!(
         new_common_metric_name("num_bytes_proxied"),
         "Number of bytes sent/received between any client and backend."
-    ).unwrap();
+    )
+    .unwrap();
 }
 
-thread_local! {
-    // Used to clean up the CANCEL_MAP. Might not be necessary if we use tokio thread pool in main loop.
-    static THREAD_CANCEL_KEY_DATA: Cell<Option<CancelKeyData>> = Cell::new(None);
-}
-
-///
-/// Main proxy listener loop.
-///
-/// Listens for connections, and launches a new handler thread for each.
-///
-pub fn thread_main(
+pub async fn thread_main(
     state: &'static ProxyState,
-    listener: std::net::TcpListener,
+    listener: tokio::net::TcpListener,
 ) -> anyhow::Result<()> {
     loop {
-        let (socket, peer_addr) = listener.accept()?;
+        let (socket, peer_addr) = listener.accept().await?;
         println!("accepted connection from {}", peer_addr);
-        NUM_CONNECTIONS_ACCEPTED_COUNTER.inc();
-        socket.set_nodelay(true).unwrap();
 
-        // TODO Use a threadpool instead. Maybe use tokio's threadpool by
-        //      spawning a future into its runtime. Tokio's JoinError should
-        //      allow us to handle cleanup properly even if the future panics.
-        thread::Builder::new()
-            .name("Proxy thread".into())
-            .spawn(move || {
-                if let Err(err) = proxy_conn_main(state, socket) {
-                    NUM_CONNECTIONS_FAILED_COUNTER.inc();
-                    println!("error: {}", err);
-                }
+        tokio::spawn(log_error(async {
+            socket
+                .set_nodelay(true)
+                .context("failed to set socket option")?;
 
-                // Clean up CANCEL_MAP.
-                NUM_CONNECTIONS_CLOSED_COUNTER.inc();
-                THREAD_CANCEL_KEY_DATA.with(|cell| {
-                    if let Some(cancel_key_data) = cell.get() {
-                        CANCEL_MAP.lock().remove(&cancel_key_data);
-                    };
-                });
-            })?;
+            let tls = state.conf.ssl_config.clone();
+            handle_client(socket, tls).await
+        }));
     }
 }
 
-// TODO: clean up fields
-struct ProxyConnection {
-    state: &'static ProxyState,
-    psql_session_id: String,
-    pgb: PostgresBackend,
+async fn log_error<R, F>(future: F) -> F::Output
+where
+    F: std::future::Future<Output = anyhow::Result<R>>,
+{
+    future.await.map_err(|err| {
+        println!("error: {}", err.to_string());
+        err
+    })
 }
 
-pub fn proxy_conn_main(state: &'static ProxyState, socket: TcpStream) -> anyhow::Result<()> {
-    let conn = ProxyConnection {
-        state,
-        psql_session_id: hex::encode(rand::random::<[u8; 8]>()),
-        pgb: PostgresBackend::new(
-            socket,
-            postgres_backend::AuthType::MD5,
-            state.conf.ssl_config.clone(),
-            false,
-        )?,
-    };
-
-    let (client, server) = match conn.handle_client()? {
-        Some(x) => x,
-        None => return Ok(()),
-    };
-
-    let server = zenith_utils::sock_split::BidiStream::from_tcp(server);
-
-    let client = match client {
-        Stream::Bidirectional(bidi_stream) => bidi_stream,
-        _ => panic!("invalid stream type"),
-    };
-
-    proxy(client.split(), server.split())
-}
-
-impl ProxyConnection {
-    /// Returns Ok(None) when connection was successfully closed.
-    fn handle_client(mut self) -> anyhow::Result<Option<(Stream, TcpStream)>> {
-        let mut authenticate = || {
-            let (username, dbname) = match self.handle_startup()? {
-                Some(x) => x,
-                None => return Ok(None),
-            };
-
-            // Both scenarios here should end up producing database credentials
-            if username.ends_with("@zenith") {
-                self.handle_existing_user(&username, &dbname).map(Some)
-            } else {
-                self.handle_new_user().map(Some)
-            }
-        };
-
-        let conn = match authenticate() {
-            Ok(Some(db_info)) => connect_to_db(db_info),
-            Ok(None) => return Ok(None),
-            Err(e) => {
-                // Report the error to the client
-                self.pgb.write_message(&Be::ErrorResponse(&e.to_string()))?;
-                bail!("failed to handle client: {:?}", e);
-            }
-        };
-
-        // We'll get rid of this once migration to async is complete
-        let (pg_version, db_stream) = {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()?;
-
-            let (pg_version, stream, cancel_key_data) = runtime.block_on(conn)?;
-            self.pgb
-                .write_message(&BeMessage::BackendKeyData(cancel_key_data))?;
-            let stream = stream.into_std()?;
-            stream.set_nonblocking(false)?;
-
-            (pg_version, stream)
-        };
-
-        // Let the client send new requests
-        self.pgb
-            .write_message_noflush(&BeMessage::ParameterStatus(
-                BeParameterStatusMessage::ServerVersion(&pg_version),
-            ))?
-            .write_message(&Be::ReadyForQuery)?;
-
-        Ok(Some((self.pgb.into_stream(), db_stream)))
+async fn handle_client(
+    stream: impl AsyncRead + AsyncWrite + Unpin,
+    tls: Option<SslConfig>,
+) -> anyhow::Result<()> {
+    // The `closed` counter will increase when this future is destroyed.
+    NUM_CONNECTIONS_ACCEPTED_COUNTER.inc();
+    scopeguard::defer! {
+        NUM_CONNECTIONS_CLOSED_COUNTER.inc();
     }
 
-    /// Returns Ok(None) when connection was successfully closed.
-    fn handle_startup(&mut self) -> anyhow::Result<Option<(String, String)>> {
-        let have_tls = self.pgb.tls_config.is_some();
-        let mut encrypted = false;
+    if let Some((stream, creds)) = handshake(stream, tls).await? {
+        cancellation::with_session(|session| async {
+            connect_client_to_db(stream, creds, session).await
+        })
+        .await?;
+    }
 
-        loop {
-            let msg = match self.pgb.read_message()? {
-                Some(Fe::StartupPacket(msg)) => msg,
-                None => bail!("connection is lost"),
-                bad => bail!("unexpected message type: {:?}", bad),
-            };
-            println!("got message: {:?}", msg);
+    Ok(())
+}
 
-            match msg {
-                FeStartupPacket::GssEncRequest => {
-                    self.pgb.write_message(&Be::EncryptionResponse(false))?;
-                }
-                FeStartupPacket::SslRequest => {
-                    self.pgb.write_message(&Be::EncryptionResponse(have_tls))?;
-                    if have_tls {
-                        self.pgb.start_tls()?;
-                        encrypted = true;
+/// Handle a connection from one client.
+/// For better testing experience, `stream` can be
+/// any object satisfying the traits.
+async fn handshake<S: AsyncRead + AsyncWrite + Unpin>(
+    stream: S,
+    mut tls: Option<SslConfig>,
+) -> anyhow::Result<Option<(PqStream<Stream<S>>, cplane::ClientCredentials)>> {
+    // Client may try upgrading to each protocol only once
+    let (mut tried_ssl, mut tried_gss) = (false, false);
+
+    let mut stream = PqStream::new(Stream::from_raw(stream));
+    loop {
+        let msg = stream.read_startup_packet().await?;
+        println!("got message: {:?}", msg);
+
+        use FeStartupPacket::*;
+        match msg {
+            SslRequest => match stream.get_ref() {
+                Stream::Raw { .. } if !tried_ssl => {
+                    tried_ssl = true;
+
+                    // We can't perform TLS handshake without a config
+                    let enc = tls.is_some();
+                    stream.write_message(&Be::EncryptionResponse(enc)).await?;
+
+                    if let Some(tls) = tls.take() {
+                        // Upgrade raw stream into a secure TLS-backed stream.
+                        // NOTE: We've consumed `tls`; this fact will be used later.
+                        stream = PqStream::new(stream.into_inner().upgrade(tls).await?);
                     }
                 }
-                FeStartupPacket::StartupMessage { mut params, .. } => {
-                    if have_tls && !encrypted {
-                        bail!("must connect with TLS");
-                    }
+                _ => bail!("protocol violation"),
+            },
+            GssEncRequest => match stream.get_ref() {
+                Stream::Raw { .. } if !tried_gss => {
+                    tried_gss = true;
 
-                    let mut get_param = |key| {
-                        params
-                            .remove(key)
-                            .with_context(|| format!("{} is missing in startup packet", key))
-                    };
+                    // Currently, we don't support GSSAPI
+                    stream.write_message(&Be::EncryptionResponse(false)).await?;
+                }
+                _ => bail!("protocol violation"),
+            },
+            StartupMessage { params, .. } => {
+                // Check that the config has been consumed during upgrade
+                // OR we didn't provide it at all (for dev purposes).
+                if tls.is_some() {
+                    let msg = "connection is insecure (try using `sslmode=require`)";
+                    stream.write_message(&Be::ErrorResponse(msg)).await?;
+                    bail!(msg);
+                }
 
-                    return Ok(Some((get_param("user")?, get_param("database")?)));
-                }
-                FeStartupPacket::CancelRequest(cancel_key_data) => {
-                    if let Some(cancel_closure) = CANCEL_MAP.lock().get(&cancel_key_data) {
-                        let runtime = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .unwrap();
-                        runtime.block_on(cancel_closure.try_cancel_query());
-                    }
-                    return Ok(None);
-                }
+                break Ok(Some((stream, params.try_into()?)));
+            }
+            CancelRequest(cancel_key_data) => {
+                cancellation::cancel_session(cancel_key_data).await?;
+
+                break Ok(None);
             }
         }
     }
+}
 
-    fn handle_existing_user(&mut self, user: &str, db: &str) -> anyhow::Result<DatabaseInfo> {
-        let md5_salt = rand::random::<[u8; 4]>();
+// TODO: implement proper authentication
+async fn connect_client_to_db(
+    mut client: PqStream<impl AsyncRead + AsyncWrite + Unpin>,
+    creds: cplane::ClientCredentials,
+    session: cancellation::Session,
+) -> anyhow::Result<()> {
+    // TODO: get this from an api call
+    let db_info = cplane::DatabaseInfo {
+        host: "127.0.0.1".into(),
+        port: 5432,
+        dbname: creds.dbname,
+        user: "dmitry".into(),
+        password: None,
+    };
 
-        // Ask password
-        self.pgb
-            .write_message(&Be::AuthenticationMD5Password(&md5_salt))?;
-        self.pgb.state = ProtoState::Authentication; // XXX
+    let (mut db, version, cancel_closure) = connect_to_db(db_info).await?;
+    let cancel_key_data = session.enable_cancellation(cancel_closure);
 
-        // Check password
-        let msg = match self.pgb.read_message()? {
-            Some(Fe::PasswordMessage(msg)) => msg,
-            None => bail!("connection is lost"),
-            bad => bail!("unexpected message type: {:?}", bad),
-        };
-        println!("got message: {:?}", msg);
+    client
+        .write_message_noflush(&Be::AuthenticationOk)?
+        .write_message_noflush(&BeParameterStatusMessage::encoding())?
+        .write_message_noflush(&BeMessage::ParameterStatus(
+            BeParameterStatusMessage::ServerVersion(&version),
+        ))?
+        .write_message_noflush(&Be::BackendKeyData(cancel_key_data))?
+        .write_message(&BeMessage::ReadyForQuery)
+        .await?;
 
-        let (_trailing_null, md5_response) = msg
-            .split_last()
-            .ok_or_else(|| anyhow!("unexpected password message"))?;
+    let mut client = client.into_inner();
+    let _ = tokio::io::copy_bidirectional(&mut client, &mut db).await?;
 
-        let cplane = CPlaneApi::new(&self.state.conf.auth_endpoint, &self.state.waiters);
-        let db_info = cplane.authenticate_proxy_request(
-            user,
-            db,
-            md5_response,
-            &md5_salt,
-            &self.psql_session_id,
-        )?;
-
-        self.pgb
-            .write_message_noflush(&Be::AuthenticationOk)?
-            .write_message_noflush(&BeParameterStatusMessage::encoding())?;
-
-        Ok(db_info)
-    }
-
-    fn handle_new_user(&mut self) -> anyhow::Result<DatabaseInfo> {
-        let greeting = hello_message(&self.state.conf.redirect_uri, &self.psql_session_id);
-
-        // First, register this session
-        let waiter = self.state.waiters.register(self.psql_session_id.clone());
-
-        // Give user a URL to spawn a new database
-        self.pgb
-            .write_message_noflush(&Be::AuthenticationOk)?
-            .write_message_noflush(&BeParameterStatusMessage::encoding())?
-            .write_message(&Be::NoticeResponse(greeting))?;
-
-        // Wait for web console response
-        let db_info = waiter.wait()?.map_err(|e| anyhow!(e))?;
-
-        self.pgb
-            .write_message_noflush(&Be::NoticeResponse("Connecting to database.".into()))?;
-
-        Ok(db_info)
-    }
+    Ok(())
 }
 
 fn hello_message(redirect_uri: &str, session_id: &str) -> String {
@@ -306,81 +189,147 @@ fn hello_message(redirect_uri: &str, session_id: &str) -> String {
     )
 }
 
-/// Create a TCP connection to a postgres database, authenticate with it, and receive the ReadyForQuery message
+/// Connect to a corresponding compute node.
 async fn connect_to_db(
-    db_info: DatabaseInfo,
-) -> anyhow::Result<(String, tokio::net::TcpStream, CancelKeyData)> {
-    // Make raw connection. When connect_raw finishes we've received ReadyForQuery.
+    db_info: cplane::DatabaseInfo,
+) -> anyhow::Result<(TcpStream, String, CancelClosure)> {
+    // TODO: establish a secure connection to the DB
     let socket_addr = db_info.socket_addr()?;
-    let mut socket = tokio::net::TcpStream::connect(socket_addr).await?;
-    let config = tokio_postgres::Config::from(db_info);
-    // NOTE We effectively ignore some ParameterStatus and NoticeResponse
-    //      messages here. Not sure if that could break something.
-    let (client, conn) = config.connect_raw(&mut socket, NoTls).await?;
+    let mut socket = TcpStream::connect(socket_addr).await?;
 
-    // Save info for potentially cancelling the query later
-    let mut rng = StdRng::from_entropy();
-    let cancel_key_data = CancelKeyData {
-        // HACK We'd rather get the real backend_pid but tokio_postgres doesn't
-        //      expose it and we don't want to do another roundtrip to query
-        //      for it. The client will be able to notice that this is not the
-        //      actual backend_pid, but backend_pid is not used for anything
-        //      so it doesn't matter.
-        backend_pid: rng.gen(),
-        cancel_key: rng.gen(),
-    };
-    let cancel_closure = CancelClosure {
-        socket_addr,
-        cancel_token: client.cancel_token(),
-    };
-    CANCEL_MAP.lock().insert(cancel_key_data, cancel_closure);
-    THREAD_CANCEL_KEY_DATA.with(|cell| {
-        let prev_value = cell.replace(Some(cancel_key_data));
-        assert!(
-            prev_value.is_none(),
-            "THREAD_CANCEL_KEY_DATA was already set"
-        );
-    });
+    let (client, conn) = tokio_postgres::Config::from(db_info)
+        .connect_raw(&mut socket, NoTls)
+        .await?;
 
-    let version = conn.parameter("server_version").unwrap();
-    Ok((version.into(), socket, cancel_key_data))
+    let version = conn
+        .parameter("server_version")
+        .context("failed to fetch postgres server version")?
+        .into();
+
+    let cancel_closure = CancelClosure::new(socket_addr, client.cancel_token());
+
+    Ok((socket, version, cancel_closure))
 }
 
-/// Concurrently proxy both directions of the client and server connections
-fn proxy(
-    (client_read, client_write): (ReadStream, WriteStream),
-    (server_read, server_write): (ReadStream, WriteStream),
-) -> anyhow::Result<()> {
-    fn do_proxy(mut reader: impl io::Read, mut writer: WriteStream) -> io::Result<u64> {
-        /// FlushWriter will make sure that every message is sent as soon as possible
-        struct FlushWriter<W>(W);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        impl<W: io::Write> io::Write for FlushWriter<W> {
-            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                // `std::io::copy` is guaranteed to exit if we return an error,
-                // so we can afford to lose `res` in case `flush` fails
-                let res = self.0.write(buf);
-                if let Ok(count) = res {
-                    NUM_BYTES_PROXIED_COUNTER.inc_by(count as u64);
-                    self.flush()?;
-                }
-                res
-            }
+    use tokio::io::DuplexStream;
+    use tokio_postgres::config::SslMode;
+    use tokio_postgres::tls::MakeTlsConnect;
+    use tokio_postgres_rustls::MakeRustlsConnect;
 
-            fn flush(&mut self) -> io::Result<()> {
-                self.0.flush()
-            }
-        }
+    async fn dummy_proxy(
+        client: impl AsyncRead + AsyncWrite + Unpin,
+        tls: Option<SslConfig>,
+    ) -> anyhow::Result<()> {
+        // TODO: add some infra + tests for credentials
+        let (mut stream, _creds) = handshake(client, tls).await?.context("no stream")?;
 
-        let res = std::io::copy(&mut reader, &mut FlushWriter(&mut writer));
-        writer.shutdown(std::net::Shutdown::Both)?;
-        res
+        stream
+            .write_message_noflush(&Be::AuthenticationOk)?
+            .write_message_noflush(&BeParameterStatusMessage::encoding())?
+            .write_message(&BeMessage::ReadyForQuery)
+            .await?;
+
+        Ok(())
     }
 
-    let client_to_server_jh = thread::spawn(move || do_proxy(client_read, server_write));
+    fn generate_certs(
+        hostname: &str,
+    ) -> anyhow::Result<(rustls::Certificate, rustls::Certificate, rustls::PrivateKey)> {
+        let ca = rcgen::Certificate::from_params({
+            let mut params = rcgen::CertificateParams::default();
+            params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+            params
+        })?;
 
-    do_proxy(server_read, client_write)?;
-    client_to_server_jh.join().unwrap()?;
+        let cert = rcgen::generate_simple_self_signed(vec![hostname.into()])?;
+        Ok((
+            rustls::Certificate(ca.serialize_der()?),
+            rustls::Certificate(cert.serialize_der_with_signer(&ca)?),
+            rustls::PrivateKey(cert.serialize_private_key_der()),
+        ))
+    }
 
-    Ok(())
+    #[tokio::test]
+    async fn handshake_tls_is_enforced_by_proxy() -> anyhow::Result<()> {
+        let (client, server) = tokio::io::duplex(1024);
+
+        let server_config = {
+            let (_ca, cert, key) = generate_certs("localhost")?;
+
+            let mut config = rustls::ServerConfig::new(rustls::NoClientAuth::new());
+            config.set_single_cert(vec![cert], key)?;
+            config
+        };
+
+        let proxy = tokio::spawn(dummy_proxy(client, Some(server_config.into())));
+
+        tokio_postgres::Config::new()
+            .user("john_doe")
+            .dbname("earth")
+            .ssl_mode(SslMode::Disable)
+            .connect_raw(server, NoTls)
+            .await
+            .err() // -> Option<E>
+            .context("client shouldn't be able to connect")?;
+
+        proxy
+            .await?
+            .err() // -> Option<E>
+            .context("server shouldn't accept client")?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handshake_tls() -> anyhow::Result<()> {
+        let (client, server) = tokio::io::duplex(1024);
+
+        let (ca, cert, key) = generate_certs("localhost")?;
+
+        let server_config = {
+            let mut config = rustls::ServerConfig::new(rustls::NoClientAuth::new());
+            config.set_single_cert(vec![cert], key)?;
+            config
+        };
+
+        let proxy = tokio::spawn(dummy_proxy(client, Some(server_config.into())));
+
+        let client_config = {
+            let mut config = rustls::ClientConfig::new();
+            config.root_store.add(&ca)?;
+            config
+        };
+
+        let mut mk = MakeRustlsConnect::new(client_config);
+        let tls = MakeTlsConnect::<DuplexStream>::make_tls_connect(&mut mk, "localhost")?;
+
+        let (_client, _conn) = tokio_postgres::Config::new()
+            .user("john_doe")
+            .dbname("earth")
+            .ssl_mode(SslMode::Require)
+            .connect_raw(server, tls)
+            .await?;
+
+        proxy.await?
+    }
+
+    #[tokio::test]
+    async fn handshake_raw() -> anyhow::Result<()> {
+        let (client, server) = tokio::io::duplex(1024);
+
+        let proxy = tokio::spawn(dummy_proxy(client, None));
+
+        let (_client, _conn) = tokio_postgres::Config::new()
+            .user("john_doe")
+            .dbname("earth")
+            .ssl_mode(SslMode::Prefer)
+            .connect_raw(server, NoTls)
+            .await?;
+
+        proxy.await?
+    }
 }

--- a/proxy/src/router.rs
+++ b/proxy/src/router.rs
@@ -1,0 +1,27 @@
+use std::net::SocketAddr;
+
+/// For users who already have credentials
+pub struct DefaultRouter {
+    pub listen_address: SocketAddr,
+    pub auth_endpoint: String,
+}
+
+/// For quick-starting new users
+pub struct LinkRouter {
+    pub listen_address: SocketAddr,
+    pub redirect_uri: String,
+}
+
+/// For local development
+pub struct StaticRouter {
+    pub listen_address: SocketAddr,
+    pub postgres_host: String,
+    pub postgres_port: u16,
+}
+
+// TODO try a trait instead
+pub enum Router {
+    Default(DefaultRouter),
+    Link(LinkRouter),
+    Static(StaticRouter),
+}

--- a/proxy/src/router.rs
+++ b/proxy/src/router.rs
@@ -1,25 +1,25 @@
 use std::net::SocketAddr;
 
-/// For users who already have credentials
+/// Routes registered users to cplane-provided compute node
 pub struct DefaultRouter {
     pub listen_address: SocketAddr,
     pub auth_endpoint: String,
 }
 
-/// For quick-starting new users
+/// Routes new user to cplane-provided compute node, authenticating via link
 pub struct LinkRouter {
     pub listen_address: SocketAddr,
     pub redirect_uri: String,
 }
 
-/// For local development
+/// Route to existing postgres instance. For local development only.
 pub struct StaticRouter {
     pub listen_address: SocketAddr,
     pub postgres_host: String,
     pub postgres_port: u16,
 }
 
-// TODO try a trait instead
+// TODO try a trait instead?
 pub enum Router {
     Default(DefaultRouter),
     Link(LinkRouter),

--- a/proxy/src/router.rs
+++ b/proxy/src/router.rs
@@ -1,27 +1,31 @@
-use std::net::SocketAddr;
-
 /// Routes registered users to cplane-provided compute node
 pub struct DefaultRouter {
-    pub listen_address: SocketAddr,
     pub auth_endpoint: String,
 }
 
 /// Routes new user to cplane-provided compute node, authenticating via link
 pub struct LinkRouter {
-    pub listen_address: SocketAddr,
     pub redirect_uri: String,
+}
+
+/// DefaultRouter for usernames ending in @zenith, otherwise LinkRouter
+pub struct MixedRouter {
+    pub default: DefaultRouter,
+    pub link: LinkRouter,
 }
 
 /// Route to existing postgres instance. For local development only.
 pub struct StaticRouter {
-    pub listen_address: SocketAddr,
     pub postgres_host: String,
     pub postgres_port: u16,
 }
 
 // TODO try a trait instead?
+// a router is anything that can construct an auth
+#[non_exhaustive]
 pub enum Router {
     Default(DefaultRouter),
     Link(LinkRouter),
+    Mixed(MixedRouter),
     Static(StaticRouter),
 }

--- a/proxy/src/state.rs
+++ b/proxy/src/state.rs
@@ -1,4 +1,5 @@
 use crate::cplane_api::DatabaseInfo;
+use crate::router::Router;
 use anyhow::{anyhow, ensure, Context};
 use rustls::{internal::pemfile, NoClientAuth, ProtocolVersion, ServerConfig};
 use std::net::SocketAddr;
@@ -7,8 +8,7 @@ use std::sync::Arc;
 pub type SslConfig = Arc<ServerConfig>;
 
 pub struct ProxyConfig {
-    /// main entrypoint for users to connect to
-    pub proxy_address: SocketAddr,
+    pub router: Router,
 
     /// internally used for status and prometheus metrics
     pub http_address: SocketAddr,
@@ -17,12 +17,6 @@ pub struct ProxyConfig {
     /// will notify us here, so that we can 'unfreeze' user session.
     /// TODO It uses postgres protocol over TCP but should be migrated to http.
     pub mgmt_address: SocketAddr,
-
-    /// send unauthenticated users to this URI
-    pub redirect_uri: String,
-
-    /// control plane address where we would check auth.
-    pub auth_endpoint: String,
 
     pub ssl_config: Option<SslConfig>,
 }

--- a/proxy/src/state.rs
+++ b/proxy/src/state.rs
@@ -10,6 +10,9 @@ pub type SslConfig = Arc<ServerConfig>;
 pub struct ProxyConfig {
     pub router: Router,
 
+    /// accept pg client connections here
+    pub listen_address: SocketAddr,
+
     /// internally used for status and prometheus metrics
     pub http_address: SocketAddr,
 

--- a/proxy/src/stream.rs
+++ b/proxy/src/stream.rs
@@ -1,0 +1,158 @@
+use bytes::BytesMut;
+use pin_project_lite::pin_project;
+use rustls::ServerConfig;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::{io, task};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio_rustls::server::TlsStream;
+use zenith_utils::pq_proto::{BeMessage, FeMessage, FeStartupPacket};
+
+pin_project! {
+    /// Stream wrapper which implements libpq's protocol.
+    /// NOTE: This object deliberately doesn't implement [`AsyncRead`]
+    /// or [`AsyncWrite`] to prevent subtle errors (e.g. trying
+    /// to pass random malformed bytes through the connection).
+    pub struct PqStream<S> {
+        #[pin]
+        stream: S,
+        buffer: BytesMut,
+    }
+}
+
+impl<S> PqStream<S> {
+    /// Construct a new libpq protocol wrapper.
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            buffer: Default::default(),
+        }
+    }
+
+    /// Extract the underlying stream.
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
+
+    /// Get a reference to the underlying stream.
+    pub fn get_ref(&self) -> &S {
+        &self.stream
+    }
+}
+
+impl<S: AsyncRead + Unpin> PqStream<S> {
+    /// Receive [`FeStartupPacket`], which is a first packet sent by a client.
+    pub async fn read_startup_packet(&mut self) -> anyhow::Result<FeStartupPacket> {
+        match FeStartupPacket::read_fut(&mut self.stream).await? {
+            Some(FeMessage::StartupPacket(packet)) => Ok(packet),
+            None => anyhow::bail!("connection is lost"),
+            other => anyhow::bail!("bad message type: {:?}", other),
+        }
+    }
+}
+
+impl<S: AsyncWrite + Unpin> PqStream<S> {
+    /// Write the message into an internal buffer, but don't flush the underlying stream.
+    pub fn write_message_noflush<'a>(&mut self, message: &BeMessage<'a>) -> io::Result<&mut Self> {
+        BeMessage::write(&mut self.buffer, message)?;
+        Ok(self)
+    }
+
+    /// Write the message into an internal buffer and flush it.
+    pub async fn write_message<'a>(&mut self, message: &BeMessage<'a>) -> io::Result<&mut Self> {
+        self.write_message_noflush(message)?;
+        self.flush().await?;
+        Ok(self)
+    }
+
+    /// Flush the output buffer into the underlying stream.
+    pub async fn flush(&mut self) -> io::Result<&mut Self> {
+        self.stream.write_all(&self.buffer).await?;
+        self.buffer.clear();
+        self.stream.flush().await?;
+        Ok(self)
+    }
+}
+
+pin_project! {
+    /// Wrapper for upgrading raw streams into secure streams.
+    /// NOTE: it should be possible to decompose this object as necessary.
+    #[project = StreamProj]
+    pub enum Stream<S> {
+        /// We always begin with a raw stream,
+        /// which may then be upgraded into a secure stream.
+        Raw { #[pin] raw: S },
+        /// We box [`TlsStream`] since it can be quite large.
+        Tls { #[pin] tls: Box<TlsStream<S>> },
+    }
+}
+
+impl<S> Stream<S> {
+    /// Construct a new instance from a raw stream.
+    pub fn from_raw(raw: S) -> Self {
+        Self::Raw { raw }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> Stream<S> {
+    /// If possible, upgrade raw stream into a secure TLS-based stream.
+    pub async fn upgrade(self, cfg: Arc<ServerConfig>) -> anyhow::Result<Self> {
+        match self {
+            Stream::Raw { raw } => {
+                let tls = Box::new(tokio_rustls::TlsAcceptor::from(cfg).accept(raw).await?);
+                Ok(Stream::Tls { tls })
+            }
+            Stream::Tls { .. } => anyhow::bail!("can't upgrade TLS stream"),
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for Stream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        context: &mut task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> task::Poll<io::Result<()>> {
+        use StreamProj::*;
+        match self.project() {
+            Raw { raw } => raw.poll_read(context, buf),
+            Tls { tls } => tls.poll_read(context, buf),
+        }
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for Stream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        context: &mut task::Context<'_>,
+        buf: &[u8],
+    ) -> task::Poll<io::Result<usize>> {
+        use StreamProj::*;
+        match self.project() {
+            Raw { raw } => raw.poll_write(context, buf),
+            Tls { tls } => tls.poll_write(context, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        context: &mut task::Context<'_>,
+    ) -> task::Poll<io::Result<()>> {
+        use StreamProj::*;
+        match self.project() {
+            Raw { raw } => raw.poll_flush(context),
+            Tls { tls } => tls.poll_flush(context),
+        }
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        context: &mut task::Context<'_>,
+    ) -> task::Poll<io::Result<()>> {
+        use StreamProj::*;
+        match self.project() {
+            Raw { raw } => raw.poll_shutdown(context),
+            Tls { tls } => tls.poll_shutdown(context),
+        }
+    }
+}

--- a/proxy/src/stream.rs
+++ b/proxy/src/stream.rs
@@ -49,6 +49,14 @@ impl<S: AsyncRead + Unpin> PqStream<S> {
             other => anyhow::bail!("bad message type: {:?}", other),
         }
     }
+
+    pub async fn read_password_message(&mut self) -> anyhow::Result<bytes::Bytes> {
+        match FeMessage::read_fut(&mut self.stream).await? {
+            Some(FeMessage::PasswordMessage(msg)) => Ok(msg),
+            None => anyhow::bail!("connection is lost"),
+            other => anyhow::bail!("bad message type: {:?}", other),
+        }
+    }
 }
 
 impl<S: AsyncWrite + Unpin> PqStream<S> {

--- a/zenith_utils/src/pq_proto.rs
+++ b/zenith_utils/src/pq_proto.rs
@@ -57,6 +57,16 @@ pub struct CancelKeyData {
     pub cancel_key: i32,
 }
 
+use rand::distributions::{Distribution, Standard};
+impl Distribution<CancelKeyData> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> CancelKeyData {
+        CancelKeyData {
+            backend_pid: rng.gen(),
+            cancel_key: rng.gen(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct FeQueryMessage {
     pub body: Bytes,


### PR DESCRIPTION
This is a pull request into https://github.com/zenithdb/zenith/tree/funbringer-proxy-async so that @funbringer can get a chance to comment before I merge into his branch.

Changes included:
1. Switch the waiter and the cplane api to async
2. Implement 4 kinds of routers https://github.com/zenithdb/console/issues/502 (also relevant: https://github.com/zenithdb/zenith/issues/920)
3. Implement 3 kinds of authentication
4. Add CLI option for router, while preserving backwards compatibility (the way we currently deploy proxy will still work)
5. Add mock cli to speed up development.

Current state:
All 4 routers seem to work. I tested using the cplane mock. Example commands:
- Run static router: `./proxy --router static`
- Run mixed router with mock cplane: `./proxy --mock-cplane localhost:3000`

TODO:
- [ ] Tidy up
- [ ] Write unit or python test
