### PR TITLE
Extend LayerMap dump() function to print also open_layers and frozen_…

### DIFF
--- a/pageserver/src/bin/dump_layerfile.rs
+++ b/pageserver/src/bin/dump_layerfile.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
     // Basic initialization of things that don't change after startup
     virtual_file::init(10);
 
-    dump_layerfile_from_path(&path)?;
+    dump_layerfile_from_path(&path, true)?;
 
     Ok(())
 }

--- a/pageserver/src/layered_repository.rs
+++ b/pageserver/src/layered_repository.rs
@@ -2066,16 +2066,16 @@ impl<'a> TimelineWriter<'_> for LayeredTimelineWriter<'a> {
 }
 
 /// Dump contents of a layer file to stdout.
-pub fn dump_layerfile_from_path(path: &Path) -> Result<()> {
+pub fn dump_layerfile_from_path(path: &Path, verbose: bool) -> Result<()> {
     let file = File::open(path)?;
     let book = Book::new(file)?;
 
     match book.magic() {
         crate::DELTA_FILE_MAGIC => {
-            DeltaLayer::new_for_path(path, &book)?.dump()?;
+            DeltaLayer::new_for_path(path, &book)?.dump(verbose)?;
         }
         crate::IMAGE_FILE_MAGIC => {
-            ImageLayer::new_for_path(path, &book)?.dump()?;
+            ImageLayer::new_for_path(path, &book)?.dump(verbose)?;
         }
         magic => bail!("unrecognized magic identifier: {:?}", magic),
     }
@@ -2216,7 +2216,7 @@ pub mod tests {
         let mut test_key = Key::from_hex("012222222233333333444444445500000000").unwrap();
         let mut blknum = 0;
         for _ in 0..50 {
-            for _ in 0..1000 {
+            for _ in 0..10000 {
                 test_key.field6 = blknum;
                 let writer = tline.writer();
                 writer.put(

--- a/pageserver/src/layered_repository/delta_layer.rs
+++ b/pageserver/src/layered_repository/delta_layer.rs
@@ -267,7 +267,7 @@ impl Layer for DeltaLayer {
     }
 
     /// debugging function to print out the contents of the layer
-    fn dump(&self) -> Result<()> {
+    fn dump(&self, verbose: bool) -> Result<()> {
         println!(
             "----- delta layer for ten {} tli {} keys {}-{} lsn {}-{} ----",
             self.tenantid,
@@ -277,6 +277,10 @@ impl Layer for DeltaLayer {
             self.lsn_range.start,
             self.lsn_range.end
         );
+
+        if !verbose {
+            return Ok(());
+        }
 
         let inner = self.load()?;
 

--- a/pageserver/src/layered_repository/image_layer.rs
+++ b/pageserver/src/layered_repository/image_layer.rs
@@ -212,11 +212,15 @@ impl Layer for ImageLayer {
     }
 
     /// debugging function to print out the contents of the layer
-    fn dump(&self) -> Result<()> {
+    fn dump(&self, verbose: bool) -> Result<()> {
         println!(
             "----- image layer for ten {} tli {} key {}-{} at {} ----",
             self.tenantid, self.timelineid, self.key_range.start, self.key_range.end, self.lsn
         );
+
+        if !verbose {
+            return Ok(());
+        }
 
         let inner = self.load()?;
 

--- a/pageserver/src/layered_repository/inmemory_layer.rs
+++ b/pageserver/src/layered_repository/inmemory_layer.rs
@@ -190,7 +190,7 @@ impl Layer for InMemoryLayer {
     }
 
     /// debugging function to print out the contents of the layer
-    fn dump(&self) -> Result<()> {
+    fn dump(&self, verbose: bool) -> Result<()> {
         let inner = self.inner.read().unwrap();
 
         let end_str = inner
@@ -203,6 +203,10 @@ impl Layer for InMemoryLayer {
             "----- in-memory layer for tli {} LSNs {}-{} ----",
             self.timelineid, self.start_lsn, end_str,
         );
+
+        if !verbose {
+            return Ok(());
+        }
 
         let mut buf = Vec::new();
         for (key, vec_map) in inner.index.iter() {

--- a/pageserver/src/layered_repository/layer_map.rs
+++ b/pageserver/src/layered_repository/layer_map.rs
@@ -392,10 +392,22 @@ impl LayerMap {
 
     /// debugging function to print out the contents of the layer map
     #[allow(unused)]
-    pub fn dump(&self) -> Result<()> {
+    pub fn dump(&self, verbose: bool) -> Result<()> {
         println!("Begin dump LayerMap");
+
+        println!("open_layer:");
+        if let Some(open_layer) = &self.open_layer {
+            open_layer.dump(verbose)?;
+        }
+
+        println!("frozen_layers:");
+        for frozen_layer in self.frozen_layers.iter() {
+            frozen_layer.dump(verbose)?;
+        }
+
+        println!("historic_layers:");
         for layer in self.historic_layers.iter() {
-            layer.dump()?;
+            layer.dump(verbose)?;
         }
         println!("End dump LayerMap");
         Ok(())

--- a/pageserver/src/layered_repository/storage_layer.rs
+++ b/pageserver/src/layered_repository/storage_layer.rs
@@ -143,7 +143,7 @@ pub trait Layer: Send + Sync {
     fn delete(&self) -> Result<()>;
 
     /// Dump summary of the contents of the layer to stdout
-    fn dump(&self) -> Result<()>;
+    fn dump(&self, verbose: bool) -> Result<()>;
 }
 
 // Flag indicating that this version initialize the page


### PR DESCRIPTION
…layers.

Add verbose option to chose if we need to print all layer's keys or not.