### PR TITLE
pair basebackup start log message with corresponding end one of the same severity

### DIFF
--- a/pageserver/src/basebackup.rs
+++ b/pageserver/src/basebackup.rs
@@ -65,6 +65,7 @@ impl<'a> Basebackup<'a> {
         // prev_lsn to Lsn(0) if we cannot provide the correct value.
         let (backup_prev, backup_lsn) = if let Some(req_lsn) = req_lsn {
             // Backup was requested at a particular LSN. Wait for it to arrive.
+            info!("waiting for {}", req_lsn);
             timeline.tline.wait_lsn(req_lsn)?;
 
             // If the requested point is the end of the timeline, we can

--- a/pageserver/src/page_service.rs
+++ b/pageserver/src/page_service.rs
@@ -514,6 +514,7 @@ impl PageServerHandler {
     ) -> anyhow::Result<()> {
         let span = info_span!("basebackup", timeline = %timelineid, tenant = %tenantid, lsn = field::Empty);
         let _enter = span.enter();
+        info!("starting");
 
         // check that the timeline exists
         let timeline = tenant_mgr::get_timeline_for_tenant_load(tenantid, timelineid)
@@ -536,7 +537,7 @@ impl PageServerHandler {
             basebackup.send_tarball()?;
         }
         pgb.write_message(&BeMessage::CopyDone)?;
-        debug!("CopyDone sent!");
+        info!("done");
 
         Ok(())
     }


### PR DESCRIPTION
Currently, there is only a message about basebackup start, so by looking at logs, it is not clear whether it is successfully finished or not