### PR TITLE
Make shared_buffers large in test_pageserver_catchup.

### DIFF
--- a/test_runner/batch_others/test_pageserver_catchup.py
+++ b/test_runner/batch_others/test_pageserver_catchup.py
@@ -10,7 +10,9 @@ def test_pageserver_catchup_while_compute_down(zenith_env_builder: ZenithEnvBuil
     env = zenith_env_builder.init_start()
 
     env.zenith_cli.create_branch('test_pageserver_catchup_while_compute_down')
-    pg = env.postgres.create_start('test_pageserver_catchup_while_compute_down')
+    # Make shared_buffers large to ensure we won't query pageserver while it is down.
+    pg = env.postgres.create_start('test_pageserver_catchup_while_compute_down',
+                                   config_lines=['shared_buffers=512MB'])
 
     pg_conn = pg.connect()
     cur = pg_conn.cursor()


### PR DESCRIPTION
We intentionally write while pageserver is down, so we shouldn't query it.

Noticed by @petuhovskiy at
https://github.com/zenithdb/postgres/pull/141#issuecomment-1080261700