### PR TITLE
Add hot page test

### DIFF
--- a/test_runner/fixtures/compare_fixtures.py
+++ b/test_runner/fixtures/compare_fixtures.py
@@ -114,7 +114,10 @@ class VanillaCompare(PgCompare):
     def __init__(self, zenbenchmark, vanilla_pg: VanillaPostgres):
         self._pg = vanilla_pg
         self._zenbenchmark = zenbenchmark
-        vanilla_pg.configure(['shared_buffers=1MB'])
+        vanilla_pg.configure([
+            'shared_buffers=1MB',
+            'synchronous_commit=off',
+        ])
         vanilla_pg.start()
 
         # Long-lived cursor, useful for flushing

--- a/test_runner/fixtures/zenith_fixtures.py
+++ b/test_runner/fixtures/zenith_fixtures.py
@@ -1301,7 +1301,7 @@ class VanillaPostgres(PgProtocol):
         """Append lines into postgresql.conf file."""
         assert not self.running
         with open(os.path.join(self.pgdatadir, 'postgresql.conf'), 'a') as conf_file:
-            conf_file.writelines(options)
+            conf_file.write("\n".join(options))
 
     def start(self):
         assert not self.running

--- a/test_runner/performance/test_hot_page.py
+++ b/test_runner/performance/test_hot_page.py
@@ -1,0 +1,30 @@
+import pytest
+from contextlib import closing
+from fixtures.compare_fixtures import PgCompare
+
+
+@pytest.mark.slow
+def test_hot_page(zenith_with_baseline: PgCompare):
+    # Update the same page many times, then measure read performance
+    env = zenith_with_baseline
+
+    num_writes = 1000000
+
+    with closing(env.pg.connect()) as conn:
+        with conn.cursor() as cur:
+
+            # Write many updates to the same row
+            with env.record_duration('write'):
+                cur.execute('create table t (i integer);')
+                cur.execute('insert into t values (0);')
+                for i in range(num_writes):
+                    cur.execute(f'update t set i = {i};')
+
+            # Write 3-4 MB to evict t from compute cache
+            cur.execute('create table f (i integer);')
+            cur.execute(f'insert into f values (generate_series(1,100000));')
+
+            # Read
+            with env.record_duration('read'):
+                cur.execute('select * from t;')
+                cur.fetchall()


### PR DESCRIPTION
Results:
```
test_hot_page[vanilla].write: 78.365 s
test_hot_page[vanilla].read: 0.000 s
test_hot_page[zenith].write: 169.256 s
test_hot_page[zenith].read: 1.501 s
```

Conclusion: The 1.501 / 0.000 difference is big.

Note: the test setup is very artificial, and I still can't think of a realistic scenario that shows the same result. Please suggest any realistic neighbors to this test, if you think of any.

Note: I turned off `synchronous_commit` because otherwise postgres writes take too long to write. It's more fair to compare this way anyway (there are no safekeepers in the zenith fixture). I can do this in a separate PR if people prefer.