### PR TITLE
Use cachepot to cache more rustc builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,12 @@ jobs:
             fi
 
             export CARGO_INCREMENTAL=0
+            export CACHEPOT_BUCKET=zenith-rust-cachepot
+            export RUSTC_WRAPPER=cachepot
+            export AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}"
+            export AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}"
             "${cov_prefix[@]}" mold -run cargo build $CARGO_FLAGS --bins --tests
+            cachepot -s
 
       - save_cache:
           name: Save rust cache
@@ -464,7 +469,10 @@ jobs:
           name: Build and push compute-tools Docker image
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
-            docker build -t zenithdb/compute-tools:latest -f Dockerfile.compute-tools .
+            docker build \
+              --build-arg AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}" \
+              --build-arg AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}" \
+              --tag zenithdb/compute-tools:latest -f Dockerfile.compute-tools .
             docker push zenithdb/compute-tools:latest
       - run:
           name: Init postgres submodule
@@ -518,7 +526,10 @@ jobs:
           name: Build and push compute-tools Docker image
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
-            docker build -t zenithdb/compute-tools:release -f Dockerfile.compute-tools .
+            docker build \
+              --build-arg AWS_ACCESS_KEY_ID="${CACHEPOT_AWS_ACCESS_KEY_ID}" \
+              --build-arg AWS_SECRET_ACCESS_KEY="${CACHEPOT_AWS_SECRET_ACCESS_KEY}" \
+              --tag zenithdb/compute-tools:release -f Dockerfile.compute-tools .
             docker push zenithdb/compute-tools:release
       - run:
           name: Init postgres submodule

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,11 +146,13 @@ jobs:
           command: |
             if [[ $BUILD_TYPE == "debug" ]]; then
               cov_prefix=(scripts/coverage "--profraw-prefix=$CIRCLE_JOB" --dir=/tmp/zenith/coverage run)
+              CARGO_FLAGS=
             elif [[ $BUILD_TYPE == "release" ]]; then
               cov_prefix=()
+              CARGO_FLAGS=--release
             fi
 
-            "${cov_prefix[@]}" cargo test
+            "${cov_prefix[@]}" cargo test $CARGO_FLAGS
 
         # Install the rust binaries, for use by test jobs
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ARG GIT_VERSION=local
 ARG CACHEPOT_BUCKET=zenith-rust-cachepot
 ARG AWS_ACCESS_KEY_ID
 ARG AWS_SECRET_ACCESS_KEY
-#ENV RUSTC_WRAPPER cachepot
 ENV RUSTC_WRAPPER /usr/local/cargo/bin/cachepot
 
 COPY --from=pg-build /pg/tmp_install/include/postgresql/server tmp_install/include/postgresql/server

--- a/Dockerfile.compute-tools
+++ b/Dockerfile.compute-tools
@@ -1,12 +1,17 @@
 # First transient image to build compute_tools binaries
 # NB: keep in sync with rust image version in .circle/config.yml
-FROM rust:1.56.1-slim-buster AS rust-build
+FROM zenithdb/build:buster-20220309 AS rust-build
 
 WORKDIR /zenith
 
+ARG CACHEPOT_BUCKET=zenith-rust-cachepot
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+ENV RUSTC_WRAPPER /usr/local/cargo/bin/cachepot
+
 COPY . .
 
-RUN cargo build -p compute_tools --release
+RUN cargo build -p compute_tools --release && /usr/local/cargo/bin/cachepot -s
 
 # Final image that only has one binary
 FROM debian:buster-slim


### PR DESCRIPTION
Closes https://github.com/zenithdb/zenith/issues/1113 as there's nothing else to reasonably apply cachepot to in our builds.

Attempts to speed up two things:
* docker build triggered via console GitHub pipeline: https://github.com/zenithdb/console/pull/884
For that, a docker image of compute tools was adjusted

*  CircleCI rust builds for tests 


Now we don't really need `target` in our CircleCI rust cache, but decided to leave it as is for now, since we're planning to move away to GitHub actions.