### PR TITLE
revert docker build to debian:buster based rust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,8 +426,7 @@ jobs:
 
   # Build zenithdb/zenith:latest image and push it to Docker hub
   docker-image:
-    docker:
-      - image: cimg/base:2021.04
+    executor: zenith-xlarge-executor
     steps:
       - checkout
       - setup_remote_docker:
@@ -440,8 +439,13 @@ jobs:
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG=$(git log --oneline|wc -l)
-            docker build --build-arg GIT_VERSION=$CIRCLE_SHA1 -t zenithdb/zenith:latest . && docker push zenithdb/zenith:latest
-            docker tag zenithdb/zenith:latest zenithdb/zenith:${DOCKER_TAG} && docker push zenithdb/zenith:${DOCKER_TAG}
+            docker build \
+              --build-arg GIT_VERSION=${CIRCLE_SHA1} \
+              --build-arg AWS_ACCESS_KEY_ID=${CACHEPOT_AWS_ACCESS_KEY_ID} \
+              --build-arg AWS_SECRET_ACCESS_KEY=${CACHEPOT_AWS_SECRET_ACCESS_KEY} \
+              --tag zenithdb/zenith:${DOCKER_TAG} --tag zenithdb/zenith:latest .
+            #docker push zenithdb/zenith:${DOCKER_TAG}
+            #docker push zenithdb/zenith:latest
 
   # Build zenithdb/compute-node:latest image and push it to Docker hub
   docker-image-compute:
@@ -468,13 +472,13 @@ jobs:
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG=$(git log --oneline|wc -l)
-            docker build -t zenithdb/compute-node:latest vendor/postgres && docker push zenithdb/compute-node:latest
-            docker tag zenithdb/compute-node:latest zenithdb/compute-node:${DOCKER_TAG} && docker push zenithdb/compute-node:${DOCKER_TAG}
+            docker build --tag zenithdb/compute-node:${DOCKER_TAG} --tag zenithdb/compute-node:latest vendor/postgres
+            docker push zenithdb/compute-node:${DOCKER_TAG}
+            docker push zenithdb/compute-node:latest
 
   # Build production zenithdb/zenith:release image and push it to Docker hub
   docker-image-release:
-    docker:
-      - image: cimg/base:2021.04
+    executor: zenith-xlarge-executor
     steps:
       - checkout
       - setup_remote_docker:
@@ -487,8 +491,13 @@ jobs:
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG="release-$(git log --oneline|wc -l)"
-            docker build --build-arg GIT_VERSION=$CIRCLE_SHA1 -t zenithdb/zenith:release . && docker push zenithdb/zenith:release
-            docker tag zenithdb/zenith:release zenithdb/zenith:${DOCKER_TAG} && docker push zenithdb/zenith:${DOCKER_TAG}
+            docker build \
+              --build-arg GIT_VERSION=${CIRCLE_SHA1} \
+              --build-arg AWS_ACCESS_KEY_ID=${CACHEPOT_AWS_ACCESS_KEY_ID} \
+              --build-arg AWS_SECRET_ACCESS_KEY=${CACHEPOT_AWS_SECRET_ACCESS_KEY} \
+              --tag zenithdb/zenith:${DOCKER_TAG} --tag zenithdb/zenith:release .
+            docker push zenithdb/zenith:${DOCKER_TAG}
+            docker push zenithdb/zenith:release
 
   # Build production zenithdb/compute-node:release image and push it to Docker hub
   docker-image-compute-release:
@@ -515,8 +524,9 @@ jobs:
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG="release-$(git log --oneline|wc -l)"
-            docker build -t zenithdb/compute-node:release vendor/postgres && docker push zenithdb/compute-node:release
-            docker tag zenithdb/compute-node:release zenithdb/compute-node:${DOCKER_TAG} && docker push zenithdb/compute-node:${DOCKER_TAG}
+            docker build --tag zenithdb/compute-node:${DOCKER_TAG} --tag zenithdb/compute-node:release vendor/postgres
+            docker push zenithdb/compute-node:${DOCKER_TAG}
+            docker push zenithdb/compute-node:release
 
   deploy-staging:
     docker:
@@ -719,6 +729,7 @@ workflows:
             branches:
               only:
                 - main
+                - docker_improvement
           requires:
             - pg_regress-tests-release
             - other-tests-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
   # Build zenithdb/zenith:latest image and push it to Docker hub
   docker-image:
     docker:
-      - image: zimg/rust:1.56
+      - image: cimg/base:2021.04
     steps:
       - checkout
       - setup_remote_docker:
@@ -446,8 +446,8 @@ jobs:
               --build-arg AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}" \
               --build-arg AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}" \
               --tag zenithdb/zenith:${DOCKER_TAG} --tag zenithdb/zenith:latest .
-            #docker push zenithdb/zenith:${DOCKER_TAG}
-            #docker push zenithdb/zenith:latest
+            docker push zenithdb/zenith:${DOCKER_TAG}
+            docker push zenithdb/zenith:latest
 
   # Build zenithdb/compute-node:latest image and push it to Docker hub
   docker-image-compute:
@@ -480,7 +480,8 @@ jobs:
 
   # Build production zenithdb/zenith:release image and push it to Docker hub
   docker-image-release:
-    executor: zenith-xlarge-executor
+    docker:
+      - image: cimg/base:2021.04
     steps:
       - checkout
       - setup_remote_docker:
@@ -494,9 +495,10 @@ jobs:
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG="release-$(git log --oneline|wc -l)"
             docker build \
+              --pull \
               --build-arg GIT_VERSION=${CIRCLE_SHA1} \
-              --build-arg AWS_ACCESS_KEY_ID=${CACHEPOT_AWS_ACCESS_KEY_ID} \
-              --build-arg AWS_SECRET_ACCESS_KEY=${CACHEPOT_AWS_SECRET_ACCESS_KEY} \
+              --build-arg AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}" \
+              --build-arg AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}" \
               --tag zenithdb/zenith:${DOCKER_TAG} --tag zenithdb/zenith:release .
             docker push zenithdb/zenith:${DOCKER_TAG}
             docker push zenithdb/zenith:release
@@ -731,10 +733,9 @@ workflows:
             branches:
               only:
                 - main
-                - docker_improvement
-#          requires:
-#            - pg_regress-tests-release
-#            - other-tests-release
+          requires:
+            - pg_regress-tests-release
+            - other-tests-release
       - docker-image-compute:
           # Context gives an ability to login
           context: Docker Hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,9 @@ jobs:
 
   # Build zenithdb/zenith:latest image and push it to Docker hub
   docker-image:
-    executor: zenith-xlarge-executor
+    docker:
+      - image: zimg/rust:1.56
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:
@@ -437,6 +439,8 @@ jobs:
       - run:
           name: Build and push Docker image
           command: |
+            nproc
+            free -h
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG=$(git log --oneline|wc -l)
             docker build \
@@ -741,9 +745,9 @@ workflows:
             branches:
               only:
                 - main
-          requires:
-            - pg_regress-tests-release
-            - other-tests-release
+#          requires:
+#            - pg_regress-tests-release
+#            - other-tests-release
       - deploy-staging:
           # Context gives an ability to login
           context: Docker Hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,7 +428,6 @@ jobs:
   docker-image:
     docker:
       - image: zimg/rust:1.56
-    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:
@@ -439,14 +438,13 @@ jobs:
       - run:
           name: Build and push Docker image
           command: |
-            nproc
-            free -h
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             DOCKER_TAG=$(git log --oneline|wc -l)
             docker build \
+              --pull \
               --build-arg GIT_VERSION=${CIRCLE_SHA1} \
-              --build-arg AWS_ACCESS_KEY_ID=${CACHEPOT_AWS_ACCESS_KEY_ID} \
-              --build-arg AWS_SECRET_ACCESS_KEY=${CACHEPOT_AWS_SECRET_ACCESS_KEY} \
+              --build-arg AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}" \
+              --build-arg AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}" \
               --tag zenithdb/zenith:${DOCKER_TAG} --tag zenithdb/zenith:latest .
             #docker push zenithdb/zenith:${DOCKER_TAG}
             #docker push zenithdb/zenith:latest
@@ -734,9 +732,9 @@ workflows:
               only:
                 - main
                 - docker_improvement
-          requires:
-            - pg_regress-tests-release
-            - other-tests-release
+#          requires:
+#            - pg_regress-tests-release
+#            - other-tests-release
       - docker-image-compute:
           # Context gives an ability to login
           context: Docker Hub
@@ -745,9 +743,9 @@ workflows:
             branches:
               only:
                 - main
-#          requires:
-#            - pg_regress-tests-release
-#            - other-tests-release
+          requires:
+            - pg_regress-tests-release
+            - other-tests-release
       - deploy-staging:
           # Context gives an ability to login
           context: Docker Hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build Postgres
 #
-FROM zimg/rust:1.56 AS pg-build
+#FROM zimg/rust:1.56 AS pg-build
+FROM zenithdb/build:buster-20220309 AS pg-build
 WORKDIR /pg
 
 USER root
@@ -16,13 +17,15 @@ RUN set -e \
 
 # Build zenith binaries
 #
-FROM zimg/rust:1.56 AS build
+#FROM zimg/rust:1.56 AS build
+FROM zenithdb/build:buster-20220309 AS build
 ARG GIT_VERSION=local
 
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
-ENV RUSTC_WRAPPER cachepot
+#ENV RUSTC_WRAPPER cachepot
+ENV RUSTC_WRAPPER /usr/local/cargo/bin/cachepot
 
 COPY --from=pg-build /pg/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,14 @@ FROM zimg/rust:1.56 AS build
 ARG GIT_VERSION=local
 
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
-ARG AWS_REGION
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
+ENV RUSTC_WRAPPER cachepot
 
 COPY --from=pg-build /pg/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
 COPY . .
 
-RUN set -e \
-    && if [ -n "${AWS_ACCESS_KEY_ID}" -a -n "${AWS_SECRET_ACCESS_KEY}" ]; then export RUSTC_WRAPPER=cachepot; fi \
-    && cargo build --release
+RUN cargo build --release
 
 # Build final image
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,60 @@
-#
-# Docker image for console integration testing.
-#
-
-#
-# Build Postgres separately --- this layer will be rebuilt only if one of
-# mentioned paths will get any changes.
+# Build Postgres
 #
 FROM zimg/rust:1.56 AS pg-build
-WORKDIR /zenith
-COPY ./vendor/postgres vendor/postgres
-COPY ./Makefile Makefile
-ENV BUILD_TYPE release
-RUN make -j $(getconf _NPROCESSORS_ONLN) -s postgres
-RUN rm -rf postgres_install/build
+WORKDIR /pg
 
-#
+USER root
+
+COPY vendor/postgres vendor/postgres
+COPY Makefile Makefile
+
+ENV BUILD_TYPE release
+RUN set -e \
+    && make -j $(nproc) -s postgres \
+    && rm -rf tmp_install/build \
+    && tar -C tmp_install -czf /postgres_install.tar.gz .
+
 # Build zenith binaries
 #
-# TODO: build cargo deps as separate layer. We used cargo-chef before but that was
-# net time waste in a lot of cases. Copying Cargo.lock with empty lib.rs should do the work.
-#
 FROM zimg/rust:1.56 AS build
+ARG GIT_VERSION=local
 
-ARG GIT_VERSION
-RUN if [ -z "$GIT_VERSION" ]; then echo "GIT_VERSION is reqired, use build_arg to pass it"; exit 1; fi
+ARG CACHEPOT_BUCKET=zenith-rust-cachepot
+ARG AWS_REGION
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
-WORKDIR /zenith
-COPY --from=pg-build /zenith/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
-
+COPY --from=pg-build /pg/tmp_install/include/postgresql/server tmp_install/include/postgresql/server
 COPY . .
-RUN GIT_VERSION=$GIT_VERSION cargo build --release
 
-#
-# Copy binaries to resulting image.
+RUN set -e \
+    && if [ -n "${AWS_ACCESS_KEY_ID}" -a -n "${AWS_SECRET_ACCESS_KEY}" ]; then export RUSTC_WRAPPER=cachepot; fi \
+    && cargo build --release
+
+# Build final image
 #
 FROM debian:bullseye-slim
 WORKDIR /data
 
-RUN apt-get update && apt-get -yq install libreadline-dev libseccomp-dev openssl ca-certificates && \
-    mkdir zenith_install
+RUN set -e \
+    && apt-get update \
+    && apt-get install -y \
+        libreadline-dev \
+        libseccomp-dev \
+        openssl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && useradd -d /data zenith \
+    && chown -R zenith:zenith /data
 
-COPY --from=build /zenith/target/release/pageserver /usr/local/bin
-COPY --from=build /zenith/target/release/safekeeper /usr/local/bin
-COPY --from=build /zenith/target/release/proxy /usr/local/bin
-COPY --from=pg-build /zenith/tmp_install postgres_install
+COPY --from=build --chown=zenith:zenith /home/circleci/project/target/release/pageserver /usr/local/bin
+COPY --from=build --chown=zenith:zenith /home/circleci/project/target/release/safekeeper /usr/local/bin
+COPY --from=build --chown=zenith:zenith /home/circleci/project/target/release/proxy      /usr/local/bin
+
+COPY --from=pg-build /pg/tmp_install/         /usr/local/
+COPY --from=pg-build /postgres_install.tar.gz /data/
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-
-# Remove build artifacts (~ 500 MB)
-RUN rm -rf postgres_install/build && \
-    # 'Install' Postgres binaries locally
-    cp -r postgres_install/* /usr/local/ && \
-    # Prepare an archive of Postgres binaries (should be around 11 MB)
-    # and keep it inside container for an ease of deploy pipeline.
-    cd postgres_install && tar -czf /data/postgres_install.tar.gz . && cd .. && \
-    rm -rf postgres_install
-
-RUN useradd -d /data zenith && chown -R zenith:zenith /data
 
 VOLUME ["/data"]
 USER zenith

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,23 @@
+FROM rust:1.56.1-slim-buster
+WORKDIR /home/circleci/project
+
+RUN set -e \
+    && apt-get update \
+    && apt-get -yq install \
+        automake \
+        libtool \
+        build-essential \
+        bison \
+        flex \
+        libreadline-dev \
+        zlib1g-dev \
+        libxml2-dev \
+        libseccomp-dev \
+        pkg-config \
+        libssl-dev \
+        clang
+
+RUN set -e \
+    && rustup component add clippy \
+    && cargo install cargo-audit \
+    && cargo install --git https://github.com/paritytech/cachepot


### PR DESCRIPTION
`zimg/rust:1.56` has too recent libc6 version (as image based on Debian 11) and not compatible with current zenith storage infrastructure (based on Debian 10)
