### PR TITLE
Add safekeeper information exchange through etcd.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +724,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcd-client"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585de5039d1ecce74773db49ba4e8107e42be7c2cd0b1a9e7fce27181db7b118"
+dependencies = [
+ "http",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+ "tower-service",
+]
+
+[[package]]
 name = "fail"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +775,12 @@ dependencies = [
  "redox_syscall",
  "winapi",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "fnv"
@@ -925,7 +967,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -951,6 +993,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1072,6 +1123,18 @@ dependencies = [
  "rustls 0.20.2",
  "tokio",
  "tokio-rustls 0.23.2",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1307,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -1326,6 +1389,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nix"
@@ -1557,6 +1626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1855,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "proxy"
 version = "0.1.0"
 dependencies = [
@@ -1977,7 +2109,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls 0.23.2",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2506,9 +2638,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -2518,8 +2650,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2552,7 +2695,7 @@ dependencies = [
  "postgres-types 0.2.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
  "socket2",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -2574,7 +2717,7 @@ dependencies = [
  "postgres-types 0.2.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=9eb0dbfbeb6a6c1b79099b9f7ae4a8c021877858)",
  "socket2",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -2640,6 +2783,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,6 +2819,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.0",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2674,6 +2900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2767,6 +2994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +3069,7 @@ dependencies = [
  "const_format",
  "crc32c",
  "daemonize",
+ "etcd-client",
  "fs2",
  "hex",
  "humantime",
@@ -2848,11 +3082,13 @@ dependencies = [
  "rust-s3",
  "serde",
  "serde_json",
+ "serde_with",
  "signal-hook",
  "tempfile",
  "tokio",
  "tokio-postgres 0.7.1 (git+https://github.com/zenithdb/rust-postgres.git?rev=2949d98df52587d562986aad155dd4e889e408b7)",
  "tracing",
+ "url",
  "walkdir",
  "workspace_hack",
  "zenith_metrics",

--- a/control_plane/src/local_env.rs
+++ b/control_plane/src/local_env.rs
@@ -57,6 +57,10 @@ pub struct LocalEnv {
     #[serde(default)]
     pub private_key_path: PathBuf,
 
+    // A comma separated broker (etcd) endpoints for storage nodes coordination, e.g. 'http://127.0.0.1:2379'.
+    #[serde(default)]
+    pub broker_endpoints: Option<String>,
+
     pub pageserver: PageServerConf,
 
     #[serde(default)]

--- a/control_plane/src/safekeeper.rs
+++ b/control_plane/src/safekeeper.rs
@@ -73,6 +73,8 @@ pub struct SafekeeperNode {
     pub http_base_url: String,
 
     pub pageserver: Arc<PageServerNode>,
+
+    broker_endpoints: Option<String>,
 }
 
 impl SafekeeperNode {
@@ -89,6 +91,7 @@ impl SafekeeperNode {
             http_client: Client::new(),
             http_base_url: format!("http://127.0.0.1:{}/v1", conf.http_port),
             pageserver,
+            broker_endpoints: env.broker_endpoints.clone(),
         }
     }
 
@@ -134,6 +137,9 @@ impl SafekeeperNode {
         );
         if !self.conf.sync {
             cmd.arg("--no-sync");
+        }
+        if let Some(ref ep) = self.broker_endpoints {
+            cmd.args(&["--broker-endpoints", ep]);
         }
 
         if !cmd.status()?.success() {

--- a/test_runner/README.md
+++ b/test_runner/README.md
@@ -10,6 +10,8 @@ Prerequisites:
       below to run from other directories.
 - The zenith git repo, including the postgres submodule
   (for some tests, e.g. `pg_regress`)
+- Some tests (involving storage nodes coordination) require etcd installed. Follow
+  [`the guide`](https://etcd.io/docs/v3.5/install/) to obtain it.
 
 ### Test Organization
 

--- a/test_runner/fixtures/utils.py
+++ b/test_runner/fixtures/utils.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 
 from typing import Any, List
@@ -76,3 +77,8 @@ def print_gc_result(row):
     log.info(
         "  total: {layers_total}, needed_by_cutoff {layers_needed_by_cutoff}, needed_by_branches: {layers_needed_by_branches}, not_updated: {layers_not_updated}, removed: {layers_removed}"
         .format_map(row))
+
+
+# path to etcd binary or None if not present.
+def etcd_path():
+    return shutil.which("etcd")

--- a/walkeeper/Cargo.toml
+++ b/walkeeper/Cargo.toml
@@ -22,11 +22,14 @@ anyhow = "1.0"
 crc32c = "0.6.0"
 humantime = "2.1.0"
 walkdir = "2"
+url = "2.2.2"
 signal-hook = "0.3.10"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = {version = "1.12.0"}
 hex = "0.4.3"
 const_format = "0.2.21"
 tokio-postgres = { git = "https://github.com/zenithdb/rust-postgres.git", rev="2949d98df52587d562986aad155dd4e889e408b7" }
+etcd-client = "0.8.3"
 
 postgres_ffi = { path = "../postgres_ffi" }
 workspace_hack = { path = "../workspace_hack" }

--- a/walkeeper/src/broker.rs
+++ b/walkeeper/src/broker.rs
@@ -1,0 +1,211 @@
+//! Communication with etcd, providing safekeeper peers and pageserver coordination.
+
+use anyhow::bail;
+use anyhow::Context;
+use anyhow::Error;
+use anyhow::Result;
+use etcd_client::Client;
+use etcd_client::EventType;
+use etcd_client::PutOptions;
+use etcd_client::WatchOptions;
+use lazy_static::lazy_static;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+use std::str::FromStr;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio::{runtime, time::sleep};
+use tracing::*;
+use zenith_utils::zid::ZTenantId;
+use zenith_utils::zid::ZTimelineId;
+use zenith_utils::{
+    lsn::Lsn,
+    zid::{ZNodeId, ZTenantTimelineId},
+};
+
+use crate::{safekeeper::Term, timeline::GlobalTimelines, SafeKeeperConf};
+
+const RETRY_INTERVAL_MSEC: u64 = 1000;
+const PUSH_INTERVAL_MSEC: u64 = 1000;
+const LEASE_TTL_SEC: i64 = 5;
+// TODO: add global zenith installation ID.
+const ZENITH_PREFIX: &str = "zenith";
+
+/// Published data about safekeeper. Fields made optional for easy migrations.
+#[serde_as]
+#[derive(Deserialize, Serialize)]
+pub struct SafekeeperInfo {
+    /// Term of the last entry.
+    pub last_log_term: Option<Term>,
+    /// LSN of the last record.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub flush_lsn: Option<Lsn>,
+    /// Up to which LSN safekeeper regards its WAL as committed.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub commit_lsn: Option<Lsn>,
+    /// LSN up to which safekeeper offloaded WAL to s3.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub s3_wal_lsn: Option<Lsn>,
+    /// LSN of last checkpoint uploaded by pageserver.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub remote_consistent_lsn: Option<Lsn>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub peer_horizon_lsn: Option<Lsn>,
+}
+
+pub fn thread_main(conf: SafeKeeperConf) {
+    let runtime = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let _enter = info_span!("broker").entered();
+    info!("started, broker endpoints {:?}", conf.broker_endpoints);
+
+    runtime.block_on(async {
+        main_loop(conf).await;
+    });
+}
+
+/// Prefix to timeline related data.
+fn timeline_path(zttid: &ZTenantTimelineId) -> String {
+    format!(
+        "{}/{}/{}",
+        ZENITH_PREFIX, zttid.tenant_id, zttid.timeline_id
+    )
+}
+
+/// Key to per timeline per safekeeper data.
+fn timeline_safekeeper_path(zttid: &ZTenantTimelineId, sk_id: ZNodeId) -> String {
+    format!("{}/safekeeper/{}", timeline_path(zttid), sk_id)
+}
+
+/// Push once in a while data about all active timelines to the broker.
+async fn push_loop(conf: SafeKeeperConf) -> Result<()> {
+    let mut client = Client::connect(conf.broker_endpoints.as_ref().unwrap(), None).await?;
+
+    // Get and maintain lease to automatically delete obsolete data
+    let lease = client.lease_grant(LEASE_TTL_SEC, None).await?;
+    let (mut keeper, mut ka_stream) = client.lease_keep_alive(lease.id()).await?;
+
+    let push_interval = Duration::from_millis(PUSH_INTERVAL_MSEC);
+    loop {
+        // Note: we lock runtime here and in timeline methods as GlobalTimelines
+        // is under plain mutex. That's ok, all this code is not performance
+        // sensitive and there is no risk of deadlock as we don't await while
+        // lock is held.
+        let active_tlis = GlobalTimelines::get_active_timelines();
+        for zttid in &active_tlis {
+            if let Ok(tli) = GlobalTimelines::get(&conf, *zttid, false) {
+                let sk_info = tli.get_public_info();
+                let put_opts = PutOptions::new().with_lease(lease.id());
+                client
+                    .put(
+                        timeline_safekeeper_path(zttid, conf.my_id),
+                        serde_json::to_string(&sk_info)?,
+                        Some(put_opts),
+                    )
+                    .await
+                    .context("failed to push safekeeper info")?;
+            }
+        }
+        // revive the lease
+        keeper
+            .keep_alive()
+            .await
+            .context("failed to send LeaseKeepAliveRequest")?;
+        ka_stream
+            .message()
+            .await
+            .context("failed to receive LeaseKeepAliveResponse")?;
+        sleep(push_interval).await;
+    }
+}
+
+/// Subscribe and fetch all the interesting data from the broker.
+async fn pull_loop(conf: SafeKeeperConf) -> Result<()> {
+    lazy_static! {
+        static ref TIMELINE_SAFEKEEPER_RE: Regex =
+            Regex::new(r"^zenith/([[:xdigit:]]+)/([[:xdigit:]]+)/safekeeper/([[:digit:]])$")
+                .unwrap();
+    }
+    let mut client = Client::connect(conf.broker_endpoints.as_ref().unwrap(), None).await?;
+    loop {
+        let wo = WatchOptions::new().with_prefix();
+        // TODO: subscribe only to my timelines
+        let (_, mut stream) = client.watch(ZENITH_PREFIX, Some(wo)).await?;
+        while let Some(resp) = stream.message().await? {
+            if resp.canceled() {
+                bail!("watch canceled");
+            }
+
+            for event in resp.events() {
+                if EventType::Put == event.event_type() {
+                    if let Some(kv) = event.kv() {
+                        if let Some(caps) = TIMELINE_SAFEKEEPER_RE.captures(kv.key_str()?) {
+                            let tenant_id = ZTenantId::from_str(caps.get(1).unwrap().as_str())?;
+                            let timeline_id = ZTimelineId::from_str(caps.get(2).unwrap().as_str())?;
+                            let zttid = ZTenantTimelineId::new(tenant_id, timeline_id);
+                            let safekeeper_id = ZNodeId(caps.get(3).unwrap().as_str().parse()?);
+                            let value_str = kv.value_str()?;
+                            match serde_json::from_str::<SafekeeperInfo>(value_str) {
+                                Ok(safekeeper_info) => {
+                                    if let Ok(tli) = GlobalTimelines::get(&conf, zttid, false) {
+                                        tli.record_safekeeper_info(&safekeeper_info, safekeeper_id)?
+                                    }
+                                }
+                                Err(err) => warn!(
+                                    "failed to deserialize safekeeper info {}: {}",
+                                    value_str, err
+                                ),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn main_loop(conf: SafeKeeperConf) {
+    let mut ticker = tokio::time::interval(Duration::from_millis(RETRY_INTERVAL_MSEC));
+    let mut push_handle: Option<JoinHandle<Result<(), Error>>> = None;
+    let mut pull_handle: Option<JoinHandle<Result<(), Error>>> = None;
+    // Selecting on JoinHandles requires some squats; is there a better way to
+    // reap tasks individually?
+
+    // Handling failures in task itself won't catch panic and in Tokio, task's
+    // panic doesn't kill the whole executor, so it is better to do reaping
+    // here.
+    loop {
+        tokio::select! {
+                res = async { push_handle.as_mut().unwrap().await }, if push_handle.is_some() => {
+                    // was it panic or normal error?
+                    let err = match res {
+                        Ok(res_internal) => res_internal.unwrap_err(),
+                        Err(err_outer) => err_outer.into(),
+                    };
+                    warn!("push task failed: {:?}", err);
+                    push_handle = None;
+                },
+                res = async { pull_handle.as_mut().unwrap().await }, if pull_handle.is_some() => {
+                    // was it panic or normal error?
+                    let err = match res {
+                        Ok(res_internal) => res_internal.unwrap_err(),
+                        Err(err_outer) => err_outer.into(),
+                    };
+                    warn!("pull task failed: {:?}", err);
+                    pull_handle = None;
+                },
+                _ = ticker.tick() => {
+                    if push_handle.is_none() {
+                        push_handle = Some(tokio::spawn(push_loop(conf.clone())));
+                    }
+                    if pull_handle.is_none() {
+                        pull_handle = Some(tokio::spawn(pull_loop(conf.clone())));
+                    }
+            }
+        }
+    }
+}

--- a/walkeeper/src/handler.rs
+++ b/walkeeper/src/handler.rs
@@ -168,7 +168,14 @@ impl SafekeeperPostgresHandler {
     fn handle_identify_system(&mut self, pgb: &mut PostgresBackend) -> Result<()> {
         let start_pos = self.timeline.get().get_end_of_wal();
         let lsn = start_pos.to_string();
-        let sysid = self.timeline.get().get_info().server.system_id.to_string();
+        let sysid = self
+            .timeline
+            .get()
+            .get_state()
+            .1
+            .server
+            .system_id
+            .to_string();
         let lsn_bytes = lsn.as_bytes();
         let tli = PG_TLI.to_string();
         let tli_bytes = tli.as_bytes();

--- a/walkeeper/src/lib.rs
+++ b/walkeeper/src/lib.rs
@@ -1,9 +1,11 @@
 //
 use std::path::PathBuf;
 use std::time::Duration;
+use url::Url;
 
 use zenith_utils::zid::{ZNodeId, ZTenantTimelineId};
 
+pub mod broker;
 pub mod callmemaybe;
 pub mod control_file;
 pub mod control_file_upgrade;
@@ -47,6 +49,7 @@ pub struct SafeKeeperConf {
     pub ttl: Option<Duration>,
     pub recall_period: Duration,
     pub my_id: ZNodeId,
+    pub broker_endpoints: Option<Vec<Url>>,
 }
 
 impl SafeKeeperConf {
@@ -71,6 +74,7 @@ impl Default for SafeKeeperConf {
             ttl: None,
             recall_period: defaults::DEFAULT_RECALL_PERIOD,
             my_id: ZNodeId(0),
+            broker_endpoints: None,
         }
     }
 }

--- a/walkeeper/src/send_wal.rs
+++ b/walkeeper/src/send_wal.rs
@@ -230,7 +230,7 @@ impl ReplicationConn {
 
         let mut wal_seg_size: usize;
         loop {
-            wal_seg_size = spg.timeline.get().get_info().server.wal_seg_size as usize;
+            wal_seg_size = spg.timeline.get().get_state().1.server.wal_seg_size as usize;
             if wal_seg_size == 0 {
                 error!("Cannot start replication before connecting to wal_proposer");
                 sleep(Duration::from_secs(1));


### PR DESCRIPTION
    Add safekeeper information exchange through etcd.
    
    Safekeers now publish to and pull from etcd per-timeline data. Immediate goal is
    WAL truncation, for which every safekeeper must know remote_consistent_lsn; the
    next would be callmemaybe replacement.
    
    Adds corresponding '--broker' argument to safekeeper and ability to run etcd in
    tests.