### PR TITLE
support variable length ZId

### DIFF
--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use zenith_utils::auth::{encode_from_key_file, Claims, Scope};
 use zenith_utils::postgres_backend::AuthType;
-use zenith_utils::zid::{opt_display_serde, ZTenantId};
+use zenith_utils::zid::{serde_opt_display, ZTenantId};
 
 //
 // This data structures represents zenith CLI config
@@ -45,7 +45,7 @@ pub struct LocalEnv {
 
     // Default tenant ID to use with the 'zenith' command line utility, when
     // --tenantid is not explicitly specified.
-    #[serde(with = "opt_display_serde")]
+    #[serde(with = "serde_opt_display")]
     #[serde(default)]
     pub default_tenantid: Option<ZTenantId>,
 

--- a/pageserver/src/http/routes.rs
+++ b/pageserver/src/http/routes.rs
@@ -20,7 +20,7 @@ use zenith_utils::http::{
     request::parse_request_param,
 };
 use zenith_utils::lsn::Lsn;
-use zenith_utils::zid::{opt_display_serde, ZTimelineId};
+use zenith_utils::zid::{serde_opt_display, ZTimelineId};
 
 use super::models::BranchCreateRequest;
 use super::models::TenantCreateRequest;
@@ -198,7 +198,7 @@ enum TimelineInfo {
         timeline_id: ZTimelineId,
         #[serde(with = "hex")]
         tenant_id: ZTenantId,
-        #[serde(with = "opt_display_serde")]
+        #[serde(with = "serde_opt_display")]
         ancestor_timeline_id: Option<ZTimelineId>,
         last_record_lsn: Lsn,
         prev_record_lsn: Lsn,


### PR DESCRIPTION
Involves some workarounds for serde, which is currently does not support
arrays with length expressed as a const generic parameter. This
workaround might be useful in other places if or when we'll want to use
arrays with const generics.