### PR TITLE
Rebuild postgres when zenith root Makefile changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,13 @@ jobs:
       - checkout
 
         # Grab the postgres git revision to build a cache key.
+        # Append makefile as it could change the way postgres is built.
         # Note this works even though the submodule hasn't been checkout out yet.
       - run:
           name: Get postgres cache key
-          command: git rev-parse HEAD:vendor/postgres > /tmp/cache-key-postgres
+          command: |
+              git rev-parse HEAD:vendor/postgres > /tmp/cache-key-postgres
+              cat Makefile >> /tmp/cache-key-postgres
 
       - restore_cache:
           name: Restore postgres cache
@@ -78,8 +81,8 @@ jobs:
       - checkout
 
         # Grab the postgres git revision to build a cache key.
+        # Append makefile as it could change the way postgres is built.
         # Note this works even though the submodule hasn't been checkout out yet.
-        # Append makefile as it could change the way postgres is built
       - run:
           name: Get postgres cache key
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,13 @@ jobs:
 
         # Grab the postgres git revision to build a cache key.
         # Note this works even though the submodule hasn't been checkout out yet.
+        # Append makefile as it could change the way postgres is built
       - run:
           name: Get postgres cache key
           command: |
             git rev-parse HEAD:vendor/postgres > /tmp/cache-key-postgres
+            cat Makefile >> tmp/cache-key-postgres
+
 
       - restore_cache:
           name: Restore postgres cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           name: Get postgres cache key
           command: |
             git rev-parse HEAD:vendor/postgres > /tmp/cache-key-postgres
-            cat Makefile >> tmp/cache-key-postgres
+            cat Makefile >> /tmp/cache-key-postgres
 
 
       - restore_cache:


### PR DESCRIPTION
Zenith root makefile is used to control Postgres build.
Include makefile into a the CI build cache key for Postgres, this will ensure that modifications to Makefile (unfortunately even unrelated) will trigger Postgres rebuild