### PR TITLE
Combine fsync for incoming AppendRequest's in safekeeper

### DIFF
--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -809,7 +809,7 @@ mod tests {
             Ok(())
         }
 
-        fn write_wal(&mut self, _server: &ServerInfo, _startpos: Lsn, _buf: &[u8], skip_sync: bool) -> Result<()> {
+        fn write_wal(&mut self, _server: &ServerInfo, _startpos: Lsn, _buf: &[u8], _skip_sync: bool) -> Result<()> {
             Ok(())
         }
 

--- a/walkeeper/src/safekeeper.rs
+++ b/walkeeper/src/safekeeper.rs
@@ -302,6 +302,7 @@ pub enum ProposerAcceptorMessage {
     VoteRequest(VoteRequest),
     Elected(ProposerElected),
     AppendRequest(AppendRequest),
+    FsyncRequest(Lsn),
 }
 
 impl ProposerAcceptorMessage {
@@ -411,7 +412,7 @@ pub trait Storage {
     /// Persist safekeeper state on disk.
     fn persist(&mut self, s: &SafeKeeperState) -> Result<()>;
     /// Write piece of wal in buf to disk and sync it.
-    fn write_wal(&mut self, server: &ServerInfo, startpos: Lsn, buf: &[u8]) -> Result<()>;
+    fn write_wal(&mut self, server: &ServerInfo, startpos: Lsn, buf: &[u8], skip_sync: bool) -> Result<()>;
     // Truncate WAL at specified LSN
     fn truncate_wal(&mut self, s: &ServerInfo, endpos: Lsn) -> Result<()>;
 }
@@ -544,6 +545,7 @@ where
             ProposerAcceptorMessage::VoteRequest(msg) => self.handle_vote_request(msg),
             ProposerAcceptorMessage::Elected(msg) => self.handle_elected(msg),
             ProposerAcceptorMessage::AppendRequest(msg) => self.handle_append_request(msg),
+            ProposerAcceptorMessage::FsyncRequest(lsn) => self.handle_fsync(*lsn),
         }
     }
 
@@ -671,6 +673,12 @@ where
         Ok(None)
     }
 
+    fn handle_fsync(&mut self, lsn: Lsn) -> Result<Option<AcceptorProposerMessage>> {
+        info!("received FsyncRequest");
+        self.storage.write_wal(&self.s.server, lsn, &[0u8; 0], false)?;
+        Ok(None)
+    }
+
     /// Handle request to append WAL.
     #[allow(clippy::comparison_chain)]
     fn handle_append_request(
@@ -704,7 +712,7 @@ where
             {
                 let _timer = self.metrics.write_wal_seconds.start_timer();
                 self.storage
-                    .write_wal(&self.s.server, msg.h.begin_lsn, &msg.wal_data)?;
+                    .write_wal(&self.s.server, msg.h.begin_lsn, &msg.wal_data, true)?;
             }
 
             // figure out last record's end lsn for reporting (if we got the
@@ -801,7 +809,7 @@ mod tests {
             Ok(())
         }
 
-        fn write_wal(&mut self, _server: &ServerInfo, _startpos: Lsn, _buf: &[u8]) -> Result<()> {
+        fn write_wal(&mut self, _server: &ServerInfo, _startpos: Lsn, _buf: &[u8], skip_sync: bool) -> Result<()> {
             Ok(())
         }
 

--- a/zenith_utils/src/postgres_backend.rs
+++ b/zenith_utils/src/postgres_backend.rs
@@ -229,6 +229,19 @@ impl PostgresBackend {
         }
     }
 
+    pub fn take_streams_io(&mut self) -> Option<(ReadStream, WriteStream)> {
+        let stream = self.stream.take();
+        match stream {
+            Some(Stream::Bidirectional(bidi_stream)) => {
+                Some(bidi_stream.split())
+            }
+            stream => {
+                self.stream = stream;
+                None
+            }
+        }
+    }
+
     /// Read full message or return None if connection is closed.
     pub fn read_message(&mut self) -> Result<Option<FeMessage>> {
         let (state, stream) = (self.state, self.get_stream_in()?);

--- a/zenith_utils/src/postgres_backend.rs
+++ b/zenith_utils/src/postgres_backend.rs
@@ -232,9 +232,7 @@ impl PostgresBackend {
     pub fn take_streams_io(&mut self) -> Option<(ReadStream, WriteStream)> {
         let stream = self.stream.take();
         match stream {
-            Some(Stream::Bidirectional(bidi_stream)) => {
-                Some(bidi_stream.split())
-            }
+            Some(Stream::Bidirectional(bidi_stream)) => Some(bidi_stream.split()),
             stream => {
                 self.stream = stream;
                 None


### PR DESCRIPTION
Implement optimization from https://github.com/zenithdb/zenith/issues/1144.

This seems to improve local results from #1141 by 2 times, but still 1.5-2 times lower than vanilla replication:

| Test info  | pgbench -i -s 200 (time) | pgbench -N -T 60 | wal_msg size | pg_wal size |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| NO PATCH safekeeper + wp (fsync=on, no checkpoints)  | 99 s | 1142 TPS | 411 b | 2608-2592 MB
| PATCHED safekeeper + wp (fsync=on, no checkpoints) | 85 s | 2662 TPS | 662 b | 2656-2592 MB
| vanilla repl (fsync=on, no checkpoints) | 141 s | 4183 TPS | 689 b | 2704-2608 MB

I'll post results for the #799 EC2 test later.