### PR TITLE
Make wal_storage initialization eager

### DIFF
--- a/walkeeper/src/timeline.rs
+++ b/walkeeper/src/timeline.rs
@@ -100,7 +100,7 @@ impl SharedState {
         let state = SafeKeeperState::new(zttid, peer_ids);
         let control_store = control_file::FileStorage::new(zttid, conf);
         let wal_store = wal_storage::PhysicalStorage::new(zttid, conf);
-        let mut sk = SafeKeeper::new(zttid.timeline_id, control_store, wal_store, state);
+        let mut sk = SafeKeeper::new(zttid.timeline_id, control_store, wal_store, state)?;
         sk.control_store.persist(&sk.s)?;
 
         Ok(Self {
@@ -127,7 +127,7 @@ impl SharedState {
 
         Ok(Self {
             notified_commit_lsn: Lsn(0),
-            sk: SafeKeeper::new(zttid.timeline_id, control_store, wal_store, state),
+            sk: SafeKeeper::new(zttid.timeline_id, control_store, wal_store, state)?,
             replicas: Vec::new(),
             active: false,
             num_computes: 0,


### PR DESCRIPTION
I had an issue with `/v1/timeline/:tenant_id/:timeline_id` displaying `"flush_lsn":"0/0"`, it was because timeline restore doesn't call init_storage() and flush_lsn is not read until some compute connects to safekeeper.

This will fix it and initialize wal_storage with SafeKeeperState at the time of timeline restore. I think I'm going to merge it without approve to deploy on staging soon, if anything wrong we can revert it later.