### PR TITLE
Show s3 spans in logs

### DIFF
--- a/pageserver/src/remote_storage/storage_sync.rs
+++ b/pageserver/src/remote_storage/storage_sync.rs
@@ -321,8 +321,8 @@ pub fn schedule_timeline_checkpoint_upload(
             tenant_id, timeline_id
         )
     } else {
-        warn!(
-            "Could not send an upload task for tenant {}, timeline {}: the sync queue is not initialized",
+        debug!(
+            "Upload task for tenant {}, timeline {} sent",
             tenant_id, timeline_id
         )
     }
@@ -455,7 +455,7 @@ fn storage_sync_loop<
                     max_concurrent_sync,
                     max_sync_errors,
                 )
-                .instrument(debug_span!("storage_sync_loop_step")) => step,
+                .instrument(info_span!("storage_sync_loop_step")) => step,
                 _ = thread_mgr::shutdown_watcher() => LoopStep::Shutdown,
             }
         });
@@ -528,7 +528,7 @@ async fn loop_step<
 
             let extra_step = match tokio::spawn(
                 process_task(conf, Arc::clone(&remote_assets), task, max_sync_errors).instrument(
-                    debug_span!("process_sync_task", sync_id = %sync_id, attempt, sync_name),
+                    info_span!("process_sync_task", sync_id = %sync_id, attempt, sync_name),
                 ),
             )
             .await

--- a/zenith_utils/src/http/endpoint.rs
+++ b/zenith_utils/src/http/endpoint.rs
@@ -160,7 +160,7 @@ pub fn serve_thread_main<S>(
 where
     S: Future<Output = ()> + Send + Sync,
 {
-    info!("Starting a http endpoint at {}", listener.local_addr()?);
+    info!("Starting an HTTP endpoint at {}", listener.local_addr()?);
 
     // Create a Service from the router above to handle incoming requests.
     let service = RouterService::new(router_builder.build().map_err(|err| anyhow!(err))?).unwrap();


### PR DESCRIPTION
This way, the span data appears in our current logs and does not need a DEBUG level as it requires now.