### PR TITLE
Remove some unnecessary Ord etc. trait implementations.

### DIFF
--- a/pageserver/src/layered_repository/metadata.rs
+++ b/pageserver/src/layered_repository/metadata.rs
@@ -28,7 +28,7 @@ pub const METADATA_FILE_NAME: &str = "metadata";
 /// Metadata stored on disk for each timeline
 ///
 /// The fields correspond to the values we hold in memory, in LayeredTimeline.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimelineMetadata {
     disk_consistent_lsn: Lsn,
     // This is only set if we know it. We track it in memory when the page


### PR DESCRIPTION
It doesn't make much sense to compare TimelineMetadata structs with
< or >. But we did depend on that in the remote storage upload code,
so replace BTreeSets with Vecs there.

@SomeoneToIgnore, I'm not 100% sure about the changes to storage_sync.rs here. The code would previously deduplicate if there are two identical SyncTasks, because they were stored in a BTreeSet, but I changed it to Vec here. The deduplication seemed odd to me: if you had two otherwise identical SyncTasks that only differed in the 'retries' field, for example, they would be considered as different tasks. So I got a feeling that the deduplication was accidental, or at least not really necessary for correctness. But please correct me if I'm wrong.