### PR TITLE
Compile and run unit tests on macOs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
         # If we want to duplicate this job for different
         # Rust toolchains (e.g. nightly or 1.37.0), add them here.
         rust_toolchain: [stable]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     timeout-minutes: 30
     name: run regression test suite
     runs-on: ${{ matrix.os }}
@@ -32,10 +32,16 @@ jobs:
           toolchain: ${{ matrix.rust_toolchain }}
           override: true
 
-      - name: Install postgres dependencies
+      - name: Install Ubuntu postgres dependencies
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt update
           sudo apt install build-essential libreadline-dev zlib1g-dev flex bison libseccomp-dev
+
+      - name: Install macOs postgres dependencies
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install flex bison
 
       - name: Set pg revision for caching
         id: pg_ver

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,10 +1,6 @@
 name: Build and Test
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: push
 
 jobs:
   regression-check:


### PR DESCRIPTION
Closes https://github.com/zenithdb/zenith/issues/556

Uses _**non-arm**_ macOs runner from https://github.com/actions/virtual-environments
Currently no arm runners are supported in GitHub.

Note that the GitHub workflow I've edited runs only on `main` branch, which is quite surprising: the job is a basic debug build with unit test run.
Should we rather run it on every PR/push to check postgres macOs miscompilations eagerly?

CI runs for hacked version, showing that Ubuntu and macOs build pass:
* [Ubuntu](https://github.com/zenithdb/zenith/runs/5550732113?check_suite_focus=true)
* [macOs](https://github.com/zenithdb/zenith/runs/5550732224?check_suite_focus=true)