### PR TITLE
Fix poetry cache in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,12 +222,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-python-deps-{{ checksum "poetry.lock" }}
+            - v2-python-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install deps
           command: ./scripts/pysync
       - save_cache:
-          key: v1-python-deps-{{ checksum "poetry.lock" }}
+          key: v2-python-deps-{{ checksum "poetry.lock" }}
           paths:
             - /home/circleci/.cache/pypoetry/virtualenvs
       - run:
@@ -281,12 +281,12 @@ jobs:
             - run: git submodule update --init --depth 1
       - restore_cache:
           keys:
-            - v1-python-deps-{{ checksum "poetry.lock" }}
+            - v2-python-deps-{{ checksum "poetry.lock" }}
       - run:
           name: Install deps
           command: ./scripts/pysync
       - save_cache:
-          key: v1-python-deps-{{ checksum "poetry.lock" }}
+          key: v2-python-deps-{{ checksum "poetry.lock" }}
           paths:
             - /home/circleci/.cache/pypoetry/virtualenvs
       - run:

--- a/scripts/pysync
+++ b/scripts/pysync
@@ -4,4 +4,10 @@
 # It is intended to be a primary endpoint for all the people who want to
 # just setup test environment without going into details of python package management
 
-poetry install --no-root # this installs dev dependencies by default
+poetry config --list
+
+if [ -z "${CI}" ]; then
+    poetry install --no-root --no-interaction --ansi
+else
+    poetry install --no-root
+fi


### PR DESCRIPTION
for some reason cache was incomplete but cache key was not changed, so circle downloaded old version of the cache, and then declined to upload it:
```
Skipping cache generation, cache already exists for key: v1-python-deps-EWim0Gm9GPcJlMEh9YoXigIKK8vYF8ue5cqFMk4Sevk=
Found one created at 2022-02-22 21:03:08 +0000 UTC
```