### PR TITLE
Shutdown pageserver on thread errors

### DIFF
--- a/control_plane/src/storage.rs
+++ b/control_plane/src/storage.rs
@@ -148,12 +148,20 @@ impl PageServerNode {
         let initial_timeline_id_string = initial_timeline_id.to_string();
         args.extend(["--initial-timeline-id", &initial_timeline_id_string]);
 
-        let init_output = fill_rust_env_vars(cmd.args(args))
+        let cmd_with_args = cmd.args(args);
+        let init_output = fill_rust_env_vars(cmd_with_args)
             .output()
-            .context("pageserver init failed")?;
+            .with_context(|| {
+                format!("failed to init pageserver with command {:?}", cmd_with_args)
+            })?;
 
         if !init_output.status.success() {
-            bail!("pageserver init failed");
+            bail!(
+                "init invocation failed, {}\nStdout: {}\nStderr: {}",
+                init_output.status,
+                String::from_utf8_lossy(&init_output.stdout),
+                String::from_utf8_lossy(&init_output.stderr)
+            );
         }
 
         Ok(initial_timeline_id)

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -145,16 +145,17 @@ impl<'a> Basebackup<'a> {
             .timeline
             .get_relish_size(RelishTag::Slru { slru, segno }, self.lsn)?;
 
-        if seg_size == None {
-            trace!(
-                "SLRU segment {}/{:>04X} was truncated",
-                slru.to_str(),
-                segno
-            );
-            return Ok(());
-        }
-
-        let nblocks = seg_size.unwrap();
+        let nblocks = match seg_size {
+            Some(seg_size) => seg_size,
+            None => {
+                trace!(
+                    "SLRU segment {}/{:>04X} was truncated",
+                    slru.to_str(),
+                    segno
+                );
+                return Ok(());
+            }
+        };
 
         let mut slru_buf: Vec<u8> =
             Vec::with_capacity(nblocks as usize * pg_constants::BLCKSZ as usize);

--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -10,7 +10,7 @@
 //! This module is responsible for creation of such tarball
 //! from data stored in object storage.
 //!
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use bytes::{BufMut, BytesMut};
 use log::*;
 use std::fmt::Write as FmtWrite;
@@ -163,7 +163,7 @@ impl<'a> Basebackup<'a> {
             let img =
                 self.timeline
                     .get_page_at_lsn(RelishTag::Slru { slru, segno }, blknum, self.lsn)?;
-            assert!(img.len() == pg_constants::BLCKSZ as usize);
+            ensure!(img.len() == pg_constants::BLCKSZ as usize);
 
             slru_buf.extend_from_slice(&img);
         }
@@ -197,7 +197,7 @@ impl<'a> Basebackup<'a> {
             String::from("global/pg_filenode.map") // filenode map for global tablespace
         } else {
             // User defined tablespaces are not supported
-            assert!(spcnode == pg_constants::DEFAULTTABLESPACE_OID);
+            ensure!(spcnode == pg_constants::DEFAULTTABLESPACE_OID);
 
             // Append dir path for each database
             let path = format!("base/{}", dbnode);
@@ -211,7 +211,7 @@ impl<'a> Basebackup<'a> {
 
             format!("base/{}/pg_filenode.map", dbnode)
         };
-        assert!(img.len() == 512);
+        ensure!(img.len() == 512);
         let header = new_tar_header(&path, img.len() as u64)?;
         self.ar.append(&header, &img[..])?;
         Ok(())
@@ -292,7 +292,7 @@ impl<'a> Basebackup<'a> {
         let wal_file_path = format!("pg_wal/{}", wal_file_name);
         let header = new_tar_header(&wal_file_path, pg_constants::WAL_SEGMENT_SIZE as u64)?;
         let wal_seg = generate_wal_segment(segno, pg_control.system_identifier);
-        assert!(wal_seg.len() == pg_constants::WAL_SEGMENT_SIZE);
+        ensure!(wal_seg.len() == pg_constants::WAL_SEGMENT_SIZE);
         self.ar.append(&header, &wal_seg[..])?;
         Ok(())
     }

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -30,7 +30,7 @@ use zenith_utils::postgres_backend;
 use zenith_utils::shutdown::exit_now;
 use zenith_utils::signals::{self, Signal};
 
-fn main() -> Result<()> {
+fn main() -> anyhow::Result<()> {
     zenith_metrics::set_common_metrics_prefix("pageserver");
     let arg_matches = App::new("Zenith page server")
         .about("Materializes WAL stream to pages and serves them to the postgres")
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
         // We're initializing the repo, so there's no config file yet
         DEFAULT_CONFIG_FILE
             .parse::<toml_edit::Document>()
-            .expect("could not parse built-in config file")
+            .context("could not parse built-in config file")?
     } else {
         // Supplement the CLI arguments with the config file
         let cfg_file_contents = std::fs::read_to_string(&cfg_file_path)
@@ -210,7 +210,9 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
 
         // There shouldn't be any logging to stdin/stdout. Redirect it to the main log so
         // that we will see any accidental manual fprintf's or backtraces.
-        let stdout = log_file.try_clone().unwrap();
+        let stdout = log_file
+            .try_clone()
+            .with_context(|| format!("Failed to clone log file '{:?}'", log_file))?;
         let stderr = log_file;
 
         let daemonize = Daemonize::new()

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -26,7 +26,6 @@ use pageserver::{
     timelines, virtual_file, LOG_FILE_NAME,
 };
 use zenith_utils::http::endpoint;
-use zenith_utils::postgres_backend;
 use zenith_utils::shutdown::exit_now;
 use zenith_utils::signals::{self, Signal};
 
@@ -323,38 +322,8 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
                 "Got {}. Terminating gracefully in fast shutdown mode",
                 signal.name()
             );
-            shutdown_pageserver();
+            pageserver::shutdown_pageserver();
             unreachable!()
         }
     })
-}
-
-fn shutdown_pageserver() {
-    // Shut down the libpq endpoint thread. This prevents new connections from
-    // being accepted.
-    thread_mgr::shutdown_threads(Some(ThreadKind::LibpqEndpointListener), None, None);
-
-    // Shut down any page service threads.
-    postgres_backend::set_pgbackend_shutdown_requested();
-    thread_mgr::shutdown_threads(Some(ThreadKind::PageRequestHandler), None, None);
-
-    // Shut down all the tenants. This flushes everything to disk and kills
-    // the checkpoint and GC threads.
-    tenant_mgr::shutdown_all_tenants();
-
-    // Stop syncing with remote storage.
-    //
-    // FIXME: Does this wait for the sync thread to finish syncing what's queued up?
-    // Should it?
-    thread_mgr::shutdown_threads(Some(ThreadKind::StorageSync), None, None);
-
-    // Shut down the HTTP endpoint last, so that you can still check the server's
-    // status while it's shutting down.
-    thread_mgr::shutdown_threads(Some(ThreadKind::HttpEndpointListener), None, None);
-
-    // There should be nothing left, but let's be sure
-    thread_mgr::shutdown_threads(None, None, None);
-
-    info!("Shut down successfully completed");
-    std::process::exit(0);
 }

--- a/pageserver/src/bin/pageserver.rs
+++ b/pageserver/src/bin/pageserver.rs
@@ -292,6 +292,7 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
         None,
         None,
         "http_endpoint_thread",
+        false,
         move || {
             let router = http::make_router(conf, auth_cloned, remote_index);
             endpoint::serve_thread_main(router, http_listener, thread_mgr::shutdown_watcher())
@@ -305,6 +306,7 @@ fn start_pageserver(conf: &'static PageServerConf, daemonize: bool) -> Result<()
         None,
         None,
         "libpq endpoint thread",
+        false,
         move || page_service::thread_main(conf, auth, pageserver_listener, conf.auth_type),
     )?;
 

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -976,7 +976,7 @@ impl Timeline for LayeredTimeline {
     /// Public entry point for checkpoint(). All the logic is in the private
     /// checkpoint_internal function, this public facade just wraps it for
     /// metrics collection.
-    fn checkpoint(&self, cconf: CheckpointConfig) -> Result<()> {
+    fn checkpoint(&self, cconf: CheckpointConfig) -> anyhow::Result<()> {
         match cconf {
             CheckpointConfig::Flush => self
                 .flush_checkpoint_time_histo

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -209,10 +209,10 @@ impl Layer for DeltaLayer {
         blknum: SegmentBlk,
         lsn: Lsn,
         reconstruct_data: &mut PageReconstructData,
-    ) -> Result<PageReconstructResult> {
+    ) -> anyhow::Result<PageReconstructResult> {
         let mut need_image = true;
 
-        assert!((0..RELISH_SEG_SIZE).contains(&blknum));
+        ensure!((0..RELISH_SEG_SIZE).contains(&blknum));
 
         match &reconstruct_data.page_img {
             Some((cached_lsn, _)) if &self.end_lsn <= cached_lsn => {
@@ -289,8 +289,8 @@ impl Layer for DeltaLayer {
     }
 
     /// Get size of the relation at given LSN
-    fn get_seg_size(&self, lsn: Lsn) -> Result<SegmentBlk> {
-        assert!(lsn >= self.start_lsn);
+    fn get_seg_size(&self, lsn: Lsn) -> anyhow::Result<SegmentBlk> {
+        ensure!(lsn >= self.start_lsn);
         ensure!(
             self.seg.rel.is_blocky(),
             "get_seg_size() called on a non-blocky rel"
@@ -641,7 +641,7 @@ impl DeltaLayerWriter {
     ///
     /// 'seg_sizes' is a list of size changes to store with the actual data.
     ///
-    pub fn finish(self, seg_sizes: VecMap<Lsn, SegmentBlk>) -> Result<DeltaLayer> {
+    pub fn finish(self, seg_sizes: VecMap<Lsn, SegmentBlk>) -> anyhow::Result<DeltaLayer> {
         // Close the page-versions chapter
         let book = self.page_version_writer.close()?;
 
@@ -652,7 +652,7 @@ impl DeltaLayerWriter {
         let book = chapter.close()?;
 
         if self.seg.rel.is_blocky() {
-            assert!(!seg_sizes.is_empty());
+            ensure!(!seg_sizes.is_empty());
         }
 
         // and seg_sizes to separate chapter

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -17,7 +17,7 @@ use crate::layered_repository::LayeredTimeline;
 use crate::layered_repository::ZERO_PAGE;
 use crate::repository::ZenithWalRecord;
 use crate::{ZTenantId, ZTimelineId};
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Result, bail};
 use bytes::Bytes;
 use log::*;
 use std::collections::HashMap;
@@ -150,9 +150,9 @@ impl InMemoryLayerInner {
         let pos = self.file.stream_position()?;
 
         // make room for the 'length' field by writing zeros as a placeholder.
-        self.file.seek(std::io::SeekFrom::Start(pos + 4)).unwrap();
+        self.file.seek(std::io::SeekFrom::Start(pos + 4))?;
 
-        pv.ser_into(&mut self.file).unwrap();
+        pv.ser_into(&mut self.file)?;
 
         // write the 'length' field.
         let len = self.file.stream_position()? - pos - 4;
@@ -315,7 +315,7 @@ impl Layer for InMemoryLayer {
                     return Ok(false);
                 }
             } else {
-                panic!("dropped in-memory layer with no end LSN");
+                bail!("dropped in-memory layer with no end LSN");
             }
         }
 
@@ -333,7 +333,7 @@ impl Layer for InMemoryLayer {
     /// Nothing to do here. When you drop the last reference to the layer, it will
     /// be deallocated.
     fn delete(&self) -> Result<()> {
-        panic!("can't delete an InMemoryLayer")
+        bail!("can't delete an InMemoryLayer")
     }
 
     fn is_incremental(&self) -> bool {

--- a/pageserver/src/layered_repository/metadata.rs
+++ b/pageserver/src/layered_repository/metadata.rs
@@ -96,7 +96,7 @@ impl TimelineMetadata {
         );
 
         let data = TimelineMetadata::from(serialize::DeTimelineMetadata::des_prefix(data)?);
-        assert!(data.disk_consistent_lsn.is_aligned());
+        ensure!(data.disk_consistent_lsn.is_aligned());
 
         Ok(data)
     }
@@ -104,7 +104,7 @@ impl TimelineMetadata {
     pub fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
         let serializeable_metadata = serialize::SeTimelineMetadata::from(self);
         let mut metadata_bytes = serialize::SeTimelineMetadata::ser(&serializeable_metadata)?;
-        assert!(metadata_bytes.len() <= METADATA_MAX_DATA_SIZE);
+        ensure!(metadata_bytes.len() <= METADATA_MAX_DATA_SIZE);
         metadata_bytes.resize(METADATA_MAX_SAFE_SIZE, 0u8);
 
         let checksum = crc32c::crc32c(&metadata_bytes[..METADATA_MAX_DATA_SIZE]);

--- a/pageserver/src/lib.rs
+++ b/pageserver/src/lib.rs
@@ -19,8 +19,14 @@ pub mod walrecord;
 pub mod walredo;
 
 use lazy_static::lazy_static;
+use tracing::info;
 use zenith_metrics::{register_int_gauge_vec, IntGaugeVec};
-use zenith_utils::zid::{ZTenantId, ZTimelineId};
+use zenith_utils::{
+    postgres_backend,
+    zid::{ZTenantId, ZTimelineId},
+};
+
+use crate::thread_mgr::ThreadKind;
 
 lazy_static! {
     static ref LIVE_CONNECTIONS_COUNT: IntGaugeVec = register_int_gauge_vec!(
@@ -42,4 +48,34 @@ pub enum CheckpointConfig {
     Flush,
     // Flush all in-memory data and reconstruct all page images
     Forced,
+}
+
+pub fn shutdown_pageserver() {
+    // Shut down the libpq endpoint thread. This prevents new connections from
+    // being accepted.
+    thread_mgr::shutdown_threads(Some(ThreadKind::LibpqEndpointListener), None, None);
+
+    // Shut down any page service threads.
+    postgres_backend::set_pgbackend_shutdown_requested();
+    thread_mgr::shutdown_threads(Some(ThreadKind::PageRequestHandler), None, None);
+
+    // Shut down all the tenants. This flushes everything to disk and kills
+    // the checkpoint and GC threads.
+    tenant_mgr::shutdown_all_tenants();
+
+    // Stop syncing with remote storage.
+    //
+    // FIXME: Does this wait for the sync thread to finish syncing what's queued up?
+    // Should it?
+    thread_mgr::shutdown_threads(Some(ThreadKind::StorageSync), None, None);
+
+    // Shut down the HTTP endpoint last, so that you can still check the server's
+    // status while it's shutting down.
+    thread_mgr::shutdown_threads(Some(ThreadKind::HttpEndpointListener), None, None);
+
+    // There should be nothing left, but let's be sure
+    thread_mgr::shutdown_threads(None, None, None);
+
+    info!("Shut down successfully completed");
+    std::process::exit(0);
 }

--- a/pageserver/src/page_cache.rs
+++ b/pageserver/src/page_cache.rs
@@ -735,9 +735,10 @@ impl PageCache {
             CacheKey::MaterializedPage {
                 hash_key: _,
                 lsn: _,
-            } => {
-                panic!("unexpected dirty materialized page");
-            }
+            } => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "unexpected dirty materialized page",
+            )),
             CacheKey::EphemeralPage { file_id, blkno } => {
                 writeback_ephemeral_file(*file_id, *blkno, buf)
             }

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -574,7 +574,6 @@ impl postgres_backend::Handler for PageServerHandler {
         let data = self
             .auth
             .as_ref()
-            .as_ref()
             .unwrap()
             .decode(str::from_utf8(jwt_response)?)?;
 

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -228,6 +228,7 @@ pub fn thread_main(
                     None,
                     None,
                     "serving Page Service thread",
+                    false,
                     move || page_service_conn_main(conf, local_auth, socket, auth_type),
                 ) {
                     // Thread creation failed. Log the error and continue.

--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -404,6 +404,7 @@ pub(super) fn spawn_storage_sync_thread<
         None,
         None,
         "Remote storage sync thread",
+        false,
         move || {
             storage_sync_loop(
                 runtime,
@@ -413,7 +414,8 @@ pub(super) fn spawn_storage_sync_thread<
                 storage,
                 max_concurrent_sync,
                 max_sync_errors,
-            )
+            );
+            Ok(())
         },
     )
     .context("Failed to spawn remote storage sync thread")?;
@@ -440,7 +442,7 @@ fn storage_sync_loop<
     storage: S,
     max_concurrent_sync: NonZeroUsize,
     max_sync_errors: NonZeroU32,
-) -> anyhow::Result<()> {
+) {
     let remote_assets = Arc::new((storage, Arc::clone(&index)));
     loop {
         let index = Arc::clone(&index);
@@ -470,8 +472,6 @@ fn storage_sync_loop<
             }
         }
     }
-
-    Ok(())
 }
 
 async fn loop_step<

--- a/pageserver/src/tenant_mgr.rs
+++ b/pageserver/src/tenant_mgr.rs
@@ -206,13 +206,13 @@ pub fn get_tenant_state(tenantid: ZTenantId) -> Option<TenantState> {
 /// Change the state of a tenant to Active and launch its checkpointer and GC
 /// threads. If the tenant was already in Active state or Stopping, does nothing.
 ///
-pub fn activate_tenant(conf: &'static PageServerConf, tenantid: ZTenantId) -> Result<()> {
+pub fn activate_tenant(conf: &'static PageServerConf, tenant_id: ZTenantId) -> Result<()> {
     let mut m = access_tenants();
     let tenant = m
-        .get_mut(&tenantid)
-        .with_context(|| format!("Tenant not found for id {}", tenantid))?;
+        .get_mut(&tenant_id)
+        .with_context(|| format!("Tenant not found for id {}", tenant_id))?;
 
-    info!("activating tenant {}", tenantid);
+    info!("activating tenant {}", tenant_id);
 
     match tenant.state {
         // If the tenant is already active, nothing to do.
@@ -222,22 +222,31 @@ pub fn activate_tenant(conf: &'static PageServerConf, tenantid: ZTenantId) -> Re
         TenantState::Idle => {
             thread_mgr::spawn(
                 ThreadKind::Checkpointer,
-                Some(tenantid),
+                Some(tenant_id),
                 None,
                 "Checkpointer thread",
-                move || crate::tenant_threads::checkpoint_loop(tenantid, conf),
+                true,
+                move || crate::tenant_threads::checkpoint_loop(tenant_id, conf),
             )?;
 
-            // FIXME: if we fail to launch the GC thread, but already launched the
-            // checkpointer, we're in a strange state.
-
-            thread_mgr::spawn(
+            let gc_spawn_result = thread_mgr::spawn(
                 ThreadKind::GarbageCollector,
-                Some(tenantid),
+                Some(tenant_id),
                 None,
                 "GC thread",
-                move || crate::tenant_threads::gc_loop(tenantid, conf),
-            )?;
+                true,
+                move || crate::tenant_threads::gc_loop(tenant_id, conf),
+            )
+            .with_context(|| format!("Failed to launch GC thread for tenant {}", tenant_id));
+
+            if let Err(e) = &gc_spawn_result {
+                error!(
+                    "Failed to start GC thread for tenant {}, stopping its checkpointer thread: {:?}",
+                    tenant_id, e
+                );
+                thread_mgr::shutdown_threads(Some(ThreadKind::Checkpointer), Some(tenant_id), None);
+                return gc_spawn_result;
+            }
 
             tenant.state = TenantState::Active;
         }

--- a/pageserver/src/tenant_threads.rs
+++ b/pageserver/src/tenant_threads.rs
@@ -49,7 +49,7 @@ pub fn gc_loop(tenantid: ZTenantId, conf: &'static PageServerConf) -> Result<()>
         // Garbage collect old files that are not needed for PITR anymore
         if conf.gc_horizon > 0 {
             let repo = tenant_mgr::get_repository_for_tenant(tenantid)?;
-            repo.gc_iteration(None, conf.gc_horizon, false).unwrap();
+            repo.gc_iteration(None, conf.gc_horizon, false)?;
         }
 
         // TODO Write it in more adequate way using

--- a/pageserver/src/thread_mgr.rs
+++ b/pageserver/src/thread_mgr.rs
@@ -250,7 +250,7 @@ pub fn shutdown_threads(
             let _ = join_handle.join();
         } else {
             // The thread had not even fully started yet. Or it was shut down
-            // concurrently and alrady exited
+            // concurrently and already exited
         }
     }
 }

--- a/pageserver/src/timelines.rs
+++ b/pageserver/src/timelines.rs
@@ -250,7 +250,7 @@ fn run_initdb(conf: &'static PageServerConf, initdbpath: &Path) -> Result<()> {
 
     let initdb_path = conf.pg_bin_dir().join("initdb");
     let initdb_output = Command::new(initdb_path)
-        .args(&["-D", initdbpath.to_str().unwrap()])
+        .args(&["-D", &initdbpath.to_string_lossy()])
         .args(&["-U", &conf.superuser])
         .args(&["-E", "utf8"])
         .arg("--no-instructions")
@@ -258,8 +258,8 @@ fn run_initdb(conf: &'static PageServerConf, initdbpath: &Path) -> Result<()> {
         // so no need to fsync it
         .arg("--no-sync")
         .env_clear()
-        .env("LD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())
-        .env("DYLD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())
+        .env("LD_LIBRARY_PATH", conf.pg_lib_dir())
+        .env("DYLD_LIBRARY_PATH", conf.pg_lib_dir())
         .stdout(Stdio::null())
         .output()
         .context("failed to execute initdb")?;

--- a/pageserver/src/virtual_file.rs
+++ b/pageserver/src/virtual_file.rs
@@ -226,7 +226,8 @@ impl VirtualFile {
         path: &Path,
         open_options: &OpenOptions,
     ) -> Result<VirtualFile, std::io::Error> {
-        let parts = path.to_str().unwrap().split('/').collect::<Vec<&str>>();
+        let path_str = path.to_string_lossy();
+        let parts = path_str.split('/').collect::<Vec<&str>>();
         let tenantid;
         let timelineid;
         if parts.len() > 5 && parts[parts.len() - 5] == "tenants" {

--- a/pageserver/src/walingest.rs
+++ b/pageserver/src/walingest.rs
@@ -249,7 +249,7 @@ impl WalIngest {
             {
                 let mut checkpoint_bytes = [0u8; SIZEOF_CHECKPOINT];
                 buf.copy_to_slice(&mut checkpoint_bytes);
-                let xlog_checkpoint = CheckPoint::decode(&checkpoint_bytes).unwrap();
+                let xlog_checkpoint = CheckPoint::decode(&checkpoint_bytes)?;
                 trace!(
                     "xlog_checkpoint.oldestXid={}, checkpoint.oldestXid={}",
                     xlog_checkpoint.oldestXid,

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -146,7 +146,7 @@ fn walreceiver_main(
     tenant_id: ZTenantId,
     timeline_id: ZTimelineId,
     wal_producer_connstr: &str,
-) -> Result<(), Error> {
+) -> anyhow::Result<(), Error> {
     // Connect to the database in replication mode.
     info!("connecting to {:?}", wal_producer_connstr);
     let connect_cfg = format!(
@@ -255,7 +255,7 @@ fn walreceiver_main(
                     // It is important to deal with the aligned records as lsn in getPage@LSN is
                     // aligned and can be several bytes bigger. Without this alignment we are
                     // at risk of hittind a deadlock.
-                    assert!(lsn.is_aligned());
+                    anyhow::ensure!(lsn.is_aligned());
 
                     let writer = timeline.writer();
                     walingest.ingest_record(writer.as_ref(), recdata, lsn)?;

--- a/pageserver/src/walreceiver.rs
+++ b/pageserver/src/walreceiver.rs
@@ -78,9 +78,11 @@ pub fn launch_wal_receiver(
                 Some(tenantid),
                 Some(timelineid),
                 "WAL receiver thread",
+                false,
                 move || {
                     IS_WAL_RECEIVER.with(|c| c.set(true));
-                    thread_main(conf, tenantid, timelineid)
+                    thread_main(conf, tenantid, timelineid);
+                    Ok(())
                 },
             )?;
 
@@ -110,11 +112,7 @@ fn get_wal_producer_connstr(tenantid: ZTenantId, timelineid: ZTimelineId) -> Str
 //
 // This is the entry point for the WAL receiver thread.
 //
-fn thread_main(
-    conf: &'static PageServerConf,
-    tenant_id: ZTenantId,
-    timeline_id: ZTimelineId,
-) -> Result<()> {
+fn thread_main(conf: &'static PageServerConf, tenant_id: ZTenantId, timeline_id: ZTimelineId) {
     let _enter = info_span!("WAL receiver", timeline = %timeline_id, tenant = %tenant_id).entered();
     info!("WAL receiver thread started");
 
@@ -138,7 +136,6 @@ fn thread_main(
     // Drop it from list of active WAL_RECEIVERS
     // so that next callmemaybe request launched a new thread
     drop_wal_receiver(tenant_id, timeline_id);
-    Ok(())
 }
 
 fn walreceiver_main(

--- a/pageserver/src/walredo.rs
+++ b/pageserver/src/walredo.rs
@@ -375,7 +375,10 @@ impl PostgresRedoManager {
             ZenithWalRecord::Postgres {
                 will_init: _,
                 rec: _,
-            } => panic!("tried to pass postgres wal record to zenith WAL redo"),
+            } => {
+                error!("tried to pass postgres wal record to zenith WAL redo");
+                return Err(WalRedoError::InvalidRequest);
+            }
             ZenithWalRecord::ClearVisibilityMapFlags {
                 new_heap_blkno,
                 old_heap_blkno,
@@ -541,20 +544,23 @@ impl PostgresRedoProcess {
         }
         info!("running initdb in {:?}", datadir.display());
         let initdb = Command::new(conf.pg_bin_dir().join("initdb"))
-            .args(&["-D", datadir.to_str().unwrap()])
+            .args(&["-D", &datadir.to_string_lossy()])
             .arg("-N")
             .env_clear()
-            .env("LD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())
-            .env("DYLD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())
+            .env("LD_LIBRARY_PATH", conf.pg_lib_dir())
+            .env("DYLD_LIBRARY_PATH", conf.pg_lib_dir())
             .output()
-            .expect("failed to execute initdb");
+            .map_err(|e| Error::new(e.kind(), format!("failed to execute initdb: {}", e)))?;
 
         if !initdb.status.success() {
-            panic!(
-                "initdb failed: {}\nstderr:\n{}",
-                std::str::from_utf8(&initdb.stdout).unwrap(),
-                std::str::from_utf8(&initdb.stderr).unwrap()
-            );
+            return Err(Error::new(
+                ErrorKind::Other,
+                format!(
+                    "initdb failed\nstdout: {}\nstderr:\n{}",
+                    String::from_utf8_lossy(&initdb.stdout),
+                    String::from_utf8_lossy(&initdb.stderr)
+                ),
+            ));
         } else {
             // Limit shared cache for wal-redo-postres
             let mut config = OpenOptions::new()
@@ -572,11 +578,16 @@ impl PostgresRedoProcess {
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())
             .env_clear()
-            .env("LD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())
-            .env("DYLD_LIBRARY_PATH", conf.pg_lib_dir().to_str().unwrap())
+            .env("LD_LIBRARY_PATH", conf.pg_lib_dir())
+            .env("DYLD_LIBRARY_PATH", conf.pg_lib_dir())
             .env("PGDATA", &datadir)
             .spawn()
-            .expect("postgres --wal-redo command failed to start");
+            .map_err(|e| {
+                Error::new(
+                    e.kind(),
+                    format!("postgres --wal-redo command failed to start: {}", e),
+                )
+            })?;
 
         info!(
             "launched WAL redo postgres process on {:?}",
@@ -636,7 +647,10 @@ impl PostgresRedoProcess {
             {
                 build_apply_record_msg(*lsn, postgres_rec, &mut writebuf);
             } else {
-                panic!("tried to pass zenith wal record to postgres WAL redo");
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "tried to pass zenith wal record to postgres WAL redo",
+                ));
             }
         }
         build_get_page_msg(tag, &mut writebuf);


### PR DESCRIPTION
Closes https://github.com/zenithdb/zenith/issues/463

I've worked on fixing the out of disk space first, and replaced a number of panic sources with errors where it was easy to do.
In a separate commit, I've also replaced `assert!` and `assert_eq!` invocations with `anyhow::ensure!` where functions returned `anyhow::Result`: have some doubts that it was a right thing to do, so can revert if other opinions appear.

After main panic sources were gone, I've discovered, that the current `thread_mgr` code silently omits the threads that return `Err`, simply allowing them to stop without any extra logging.
Besides adding some logging, I've also decided to shut down the pageserver on any panic or `Err` in any of pageserver's main threads.
Not sure if this is a viable approach currently, but feels that just logging the errors and allowing the pageserver to continue is also bad, since masks the error state. We could split threads to more important or not, shutting down only on panics or important thread failures, but again it feels better to not to mask errors at this stage, if they are not abundant.